### PR TITLE
fix: write-failure guard returned success; pqueue priorities 32-bit on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **A failed write of generated C now fails the compile.** The write-failure
+  guard added in the cleanup sweep printed its error but returned
+  compile_source's success code, so a full disk still handed the truncated
+  .c file to the C compiler; the guard now returns failure like every other
+  error path in that function.
+- **`std.pqueue` priorities are 64-bit on every platform.** The C entry
+  points took `long`, which is 32-bit on Windows while Aether `long` is 64,
+  an ABI mismatch that truncated priorities past 2^31 and only round-tripped
+  small test values by calling-convention luck. The C side now uses
+  `long long`, matching the `string_to_long_raw` convention; the
+  Aether-facing API is unchanged.
+
 ## [0.434.0]
 
 ### Added

--- a/compiler/aetherc.c
+++ b/compiler/aetherc.c
@@ -1731,8 +1731,11 @@ int compile_source(const char* input_path, const char* output_path) {
     if (!close_generated_file(csrc_catalog, csrc_catalog_path)) write_ok = 0;
     if (!close_generated_file(header_output, header_path))      write_ok = 0;
     if (!write_ok) {
+        /* compile_source reports failure as 0; every caller tests
+         * !compile_source(...). Returning 1 here would print the error and
+         * then hand the truncated output to the C compiler anyway. */
         if (header_path) free(header_path);
-        return 1;
+        return 0;
     }
     if (header_path) {
         free(header_path);

--- a/std/collections/aether_pqueue.c
+++ b/std/collections/aether_pqueue.c
@@ -8,7 +8,7 @@
 #define PQUEUE_INITIAL_CAPACITY 16
 
 typedef struct {
-    long  priority;
+    long long priority;
     void* item;
 } PQueueEntry;
 
@@ -80,7 +80,7 @@ AetherPQueue* aether_pqueue_new(void) {
     return pq;
 }
 
-int aether_pqueue_push(AetherPQueue* pq, long priority, void* item) {
+int aether_pqueue_push(AetherPQueue* pq, long long priority, void* item) {
     if (!pq) return 0;
     if (pq->size == pq->capacity && !pqueue_grow(pq)) return 0;
 
@@ -108,7 +108,7 @@ void* aether_pqueue_peek(AetherPQueue* pq) {
     return pq->entries[0].item;
 }
 
-long aether_pqueue_peek_priority(AetherPQueue* pq) {
+long long aether_pqueue_peek_priority(AetherPQueue* pq) {
     if (!pq || pq->size == 0) return 0;
     return pq->entries[0].priority;
 }

--- a/std/collections/aether_pqueue.h
+++ b/std/collections/aether_pqueue.h
@@ -14,8 +14,10 @@ typedef struct AetherPQueue AetherPQueue;
 // Returns NULL on allocation failure.
 AetherPQueue* aether_pqueue_new(void);
 
-// 1 on success, 0 on a null queue or allocation failure.
-int aether_pqueue_push(AetherPQueue* pq, long priority, void* item);
+// 1 on success, 0 on a null queue or allocation failure. Priority is
+// long long, not long: Aether `long` is 64-bit and Windows C `long`
+// is 32, matching the string_to_long_raw convention.
+int aether_pqueue_push(AetherPQueue* pq, long long priority, void* item);
 
 // Removes and returns the lowest-priority item, or NULL when empty.
 // A NULL return is ambiguous if NULL items were pushed; use
@@ -27,7 +29,7 @@ void* aether_pqueue_peek(AetherPQueue* pq);
 
 // Priority of the item aether_pqueue_peek would return. Returns 0 when empty,
 // so check aether_pqueue_size first.
-long aether_pqueue_peek_priority(AetherPQueue* pq);
+long long aether_pqueue_peek_priority(AetherPQueue* pq);
 
 int aether_pqueue_size(AetherPQueue* pq);
 int aether_pqueue_is_empty(AetherPQueue* pq);


### PR DESCRIPTION
## Summary

Two defects found in a final post-merge review of the cleanup sweep (#1236), both in code that sweep introduced. Small, surgical, verified.

**The write-failure guard reported success.** `compile_source` reports failure as 0 and every caller tests `!compile_source(...)`, but the guard added for failed writes of generated C returned 1. So on a full disk it printed the error and then handed the truncated `.c` to the C compiler anyway, exactly the behaviour it was added to prevent. It now returns 0 like every other error path in that function.

**`std.pqueue` priorities were 32-bit on Windows.** The C entry points took `long`. Aether `long` is 64-bit everywhere, but C `long` is 32-bit on Windows (LLP64), so the extern was ABI-mismatched there: priorities past 2^31 truncated, and the regression test only passed because small values survive in the argument register. The C side now uses `long long`, the convention `string_to_long_raw` documents for exactly this reason ("64-bit slot, Windows `long` is 32-bit"). The Aether-facing `pqueue.push` / `peek_priority` API is unchanged.

## Verification

- Clean rebuild; `-Werror` clean on both touched C files, POSIX and MinGW cross-compile.
- `test_std_pqueue` and `test_std_set` regression suites pass.
- CHANGELOG entry under `[current]`.
