### PR TITLE
fix(portability): toolchain compiles on musl (Alpine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **The toolchain now compiles on musl (Alpine Linux).** Two portability
+  fixes surfaced by the first native aarch64 Alpine build of the toolchain:
+  `lsp/aether_lsp.c` captured parser errors by assigning to `stderr`, which
+  is not an assignable lvalue on musl (glibc and macOS merely tolerate it);
+  the capture now uses fd-level redirection (`dup`/`dup2` onto stderr's fd,
+  read back from a `tmpfile`), same behavior on glibc, macOS, and musl, with
+  the Windows gating unchanged. `std/net/aether_net.c` used `struct timeval`
+  without including `sys/time.h`, which glibc leaks via other headers and
+  musl does not. Unblocks static musl builds of downstream binaries such as
+  aeo-agent on aarch64.
 - **A failed write of generated C now fails the compile.** The write-failure
   guard added in the cleanup sweep printed its error but returned
   compile_source's success code, so a full disk still handed the truncated

--- a/lsp/aether_lsp.c
+++ b/lsp/aether_lsp.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 #include "../compiler/parser/lexer.h"
 #include "../compiler/parser/parser.h"
 #include "../compiler/ast.h"
@@ -516,20 +519,25 @@ void lsp_publish_diagnostics(LSPServer* server, const char* uri) {
             if (t->type == TOKEN_EOF || t->type == TOKEN_ERROR) break;
         }
 
-        /* Redirect stderr to capture parser errors. The whole save/
-         * swap/restore dance only works on libc implementations where
-         * `stderr` is an assignable lvalue (glibc, macOS) — Windows
-         * mingw defines it as a non-assignable macro, so the entire
-         * block is gated on AETHER_HAS_FMEMOPEN (already platform-
-         * gated upstream the same way) to avoid an "lvalue required"
-         * compile error on the Windows CI matrix.
+        /* Capture parser errors via fd-level redirection. Do NOT assign to
+         * `stderr`: it is not an assignable lvalue on musl or mingw (glibc
+         * and macOS merely tolerate it). dup2 onto stderr's fd is the
+         * portable capture; the block stays gated off on Windows like the
+         * fmemopen version it replaces.
          */
         char parse_errors[4096] = {0};
 #if AETHER_HAS_FMEMOPEN
-        FILE* old_stderr = stderr;
-        FILE* err_capture = fmemopen(parse_errors, sizeof(parse_errors), "w");
+        int saved_err_fd = -1;
+        FILE* err_capture = tmpfile();
         if (err_capture) {
-            stderr = err_capture;
+            fflush(stderr);
+            saved_err_fd = dup(fileno(stderr));
+            if (saved_err_fd >= 0) {
+                dup2(fileno(err_capture), fileno(stderr));
+            } else {
+                fclose(err_capture);
+                err_capture = NULL;
+            }
         }
 #endif
 
@@ -538,9 +546,13 @@ void lsp_publish_diagnostics(LSPServer* server, const char* uri) {
 
 #if AETHER_HAS_FMEMOPEN
         if (err_capture) {
-            fflush(err_capture);
+            fflush(stderr);
+            dup2(saved_err_fd, fileno(stderr));
+            close(saved_err_fd);
+            rewind(err_capture);
+            size_t err_got = fread(parse_errors, 1, sizeof(parse_errors) - 1, err_capture);
+            parse_errors[err_got] = '\0';
             fclose(err_capture);
-            stderr = old_stderr;
         }
 #endif
 

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -40,6 +40,7 @@ int tcp_poll2_raw(TcpSocket* a, TcpSocket* b, int t) { (void)a; (void)b; (void)t
     typedef int socklen_t;
 #else
     #include <sys/socket.h>
+    #include <sys/time.h>   /* struct timeval: glibc leaks it via other headers, musl does not */
     #include <netinet/in.h>
     #include <netdb.h>
     #include <unistd.h>


### PR DESCRIPTION
First native aarch64 Alpine (musl) build of the toolchain, done for the aeo-agent static run-proof ask (aeo asks/aarch64-agent-runproof-and-static.md), surfaced two portability bugs that fail the build on musl. Neither is ARM-specific; any Alpine build hits both.

1. `lsp/aether_lsp.c` captured parser errors by assigning to `stderr`. That is a glibc/macOS-ism: musl's `stderr` is not an assignable lvalue (and the C standard does not require it to be), so the build fails with `assignment of read-only variable 'stderr'`. The capture now uses fd-level redirection: `dup` the stderr fd, `dup2` a `tmpfile` over it, run the parse, restore, read the capture back. Same observable behavior on glibc and macOS, now also correct on musl. The Windows gating (`AETHER_HAS_FMEMOPEN`) is unchanged: the whole capture block stays off there, exactly as before.

2. `std/net/aether_net.c` used `struct timeval` in `net_set_socket_timeouts` without including `sys/time.h` (`storage size of 'tv' isn't known` on musl). glibc leaks the definition through other headers; musl does not. One include added in the POSIX branch.

Verification: clean `make -j8` on macOS arm64 (zero warnings) and `make test` 235/235 green on the branch. The motivating end-to-end check, a native aarch64 Alpine toolchain build followed by a `gcc -static` musl build of aeo-agent, is being run against this branch and reported in the aeo ask.

CHANGELOG entry under `[current]` included.