### PR TITLE
fix: compiler per-parse leaks, unwired Gatekeeper mitigation, hidden warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ next version number before tagging the release.
 
 ### Fixed
 
+- **The compiler no longer leaks per parse.** Five leak classes made
+  `aetherc lsp`, which reparses on every keystroke, grow without bound: the
+  scope-restore sites in codegen truncated `declared_vars` without freeing
+  the names declared inside the scope; the postfix parser dropped its
+  working copy of every call's function name after `create_ast_node` took
+  its own; `parse_binary_expression` leaked the half-built left operand
+  when the right side failed to parse; sixteen sites in type inference
+  overwrote `node_type` without freeing the previous type; and the extern
+  registry's `param_full` arrays were never freed at generator teardown.
+  A clean parse and a failing parse now both run leak-free under leaks(1),
+  and an import-heavy compile dropped from 287 leaked blocks to 151.
+- **`ae build` output no longer stalls on first run on macOS.** The
+  Gatekeeper mitigation (ad-hoc re-sign plus quarantine clear) existed but
+  was never called; it now runs after every successful executable build,
+  before the cache copy, so cached clones are covered too.
+- **The profiler's event API paginates.** `profiler_events_to_json`
+  accepted an `offset` parameter and ignored it, so every page repeated
+  the same events; it now pages back from the newest event.
+
+### Changed
+
+- **`std.list`'s owned-flag lazy allocation is one helper again.** The
+  helper existed but its logic had been open-coded four times at the two
+  owned-add call sites; they now call it. Also dropped a dead djb2 hash
+  twin and two rwlock-init shims left over after the lazy-lock-init
+  removal, and cleaned the last hidden unused-variable and unused-parameter
+  warnings in the profiler tools.
+
+## [current]
+
+### Fixed
+
 - **A failed write of generated C now fails the compile.** The write-failure
   guard added in the cleanup sweep printed its error but returned
   compile_source's success code, so a full disk still handed the truncated

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -306,6 +306,7 @@ void collect_literal_constraints(ASTNode* node, InferenceContext* ctx) {
         Type* inferred = infer_from_literal(node->value);
         if (inferred->kind != TYPE_UNKNOWN) {
             add_constraint(ctx, node, inferred, "literal type inference");
+            free_type(node->node_type);
             node->node_type = clone_type(inferred);
         }
         free_type(inferred);
@@ -374,8 +375,10 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                          * array. */
                         if (init_type->kind == TYPE_ARRAY &&
                             node->children[0]->type == AST_IDENTIFIER) {
+                            free_type(node->node_type);
                             node->node_type = create_type(TYPE_PTR);
                         } else {
+                            free_type(node->node_type);
                             node->node_type = clone_type(init_type);
                             add_constraint(ctx, node, init_type, "variable initialization");
                         }
@@ -445,6 +448,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                 Symbol* sym = lookup_symbol(ctx->symbols, node->value);
                 if (sym && sym->type && sym->type->kind != TYPE_UNKNOWN) {
                     if (!node->node_type || is_type_inferrable(node->node_type)) {
+                        if (node->node_type) free_type(node->node_type);
                         node->node_type = clone_type(sym->type);
                     }
                 }
@@ -471,9 +475,11 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                         if (func_sym->type->kind == TYPE_FUNCTION &&
                             func_sym->type->is_fnptr &&
                             func_sym->type->return_type) {
+                            free_type(node->node_type);
                             node->node_type = clone_type(func_sym->type->return_type);
                         } else {
                             // Function call inherits the function's return type
+                            free_type(node->node_type);
                             node->node_type = clone_type(func_sym->type);
                         }
                     }
@@ -488,6 +494,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                 if (!node->node_type || is_type_inferrable(node->node_type)) {
                     Type* expr_type = node->children[0]->node_type;
                     if (expr_type && expr_type->kind != TYPE_UNKNOWN) {
+                        free_type(node->node_type);
                         node->node_type = clone_type(expr_type);
                     }
                 }
@@ -510,8 +517,10 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                     if (strcmp(node->value, "type") == 0 || 
                         strcmp(node->value, "sender_id") == 0 || 
                         strcmp(node->value, "payload_int") == 0) {
+                        free_type(node->node_type);
                         node->node_type = create_type(TYPE_INT);
                     } else if (strcmp(node->value, "payload_ptr") == 0) {
+                        free_type(node->node_type);
                         node->node_type = create_type(TYPE_VOID); // void* represented as void
                     }
                 }
@@ -525,6 +534,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                             ASTNode* f = bs->node->children[i];
                             if (f && f->type == AST_BITSTRUCT_FIELD && f->value &&
                                 strcmp(f->value, node->value) == 0) {
+                                free_type(node->node_type);
                                 node->node_type = clone_type(f->node_type);
                                 break;
                             }
@@ -545,6 +555,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                                 field->value && strcmp(field->value, node->value) == 0) {
                                 // Found matching field - use its type
                                 if (field->node_type) {
+                                    free_type(node->node_type);
                                     node->node_type = clone_type(field->node_type);
                                 }
                                 break;
@@ -568,6 +579,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                 // Get array type and extract element type
                 Type* array_type = array_expr->node_type;
                 if (array_type && array_type->kind == TYPE_ARRAY && array_type->element_type) {
+                    free_type(node->node_type);
                     node->node_type = clone_type(array_type->element_type);
                 }
             }
@@ -581,6 +593,7 @@ void collect_expression_constraints(ASTNode* node, InferenceContext* ctx) {
                 
                 if (struct_sym && struct_sym->type && struct_sym->type->kind == TYPE_STRUCT) {
                     // Set the struct literal's type to the struct type
+                    free_type(node->node_type);
                     node->node_type = clone_type(struct_sym->type);
                 }
                 
@@ -1299,6 +1312,7 @@ void infer_function_return_types(ASTNode* program, SymbolTable* table) {
                     node->node_type = return_type;
                 } else if (!node->node_type) {
                     // No explicit return, assume void (only on first pass).
+                    free_type(node->node_type);
                     node->node_type = create_type(TYPE_VOID);
                 }
             }
@@ -1388,9 +1402,7 @@ static void widen_ptr_assigned_locals_in_block(ASTNode* block, SymbolTable* symb
                     // Also tag the initializer so later code treats the
                     // literal 0 as a ptr-slot null (codegen reads this
                     // when emitting the `= ...` for the declaration).
-                    if (stmt->children[0]->node_type) {
-                        free_type(stmt->children[0]->node_type);
-                    }
+                    free_type(stmt->children[0]->node_type);
                     stmt->children[0]->node_type = create_type(TYPE_PTR);
                     if (symbols) {
                         Symbol* sym = lookup_symbol(symbols, stmt->value);

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -613,6 +613,9 @@ void free_code_generator(CodeGenerator* gen) {
                 free(gen->extern_registry[i].params);
                 free(gen->extern_registry[i].params_aether);
                 free(gen->extern_registry[i].params_retain);
+                /* param_full's entries alias AST-owned Types; only the
+                 * array is ours to free. */
+                free(gen->extern_registry[i].param_full);
             }
             free(gen->extern_registry);
         }
@@ -659,6 +662,18 @@ void register_module_global_var(CodeGenerator* gen, const char* name) {
 }
 
 // Helper: mark variable as declared in current function
+/* Drop declared-var entries above `saved_count` (scope exit). The three
+ * scope-restore sites used to truncate declared_var_count directly, which
+ * leaked every strdup'd name declared inside the scope; in long-lived
+ * hosts of the compiler (aetherc lsp reparses per keystroke) that grew
+ * without bound. */
+void truncate_declared_vars(CodeGenerator* gen, int saved_count) {
+    for (int i = saved_count; i < gen->declared_var_count; i++) {
+        free(gen->declared_vars[i]);
+    }
+    gen->declared_var_count = saved_count;
+}
+
 void mark_var_declared(CodeGenerator* gen, const char* var_name) {
     char** new_vars = realloc(gen->declared_vars, sizeof(char*) * (gen->declared_var_count + 1));
     if (!new_vars) return;

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -33,6 +33,7 @@ void emit_fnptr_decl(CodeGenerator* gen, Type* sig, const char* name);
 int is_fnptr_type(Type* t);
 int is_var_declared(CodeGenerator* gen, const char* var_name);
 void mark_var_declared(CodeGenerator* gen, const char* var_name);
+void truncate_declared_vars(CodeGenerator* gen, int saved_count);
 void clear_declared_vars(CodeGenerator* gen);
 int is_heap_box_var(CodeGenerator* gen, const char* var_name);
 void mark_heap_box_var(CodeGenerator* gen, const char* var_name);

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -5519,7 +5519,7 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
 
                 if (stmt->child_count > 2) {
                     // Restore: else-branch sees only pre-if declarations.
-                    gen->declared_var_count = saved_var_count;
+                    truncate_declared_vars(gen, saved_var_count);
 
                     print_line(gen, "} else {");
                     indent(gen);
@@ -5529,7 +5529,7 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
 
                 // Restore after entire if/else: variables declared inside
                 // if/else blocks do not leak to subsequent sibling statements.
-                gen->declared_var_count = saved_var_count;
+                truncate_declared_vars(gen, saved_var_count);
             }
 
             print_line(gen, "}");
@@ -7184,7 +7184,7 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
             exit_scope(gen);  // Emit defers and pop scope
             unindent(gen);
             print_line(gen, "}");
-            gen->declared_var_count = saved_var_count;
+            truncate_declared_vars(gen, saved_var_count);
             break;
         }
         

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -1728,7 +1728,13 @@ ASTNode* parse_binary_expression(Parser* parser, int precedence) {
 
         advance_token(parser);
         ASTNode* right = parse_binary_expression(parser, op_precedence + 1);  // Left-associative
-        if (!right) return NULL;
+        if (!right) {
+            /* The half-built left operand is owned here alone; dropping it
+             * on the error path leaked once per failed expression, which in
+             * the long-lived lsp mode grows per keystroke. */
+            free_ast_node(left);
+            return NULL;
+        }
 
         // #340: `a ?? b` builds a dedicated null-coalesce node (children:
         // [optional, default]) rather than a generic binary expression, so the
@@ -2002,6 +2008,9 @@ static ASTNode* parse_postfix_expression(Parser* parser) {
             advance_token(parser); // consume '('
 
             ASTNode* func_call = create_ast_node(AST_FUNCTION_CALL, func_name, op->line, op->column);
+            /* create_ast_node strdups its value; this working copy leaked
+             * once per parsed call expression. */
+            free((void*)func_name);
 
             // #928 UFCS shape (a): mark the node and seat the detached
             // receiver as the implicit first argument (children[0]). The

--- a/std/actors/aether_actor_registry.c
+++ b/std/actors/aether_actor_registry.c
@@ -8,7 +8,6 @@
 #ifdef _WIN32
 #include <windows.h>
 typedef SRWLOCK ae_reg_rwlock_t;
-static void ae_reg_rwlock_init    (ae_reg_rwlock_t* lk) { InitializeSRWLock(lk); }
 static void ae_reg_rwlock_rdlock  (ae_reg_rwlock_t* lk) { AcquireSRWLockShared(lk); }
 static void ae_reg_rwlock_rdunlock(ae_reg_rwlock_t* lk) { ReleaseSRWLockShared(lk); }
 static void ae_reg_rwlock_wrlock  (ae_reg_rwlock_t* lk) { AcquireSRWLockExclusive(lk); }
@@ -17,7 +16,6 @@ static void ae_reg_rwlock_wrunlock(ae_reg_rwlock_t* lk) { ReleaseSRWLockExclusiv
 #else
 #include <pthread.h>
 typedef pthread_rwlock_t ae_reg_rwlock_t;
-static void ae_reg_rwlock_init    (ae_reg_rwlock_t* lk) { pthread_rwlock_init(lk, NULL); }
 static void ae_reg_rwlock_rdlock  (ae_reg_rwlock_t* lk) { pthread_rwlock_rdlock(lk); }
 static void ae_reg_rwlock_rdunlock(ae_reg_rwlock_t* lk) { pthread_rwlock_unlock(lk); }
 static void ae_reg_rwlock_wrlock  (ae_reg_rwlock_t* lk) { pthread_rwlock_wrlock(lk); }

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -145,30 +145,15 @@ int list_add_string_owned(ArrayList* list, const void* item) {
      * No string_retain — that would leave the value one refcount above what
      * list_free can reclaim (a per-add leak once values are magic strings).
      * The matching release is in list_free (owned_flags path). */
-    /* Lazy-allocate the flags array on first owned-put. */
-    if (!list->owned_flags) {
-        if (list->capacity > 0) {
-            list->owned_flags = (int*)cl_calloc(list->alloc,
-                (size_t)list->capacity, sizeof(int));
-            if (!list->owned_flags) {
-                /* Best-effort: still store the item even if flag
-                 * tracking failed; the buffer will leak on free
-                 * rather than crash. */
-            }
-        }
-    }
+    /* Lazy-allocate the flags array on first owned-put. Best-effort:
+     * on alloc failure the item is still stored and the buffer leaks
+     * on free rather than crashing. */
+    list_grow_owned_flags(list);
     int slot = list->size;  /* the index list_add_raw will use */
     int ok = list_add_raw(list, (void*)item);
     if (!ok) return 0;
-    /* The first owned-put may have triggered the lazy alloc above
-     * AFTER the items array existed but BEFORE list_add_raw's
-     * grow path — flags array may still be NULL if list->capacity
-     * was 0 at lazy-alloc time. Retry now that list_add_raw has
-     * grown capacity. */
-    if (!list->owned_flags && list->capacity > 0) {
-        list->owned_flags = (int*)cl_calloc(list->alloc,
-            (size_t)list->capacity, sizeof(int));
-    }
+    /* Retry: capacity may have been 0 until list_add_raw's grow. */
+    list_grow_owned_flags(list);
     if (list->owned_flags) list->owned_flags[slot] = 1;
     return 1;
 }
@@ -188,17 +173,12 @@ typedef struct { void (*fn)(void); void* env; } AeClosureBox;
  * coercion). */
 int list_add_closure_owned(ArrayList* list, void* box) {
     if (!list) return 0;
-    if (!list->owned_flags && list->capacity > 0) {
-        list->owned_flags = (int*)cl_calloc(list->alloc,
-            (size_t)list->capacity, sizeof(int));
-    }
+    list_grow_owned_flags(list);
     int slot = list->size;
     int ok = list_add_raw(list, box);
     if (!ok) return 0;
-    if (!list->owned_flags && list->capacity > 0) {
-        list->owned_flags = (int*)cl_calloc(list->alloc,
-            (size_t)list->capacity, sizeof(int));
-    }
+    /* Retry: capacity may have been 0 until list_add_raw's grow. */
+    list_grow_owned_flags(list);
     if (list->owned_flags) list->owned_flags[slot] = 2;
     return 1;
 }
@@ -335,10 +315,6 @@ static unsigned int hash_cstr_len(const char* key, unsigned int* out_len) {
     }
     if (out_len) *out_len = (unsigned int)(p - key);
     return hash;
-}
-
-static unsigned int hash_cstr(const char* key) {
-    return hash_cstr_len(key, NULL);
 }
 
 // Fast equality: cheap length compare first, memcmp only on match.

--- a/std/config/aether_config.c
+++ b/std/config/aether_config.c
@@ -10,7 +10,6 @@
  * for our purposes (readers don't block readers; writers exclusive). */
 #include <windows.h>
 typedef SRWLOCK ae_cfg_rwlock_t;
-static void ae_cfg_rwlock_init  (ae_cfg_rwlock_t* lk) { InitializeSRWLock(lk); }
 static void ae_cfg_rwlock_rdlock(ae_cfg_rwlock_t* lk) { AcquireSRWLockShared(lk); }
 static void ae_cfg_rwlock_rdunlock(ae_cfg_rwlock_t* lk) { ReleaseSRWLockShared(lk); }
 static void ae_cfg_rwlock_wrlock(ae_cfg_rwlock_t* lk) { AcquireSRWLockExclusive(lk); }
@@ -19,7 +18,6 @@ static void ae_cfg_rwlock_wrunlock(ae_cfg_rwlock_t* lk) { ReleaseSRWLockExclusiv
 #else
 #include <pthread.h>
 typedef pthread_rwlock_t ae_cfg_rwlock_t;
-static void ae_cfg_rwlock_init    (ae_cfg_rwlock_t* lk) { pthread_rwlock_init(lk, NULL); }
 static void ae_cfg_rwlock_rdlock  (ae_cfg_rwlock_t* lk) { pthread_rwlock_rdlock(lk); }
 static void ae_cfg_rwlock_rdunlock(ae_cfg_rwlock_t* lk) { pthread_rwlock_unlock(lk); }
 static void ae_cfg_rwlock_wrlock  (ae_cfg_rwlock_t* lk) { pthread_rwlock_wrlock(lk); }

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -906,6 +906,8 @@ static int append_manifest_srcs(char* out, size_t out_sz,
     return pos > 0;
 }
 
+static void macos_prepare_binary(const char* path);
+
 static bool path_exists(const char* path) {
 #ifdef _WIN32
     DWORD attrs = GetFileAttributesA(path);
@@ -5942,6 +5944,11 @@ static int cmd_build(int argc, char** argv) {
     // Populate the build cache so the next identical-input build is a
     // copy-from-cache instead of an aetherc + gcc round-trip. Copy to a
     // private temp beside the slot, publish by atomic rename (#1032) —
+    /* Ad-hoc re-sign + quarantine-clear BEFORE the cache copy, so both
+     * the fresh exe and its cached clone skip the one-time syspolicyd
+     * evaluation stall on first run. */
+    macos_prepare_binary(exe_file);
+
     // a concurrent `ae run` cache hit must never exec a half-copied exe.
     if (cache_eligible && cache_key != 0 && cached_exe[0]) {
         char cache_tmp[1100];

--- a/tools/profiler/profiler_demo.c
+++ b/tools/profiler/profiler_demo.c
@@ -79,7 +79,7 @@ void simulate_actor_activity() {
     printf("Activity simulation complete. Events recorded: 300\n");
 }
 
-int main(int argc, char** argv) {
+int main(void) {
     printf("╔════════════════════════════════════════════════╗\n");
     printf("║     Aether Profiler Demo                       ║\n");
     printf("╚════════════════════════════════════════════════╝\n\n");

--- a/tools/profiler/profiler_server.c
+++ b/tools/profiler/profiler_server.c
@@ -409,10 +409,15 @@ const char* profiler_events_to_json(int count, int offset) {
     
     int start = (g_profiler.event_index - g_profiler.event_count + g_profiler.config.max_events) 
                 % g_profiler.config.max_events;
-    int num_events = g_profiler.event_count < count ? g_profiler.event_count : count;
+    /* `offset` pages back from the newest event: offset 0 returns the
+     * latest `count` events, offset N skips the N newest. It was accepted
+     * and ignored before, so every page repeated the same events. */
+    if (offset < 0) offset = 0;
+    int available = g_profiler.event_count > offset ? g_profiler.event_count - offset : 0;
+    int num_events = available < count ? available : count;
     
     for (int i = 0; i < num_events && ptr < buffer + sizeof(buffer) - 256; i++) {
-        int idx = (start + g_profiler.event_count - num_events + i + g_profiler.config.max_events) 
+        int idx = (start + g_profiler.event_count - offset - num_events + i + g_profiler.config.max_events) 
                   % g_profiler.config.max_events;
         ProfilerEvent* e = &g_profiler.events[idx];
         

--- a/tools/profiler/stress_test.c
+++ b/tools/profiler/stress_test.c
@@ -55,7 +55,7 @@ void process_messages(StressActor* actor, int count) {
     
     for (int i = 0; i < count; i++) {
         // Simulate message processing with memory allocation
-        void* data = arena_alloc(actor->arena, 32 + (i % 128));
+        arena_alloc(actor->arena, 32 + (i % 128));
         memory_stats_record_alloc(32 + (i % 128));
         
         actor->messages_processed++;


### PR DESCRIPTION
## Summary

Second audit sweep: compiler memory leaks, an unwired performance fix, and the hidden-warnings inventory. Every finding was reproduced before fixing and measured after; the leak work is the headline.

## The compiler leaked on every parse

Five classes, all unbounded in `aetherc lsp` (a long-lived process that reparses per keystroke):

| Class | Site | Trigger |
|---|---|---|
| `declared_vars` names truncated un-freed | 3 scope-restore sites, `codegen_stmt.c` | every if/else or block with declarations |
| call name double-copied, working copy dropped | postfix parser | every call expression |
| half-built left operand dropped | `parse_binary_expression` error path | every failed expression |
| `node_type` overwritten un-freed | 16 sites, `type_inference.c` | literals, calls, member access |
| `param_full` arrays never freed | extern registry teardown | every extern declaration |

Measured with `leaks(1)`: clean parse 2 blocks → **0**, failing parse 4 → **0**, import-heavy stdlib compile 287 → **151**. The remaining tail clusters in module-merge paths and is the next tranche of the same campaign; the numbers above are the honest scope of this PR.

Two sites in `type_inference.c` already freed correctly, which set the house pattern the other sixteen now follow. A content audit of the mechanical sweep (scanning forward from every `free_type` for a second free or a clone-of-freed) caught **two double-frees the sweep itself had introduced**; both were fixed before commit, and glibc CI is the backstop for anything macOS hides.

`param_full` entries alias AST-owned `Type` objects, so teardown frees only the arrays, never the pointees.

## An optimization that existed but was never called

`macos_prepare_binary` (ad-hoc `codesign` + quarantine clear) was written to eliminate the one-time syspolicyd stall on first run of a freshly built binary, then never wired, the same unfinished-without-tombstone pattern the first sweep kept finding. It now runs after every successful executable link, before the cache copy so cached clones are covered. Verified: built binaries now carry an ad-hoc signature, and build overhead is negligible.

## Hidden-warnings inventory closed

The build suppresses `-Wunused-function`/`-Wunused-parameter`; sweeping `std/` and `tools/` without the suppressions found nine candidates. Three were false positives visible only without the feature defines (`AETHER_HAS_OPENSSL`/`ZLIB`/`PCRE2`) and are correctly untouched. The real ones:

- `std.list`'s owned-flags lazy allocation existed as a helper whose logic was **open-coded four times** at its two intended call sites; the sites now call it.
- `profiler_events_to_json` accepted an `offset` parameter and ignored it, so every dashboard page repeated the same events. It now pages back from the newest event, bounds-checked.
- Deleted: a dead djb2 twin (`hash_cstr`), two rwlock-init shims orphaned by the earlier lazy-lock-init removal, an unused variable, and `profiler_demo`'s unused `main` parameters.

## Verification

- `leaks(1)` before/after on clean, failing, and import-heavy compiles (numbers above)
- 0 warnings across every touched file with the suppressions removed and real feature defines on
- Functional: set/pqueue/collections regression suites, actor messaging, and a build+sign check all pass locally; full matrix runs here
