### PR TITLE
fix(lexer): string-literal call arg inside ${...} interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **String-literal argument to a call inside `${...}` interpolation.**
+  `${id("hi")}` used to be a parse error (the `"` ended the *outer*
+  string), and the workaround developers reached for instead,
+  `${id(\"hi\")}`, compiled clean but silently evaluated to `""` — no
+  error, wrong value. The lexer now tracks interpolation depth and
+  treats a `"` (or `\"`) inside `${...}` as opening a real nested
+  string literal, so both spellings parse and evaluate correctly.
+  `ae fmt` updated to match, so formatting a file using this no longer
+  mangles the string. (#1237)
+
 ## [0.434.0]
 
 ### Added

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -110,8 +110,13 @@ Token* read_string() {
     char* buffer = malloc(capacity);
     int i = 0;
     bool has_interp = false;
+    // Depth of ${...} nesting we're currently inside. While > 0, an
+    // unescaped '"' opens a NESTED string literal (e.g. ${id("hi")})
+    // rather than ending the outer string, and a '}' closes one level
+    // of interpolation instead of being ordinary literal text.
+    int interp_depth = 0;
 
-    while (current_pos < source_length && peek() != '"') {
+    while (current_pos < source_length && (interp_depth > 0 || peek() != '"')) {
         if (i >= capacity - 3) {
             capacity *= 2;
             char* new_buf = realloc(buffer, capacity);
@@ -120,9 +125,57 @@ Token* read_string() {
         }
         if (peek() == '$' && current_pos + 1 < source_length && source[current_pos + 1] == '{') {
             has_interp = true;
+            interp_depth++;
             // Store raw ${...} content without escape processing
             buffer[i++] = advance(); // $
             buffer[i++] = advance(); // {
+        } else if (interp_depth > 0 &&
+                   (peek() == '"' ||
+                    (peek() == '\\' && current_pos + 1 < source_length && source[current_pos + 1] == '"'))) {
+            // Nested string literal inside ${...}: copy it through verbatim
+            // (including its own escapes) so the parser's re-lex of the
+            // interpolation expression sees real Aether source, not text
+            // that was only valid in the OUTER string's escaping convention.
+            // A leading '\"' is accepted the same as '"' (the natural
+            // spelling a developer reaches for since the outer string's own
+            // quotes must be escaped) and normalized down to a plain '"' —
+            // it's not needed here since a bare '"' no longer terminates
+            // the outer string, but rejecting it outright would resurrect
+            // the silent-empty trap for whichever spelling isn't the one
+            // this branch expects.
+            if (peek() == '\\') advance(); // drop the escaping backslash
+            buffer[i++] = advance(); // opening "
+            bool closed = false;
+            while (current_pos < source_length) {
+                if (i >= capacity - 3) { capacity *= 2; char* nb = realloc(buffer, capacity); if (!nb) { free(buffer); return create_token(TOKEN_ERROR, "out of memory", current_line, current_column); } buffer = nb; }
+                if (peek() == '"') {
+                    buffer[i++] = advance(); // closing "
+                    closed = true;
+                    break;
+                }
+                if (peek() == '\\' && current_pos + 1 < source_length && source[current_pos + 1] == '"') {
+                    advance(); // drop the escaping backslash
+                    buffer[i++] = advance(); // closing " (normalized, unescaped)
+                    closed = true;
+                    break;
+                }
+                if (peek() == '\\' && current_pos + 1 < source_length) {
+                    buffer[i++] = advance(); // backslash
+                    buffer[i++] = advance(); // escaped char
+                } else {
+                    buffer[i++] = advance();
+                }
+            }
+            if (!closed) {
+                free(buffer);
+                return create_token(TOKEN_ERROR, "unterminated string literal", current_line, current_column);
+            }
+        } else if (interp_depth > 0 && peek() == '{') {
+            interp_depth++;
+            buffer[i++] = advance();
+        } else if (interp_depth > 0 && peek() == '}') {
+            interp_depth--;
+            buffer[i++] = advance();
         } else if (peek() == '\\') {
             if (has_interp) {
                 // In interpolated strings, keep escape sequences raw so parser can handle them

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -839,10 +839,21 @@ static ASTNode* parse_interp_string_expr(const char* raw) {
             FLUSH_LIT();
             p += 2; // skip ${
 
-            // Collect expression source until matching }
+            // Collect expression source until matching }. Skip over nested
+            // string literals so a '{' or '}' inside one (e.g. ${id("a}b")})
+            // doesn't miscount the interpolation's own brace depth.
             int depth = 1;
             const char* expr_start = p;
             while (*p && depth > 0) {
+                if (*p == '"') {
+                    p++;
+                    while (*p && *p != '"') {
+                        if (*p == '\\' && p[1]) p++;
+                        p++;
+                    }
+                    if (*p == '"') p++;
+                    continue;
+                }
                 if (*p == '{') depth++;
                 else if (*p == '}') { if (--depth == 0) break; }
                 p++;

--- a/tests/regression/test_issue1237_interp_nested_string_literal.ae
+++ b/tests/regression/test_issue1237_interp_nested_string_literal.ae
@@ -1,0 +1,81 @@
+// Regression for #1237: a string-literal argument to a call inside
+// ${...} interpolation had no correct spelling.
+//
+//   ${id("hi")}     -> compile error (the '"' ended the OUTER string)
+//   ${id(\"hi\")}   -> compiled clean but silently evaluated to ""
+//
+// Root cause: read_string() had no concept of being "inside ${...}", so
+// an unescaped '"' there always terminated the outer string, and once
+// has_interp was set, backslash-escapes were preserved raw for the
+// parser to re-lex — but the re-lex just fed \" through to a fresh
+// lexer pass, which has no meaning outside a string it's already
+// inside (a bare '\' is a lex error, silently dropping the ${...}
+// child node). Fixed by tracking interpolation depth in the lexer and
+// treating a nested '"' (or '\"') as opening a real nested string
+// literal instead of ending the outer one.
+
+import std.string
+
+extern exit(code: int)
+
+id(s: string) -> string { return s }
+greet(name: string, punct: string) -> string { return "${name}${punct}" }
+
+main() {
+    println("=== test_issue1237_interp_nested_string_literal ===")
+
+    x = "hi"
+
+    // Baseline: passing the literal via a variable always worked.
+    via_var = "[${id(x)}]"
+    if string.equals(via_var, "[hi]") != 1 {
+        println("  FAIL: via variable -> '${via_var}'"); exit(1)
+    }
+
+    // Plain double-quoted literal inside ${...} must now parse and
+    // evaluate correctly (previously: parse error).
+    plain = "[${id("hi")}]"
+    if string.equals(plain, "[hi]") != 1 {
+        println("  FAIL: plain-quote -> '${plain}'"); exit(1)
+    }
+
+    // Escaped-quote spelling must evaluate correctly too, not
+    // silently collapse to empty string (the original bug report).
+    escaped = "[${id(\"hi\")}]"
+    if string.equals(escaped, "[hi]") != 1 {
+        println("  FAIL: escaped-quote -> '${escaped}'"); exit(1)
+    }
+
+    // Mixed open/close escaping spellings must also work.
+    mixed_open = "[${id(\"hi")}]"
+    if string.equals(mixed_open, "[hi]") != 1 {
+        println("  FAIL: mixed-open -> '${mixed_open}'"); exit(1)
+    }
+
+    mixed_close = "[${id("hi\")}]"
+    if string.equals(mixed_close, "[hi]") != 1 {
+        println("  FAIL: mixed-close -> '${mixed_close}'"); exit(1)
+    }
+
+    // Multiple string-literal arguments in one interpolated call.
+    two_args = "[${greet("bob", "!")}]"
+    if string.equals(two_args, "[bob!]") != 1 {
+        println("  FAIL: two-args -> '${two_args}'"); exit(1)
+    }
+
+    // Literal text (with its own escapes) after the interpolation
+    // must still be processed correctly (no depth-tracking leakage).
+    tail = "${id(x)} then \"literal\""
+    if string.equals(tail, "hi then \"literal\"") != 1 {
+        println("  FAIL: tail -> '${tail}'"); exit(1)
+    }
+
+    // Non-interpolated strings must be entirely unaffected.
+    plain_escape = "say \"hi\""
+    if string.equals(plain_escape, "say \"hi\"") != 1 {
+        println("  FAIL: plain escape -> '${plain_escape}'"); exit(1)
+    }
+
+    println("  PASS: ${via_var} ${plain} ${escaped} ${mixed_open} ${mixed_close} ${two_args}")
+    println("=== test_issue1237_interp_nested_string_literal passed ===")
+}

--- a/tools/ae_fmt.c
+++ b/tools/ae_fmt.c
@@ -74,14 +74,31 @@ static int op_len(const char* s){
 
 // Scan a "..." literal starting at s[i]=='"'. Returns index just past the
 // closing quote, or 0 if unterminated. This mirrors the compiler lexer's
-// read_string exactly: the string ends at the first unescaped '"', and `\<c>`
-// is a two-character escape. `${...}` interpolation content is ordinary bytes
-// for boundary purposes (the lexer does not track nested quotes inside it, so
-// valid Aether never puts a bare '"' there).
+// read_string exactly: the string ends at the first unescaped '"' seen
+// outside any ${...} interpolation, and `\<c>` is a two-character escape.
+// Inside a ${...} span (tracked via interp_depth, matching '{'/'}' nesting),
+// a '"' or '\"' opens a NESTED string literal rather than ending the outer
+// one (#1237: `${id("hi")}` and `${id(\"hi\")}` are both valid Aether).
 static size_t scan_quoted(const char* s, size_t i){
     i++; // opening quote
+    int interp_depth=0;
     while (s[i]){
         char c=s[i];
+        if (c=='$' && s[i+1]=='{'){ interp_depth++; i+=2; continue; }
+        if (interp_depth>0 && c=='{'){ interp_depth++; i++; continue; }
+        if (interp_depth>0 && c=='}'){ interp_depth--; i++; continue; }
+        if (interp_depth>0 && (c=='"' || (c=='\\' && s[i+1]=='"'))){
+            if (c=='\\') i++; // drop escaping backslash (opening)
+            i++; // opening "
+            for(;;){
+                if (!s[i]) return 0;
+                if (s[i]=='"'){ i++; break; }
+                if (s[i]=='\\' && s[i+1]=='"'){ i+=2; break; }
+                if (s[i]=='\\'){ if(!s[i+1]) return 0; i+=2; continue; }
+                i++;
+            }
+            continue;
+        }
         if (c=='\\'){ if(!s[i+1]) return 0; i+=2; continue; }
         if (c=='"') return i+1;
         i++;


### PR DESCRIPTION
## Problem

Fixes #1237.

A string-literal argument to a call embedded in `${...}` interpolation had no correct spelling:

- **Plain quotes** `${id("hi")}` → compile error. `read_string()` has no concept of being inside a `${...}` span, so the unescaped `"` before `hi` always ended the *outer* string.
- **Escaped quotes** `${id(\"hi\")}` → compiled clean but silently evaluated to `""`. Once `has_interp` was set, backslash-escapes were preserved raw so the parser could re-lex them — but the re-lex just feeds `\"` through a fresh lexer pass, where a bare `\` is a lex error that silently drops the whole `${...}` child node (no diagnostic anywhere).

Passing the literal via a variable always worked; this was specifically about a string *literal* inside an interpolated call.

## Fix

`read_string()` (`compiler/parser/lexer.c`) now tracks interpolation depth (incremented on `${`, and on nested `{`, decremented on `}`). While inside a `${...}` span, an unescaped `"` (or `\"`) opens a **real nested string literal** instead of ending the outer one — both spellings now parse and evaluate correctly. The nested string's own escapes (including an escaped closing quote) are honored normally.

`parse_interp_string_expr`'s brace-matching scan (`compiler/parser/parser.c`) now skips over nested string contents so a `{`/`}` inside one (e.g. `${id("a}b")}`) can't miscount the interpolation's own depth.

`tools/ae_fmt.c`'s `scan_quoted` had a comment claiming the old (buggy) boundary rule was safe because "valid Aether never puts a bare `\"` there" — no longer true, so it needed the identical depth-tracking fix, otherwise `ae fmt` would mangle any file using the newly-legal syntax (verified this was a real, reproducible corruption before the fix: `id("hi")` got reformatted as `id(" hi ")`, splitting one string token into two under the old scanner).

## Verification

- New regression test `tests/regression/test_issue1237_interp_nested_string_literal.ae`: plain-quote, escaped-quote, mixed open/close escaping, multi-arg calls, literal text following the interpolation, and non-interpolated escape sequences (regression check) — all assert on exact string equality, not eyeballed output.
- Full unit suite: 235/235 passed.
- `make test-ae`: unaffected. The only 3 failures come from `tests/regression/test_issue1046_bit_set.ae`, an untracked WIP file (not part of this branch, pre-existing at session start) exercising a `bit_set[...]` sum-type feature that isn't implemented yet — confirmed it fails identically with or without this change (`type Name = A | B` sum-type-needs-two-variants error, unrelated to interpolation).
- Existing interpolation regression tests (`test_interp_escape_combo.ae`, `test_string_interp_value.ae`, `test_return_escape_interp.ae`) all still pass unchanged.
- `ae fmt` manually verified idempotent/non-mangling on files using the new syntax (both plain- and escaped-quote spellings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)