### PR TITLE
fix: -Wformat through extern calls, libc-named struct fields, Windows cache staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ next version number before tagging the release.
   linker symbols: the libc-collision rename no longer applies to them, and
   definition and call site agree. Redis-style vtables (`rio.read`,
   `rio.write`) now port cleanly.
+- **Rebuilding `ae` itself invalidates the build cache.** The key hashed
+  aetherc's mtime but not the driver's, and the flags ae passes to the C
+  compiler are part of the output, so upgrading ae could serve binaries
+  built with the old flags until `ae cache clear`. The running executable's
+  mtime is now folded into the key.
+- **`ae.c` compiles warning-free under MinGW GCC's full `-Wall -Wextra
+  -Werror`** (15 findings on the previous release, zero now): misleading
+  indentation twice, two POSIX-only globals unused on Windows, nine
+  format-truncation sites fixed by sizing derived buffers past their
+  sources, and one cross-compile source-path join that now reports and
+  skips an overlong path instead of silently truncating it, which could
+  have compiled the wrong file.
 - **Editing a module under `lib/` invalidates the build cache on Windows**
   (#1235). The lib-dir content walk that feeds the cache key was compiled
   out on Windows, leaving only the directory's own mtime, which does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the
 next version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Format bugs in printf-family extern calls are caught again** (#1252).
+  The interop lowering cast literal format strings to `void*`, which
+  stripped the constant the C compiler's `-Wformat` check reads, so a
+  `%s`-vs-int bug compiled silently even against libc's own attributed
+  prototype. String literals now pass into `ptr` parameters bare (they are
+  `char[]` in C and convert implicitly), `ae` passes `-Wformat` when
+  compiling generated C, and `ae build` surfaces compiler warnings the way
+  `ae run` already did. The `#line` mapping points the diagnostic at the
+  offending `.ae` line; `-Wno-format` via aether.toml cflags opts out.
+- **Struct fields named after libc symbols work again** (#1251). A field
+  spelled `read` or `write` was renamed to `ae_read` at the member-call
+  site but kept its own name in the struct definition, so the emitted C
+  referenced a member that does not exist. Fields are struct members, not
+  linker symbols: the libc-collision rename no longer applies to them, and
+  definition and call site agree. Redis-style vtables (`rio.read`,
+  `rio.write`) now port cleanly.
+- **Editing a module under `lib/` invalidates the build cache on Windows**
+  (#1235). The lib-dir content walk that feeds the cache key was compiled
+  out on Windows, leaving only the directory's own mtime, which does not
+  change on an edit-in-place, so every module edit served a stale cached
+  binary until `ae cache clear`. The walk now has a native
+  FindFirstFileA implementation with the same bounded-depth,
+  content-hashing semantics as the POSIX one, and a cross-platform
+  integration test guards the behavior end to end.
+
 ## [0.435.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -3175,8 +3175,15 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     memcpy(recv, expr->value, rlen);
                     recv[rlen] = '\0';
                     char recv_c[200], field_c[200];
-                    snprintf(recv_c, sizeof(recv_c), "%s", safe_c_name(recv));
-                    snprintf(field_c, sizeof(field_c), "%s", safe_c_name(dot + 1));
+                    /* Keyword mangling only (safe_value_name): the receiver
+                     * is a local and the field is a struct member, neither is
+                     * a linker symbol, so the libc-collision rename in
+                     * safe_c_name must not apply. It renamed a field spelled
+                     * `read` to `ae_read` here while the struct definition
+                     * kept `read`, so the emitted C referenced a member that
+                     * does not exist (#1251). */
+                    snprintf(recv_c, sizeof(recv_c), "%s", safe_value_name(recv));
+                    snprintf(field_c, sizeof(field_c), "%s", safe_value_name(dot + 1));
                     fprintf(gen->output, "(%s%s%s)(",
                             recv_c, is_ptr ? "->" : ".", field_c);
                     for (int i = 0; i < expr->child_count; i++) {
@@ -4714,13 +4721,26 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                             fprintf(gen->output, ")");
                         } else if (expected == TYPE_PTR && arg->node_type &&
                                    arg->node_type->kind == TYPE_STRING) {
-                            // Cast const char* to void* to silence C's
-                            // "discards qualifiers" warning when passing
-                            // a string literal or const-char expression
-                            // into a ptr parameter.
-                            fprintf(gen->output, "(void*)(");
-                            generate_expression(gen, arg);
-                            fprintf(gen->output, ")");
+                            if (arg->type == AST_LITERAL) {
+                                /* A string literal is char[] in C: it decays
+                                 * and converts to void* implicitly with no
+                                 * qualifier warning, so it needs no cast, and
+                                 * casting it to void* destroys the constant
+                                 * the C compiler's -Wformat check reads. With
+                                 * the cast, a format/argument bug in a printf
+                                 *-family extern call compiled silently
+                                 * (#1252). libc externs keep their real
+                                 * attributed prototypes (declaration skipped),
+                                 * so the check fires end to end. */
+                                generate_expression(gen, arg);
+                            } else {
+                                // Cast const char* expressions to void* to
+                                // silence C's "discards qualifiers" warning
+                                // when passing into a ptr parameter.
+                                fprintf(gen->output, "(void*)(");
+                                generate_expression(gen, arg);
+                                fprintf(gen->output, ")");
+                            }
                         } else if (expected == TYPE_STRING && arg->node_type &&
                                    (arg->node_type->kind == TYPE_STRING ||
                                     arg->node_type->kind == TYPE_PTR) &&

--- a/tests/integration/cache_libdir_invalidation/test_cache_libdir_invalidation.sh
+++ b/tests/integration/cache_libdir_invalidation/test_cache_libdir_invalidation.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Regression: editing a module under the default lib/ directory must
+# invalidate the build cache (#1025, #1235).
+#
+# The cache key folds in the content of every source file under each lib
+# dir. On Windows that walk was compiled out entirely (only the lib dir's
+# own mtime was hashed, which does not change on an edit-in-place), so
+# every lib/ module edit served a stale cached binary until
+# `ae cache clear`. The walk now has a native Windows implementation;
+# this test runs on every platform, including the MSYS2 CI job.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/proj/lib/greet"
+cd "$TMPDIR/proj"
+
+cat > lib/greet/module.ae <<'EOF'
+exports (hello)
+hello() -> string { return "v1" }
+EOF
+
+cat > main.ae <<'EOF'
+import greet
+main() { println(greet.hello()) }
+EOF
+
+OUT1=$("$AE" run main.ae 2>/dev/null | tail -1)
+if [ "$OUT1" != "v1" ]; then
+    echo "  [FAIL] baseline run printed '$OUT1', expected v1"
+    exit 1
+fi
+
+# Edit the module in place. Keep byte length identical (v1 -> v2) so an
+# mtime+size key cannot pass by accident; only content hashing catches it.
+sed 's/v1/v2/' lib/greet/module.ae > lib/greet/module.ae.new
+mv lib/greet/module.ae.new lib/greet/module.ae
+
+OUT2=$("$AE" run main.ae 2>/dev/null | tail -1)
+if [ "$OUT2" != "v2" ]; then
+    echo "  [FAIL] lib/ edit served stale binary: got '$OUT2', expected v2 (#1235)"
+    exit 1
+fi
+
+# Same check through `ae build` with a fresh output name: the stale
+# artifact must not be served under a different -o either.
+sed 's/v2/v3/' lib/greet/module.ae > lib/greet/module.ae.new
+mv lib/greet/module.ae.new lib/greet/module.ae
+
+"$AE" build main.ae -o out3 >/dev/null 2>&1
+OUT3=$(./out3 | tail -1)
+if [ "$OUT3" != "v3" ]; then
+    echo "  [FAIL] ae build served stale binary: got '$OUT3', expected v3 (#1235)"
+    exit 1
+fi
+
+echo "  [PASS] cache_libdir_invalidation: lib/ edits invalidate run + build caches"

--- a/tests/integration/wformat_extern_literal/test_wformat_extern_literal.sh
+++ b/tests/integration/wformat_extern_literal/test_wformat_extern_literal.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Regression #1252: the interop lowering cast literal format strings to
+# void*, which stripped the constant the C compiler's -Wformat check
+# reads. A format/argument bug in a printf-family extern call compiled
+# with no warning, even against libc's own attributed prototype. The
+# lowering now emits string literals bare into ptr parameters, ae passes
+# -Wformat, and the #line mapping points the warning at the .ae source.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat > "$TMPDIR/fmtbug.ae" <<'AEOF'
+extern printf(fmt: ptr, ...) -> int
+
+main() {
+    printf("value is %s\n", 42)
+    return 0
+}
+AEOF
+
+# The build must SUCCEED (a warning, not an error) and the C compiler's
+# format diagnostic must be visible and attributed to the .ae file.
+if ! "$AE" build "$TMPDIR/fmtbug.ae" -o "$TMPDIR/fmtbug" >"$TMPDIR/out.log" 2>&1; then
+    echo "  [FAIL] build errored; -Wformat should warn, not fail"
+    head -10 "$TMPDIR/out.log"
+    exit 1
+fi
+
+if ! grep -qi "format" "$TMPDIR/out.log"; then
+    echo "  [FAIL] no format diagnostic surfaced; the void* cast is back (#1252)"
+    head -10 "$TMPDIR/out.log"
+    exit 1
+fi
+
+if ! grep -q "fmtbug.ae" "$TMPDIR/out.log"; then
+    echo "  [FAIL] diagnostic not attributed to the .ae source"
+    grep -i format "$TMPDIR/out.log" | head -3
+    exit 1
+fi
+
+echo "  [PASS] wformat_extern_literal: format bug in extern call warns at the .ae line"

--- a/tests/regression/test_issue1251_field_named_read.ae
+++ b/tests/regression/test_issue1251_field_named_read.ae
@@ -1,0 +1,33 @@
+// Regression #1251: a struct field named after a libc symbol (read, write)
+// was renamed to ae_<name> at the member-call site but not in the struct
+// definition, so the emitted C referenced a member that does not exist.
+// Fields are struct members, not linker symbols; only C-keyword mangling
+// applies to them, and definition and call site must agree.
+
+struct rioMethods {
+    read:  fn(ptr, ptr, long) -> long
+    write: fn(ptr, ptr, long) -> long
+}
+
+my_read(r: ptr, buf: ptr, len: long) -> long { return len }
+my_write(r: ptr, buf: ptr, len: long) -> long { return len * 2 }
+
+extern exit(code: int)
+
+main() {
+    t = rioMethods {
+        read:  my_read as fn(ptr, ptr, long) -> long,
+        write: my_write as fn(ptr, ptr, long) -> long
+    }
+    n = t.read(null, null, 7)
+    m = t.write(null, null, 7)
+    if n != 7 {
+        println("FAIL: t.read returned ${n}, expected 7")
+        exit(1)
+    }
+    if m != 14 {
+        println("FAIL: t.write returned ${m}, expected 14")
+        exit(1)
+    }
+    println("PASS: read/write vtable fields callable")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -503,6 +503,8 @@ static unsigned long long fnv64_file(const char* path) {
  * and compute_cache_key couldn't include the env-resolved modules'
  * mtimes — so an edit to a vendored module behind that env var would
  * never invalidate the cache. Idempotent: skips if already populated. */
+static bool get_exe_path(char* buf, size_t size);
+
 static void tc_seed_lib_dirs_from_env(void) {
     if (tc.lib_dir_count > 0) return;
     const char* env = getenv("AETHER_LIB_DIR");
@@ -625,6 +627,11 @@ static unsigned long long compute_cache_key(const char* ae_file,
     struct stat st;
     if (stat(tc.compiler, &st) == 0)
         pos += snprintf(key_buf + pos, sizeof(key_buf) - pos, ":%lld", (long long)st.st_mtime);
+    /* The driver's own mtime: flags ae passes to the C compiler are part
+     * of the output, so a rebuilt ae must miss the cache (#1235 family). */
+    char self_path[1200];
+    if (get_exe_path(self_path, sizeof(self_path)) && stat(self_path, &st) == 0)
+        pos += snprintf(key_buf + pos, sizeof(key_buf) - pos, ":ae=%lld", (long long)st.st_mtime);
     if (tc.has_lib && stat(tc.lib, &st) == 0)
         pos += snprintf(key_buf + pos, sizeof(key_buf) - pos, ":%lld", (long long)st.st_mtime);
 
@@ -1041,32 +1048,48 @@ static char* get_basename(const char* path) {
 }
 
 // Get directory containing this executable
-static bool get_exe_dir(char* buf, size_t size) {
+/* Absolute path of the running `ae` binary itself. Besides seeding
+ * get_exe_dir, compute_cache_key folds this file's mtime into the key:
+ * the key already covered aetherc's mtime, but a rebuilt `ae` (whose
+ * codegen-driving flags such as -Wformat live here) served stale
+ * binaries until `ae cache clear`. */
+static bool get_exe_path(char* buf, size_t size) {
 #ifdef __APPLE__
     uint32_t sz = (uint32_t)size;
     if (_NSGetExecutablePath(buf, &sz) == 0) {
         char resolved[PATH_MAX];
         if (realpath(buf, resolved)) {
-            char* slash = strrchr(resolved, '/');
-            if (slash) { *slash = '\0'; strncpy(buf, resolved, size - 1); buf[size - 1] = '\0'; return true; }
+            strncpy(buf, resolved, size - 1);
+            buf[size - 1] = '\0';
+            return true;
         }
     }
 #elif defined(__linux__)
     ssize_t len = readlink("/proc/self/exe", buf, size - 1);
     if (len > 0) {
         buf[len] = '\0';
-        char* slash = strrchr(buf, '/');
-        if (slash) { *slash = '\0'; return true; }
+        return true;
     }
 #elif defined(_WIN32)
     DWORD len = GetModuleFileNameA(NULL, buf, (DWORD)size);
     if (len > 0 && len < (DWORD)size) {
         buf[len] = '\0';
-        char* slash = strrchr(buf, '\\');
-        if (slash) { *slash = '\0'; return true; }
+        return true;
     }
 #endif
     return false;
+}
+
+static bool get_exe_dir(char* buf, size_t size) {
+    if (!get_exe_path(buf, size)) return false;
+    char* slash = strrchr(buf, '/');
+#ifdef _WIN32
+    char* bslash = strrchr(buf, '\\');
+    if (!slash || (bslash && bslash > slash)) slash = bslash;
+#endif
+    if (!slash) return false;
+    *slash = '\0';
+    return true;
 }
 
 // --------------------------------------------------------------------------
@@ -1774,7 +1797,7 @@ static const char* c_backend_env_override(void) {
     "https://github.com/brechtsanders/winlibs_mingw/releases/download/" \
     WINLIBS_TAG "/" WINLIBS_ZIP
 
-static char s_gcc_bin[1024] = "gcc";  // path to gcc; updated by ensure_gcc_windows()
+static char s_gcc_bin[1100] = "gcc";  // path to gcc; updated by ensure_gcc_windows()
 static bool s_gcc_ready      = false; // set after first successful check
 
 // Checks PATH, then ~/.aether/tools/, then downloads WinLibs on demand.
@@ -1799,7 +1822,10 @@ static bool ensure_gcc_windows(void) {
 
     // 2. Already installed to ~/.aether/tools/ from a previous run?
     const char* home  = get_home_dir();
-    char tools_dir[1024], tools_bin[1024], tools_gcc[1024];
+    /* tools_bin/tools_gcc derive from tools_dir plus a fixed suffix;
+     * sized a tier up so gcc's -Wformat-truncation heuristic (which
+     * assumes the %s can fill its whole source buffer) stays quiet. */
+    char tools_dir[1024], tools_bin[1100], tools_gcc[1100];
     snprintf(tools_dir, sizeof(tools_dir), "%s\\.aether\\tools",           home);
     snprintf(tools_bin, sizeof(tools_bin), "%s\\mingw64\\bin",             tools_dir);
     snprintf(tools_gcc, sizeof(tools_gcc), "%s\\mingw64\\bin\\gcc.exe",    tools_dir);
@@ -1814,7 +1840,7 @@ static bool ensure_gcc_windows(void) {
     mkdirs(tools_dir);  // Create ~/.aether/tools/ (and parents)
 
     // Write a tiny PowerShell script to avoid shell-quoting nightmares.
-    char ps_path[1024], zip_path[1024];
+    char ps_path[1100], zip_path[1100];
     snprintf(ps_path,  sizeof(ps_path),  "%s\\install_gcc.ps1", tools_dir);
     snprintf(zip_path, sizeof(zip_path), "%s\\mingw.zip",        tools_dir);
 
@@ -1846,7 +1872,7 @@ static bool ensure_gcc_windows(void) {
 found:
     // Add bundled bin dir to PATH for this process so gcc is found by name too.
     {
-        char cur[8192] = "", updated[8192];
+        char cur[8192] = "", updated[9400];
         GetEnvironmentVariableA("PATH", cur, sizeof(cur));
         snprintf(updated, sizeof(updated), "%s;%s", tools_bin, cur);
         SetEnvironmentVariableA("PATH", updated);
@@ -3342,7 +3368,7 @@ static int cmd_check(int argc, char** argv) {
         if (w < 0 || (size_t)w >= sizeof(lib_flags) - lf_off) break;
         lf_off += (size_t)w;
     }
-    char cmd[4096];
+    char cmd[8192];
     snprintf(cmd, sizeof(cmd), "\"%s\"%s --check \"%s\"",
              tc.compiler, lib_flags, file);
     return run_cmd(cmd);
@@ -3387,7 +3413,7 @@ static int cmd_inspect(int argc, char** argv) {
         if (w < 0 || (size_t)w >= sizeof(lib_flags) - lf_off) break;
         lf_off += (size_t)w;
     }
-    char cmd[4096];
+    char cmd[8192];
     snprintf(cmd, sizeof(cmd), "\"%s\" --emit=inspect%s \"%s\"",
              tc.compiler, lib_flags, file);
     return run_cmd(cmd);
@@ -4941,7 +4967,7 @@ int cmd_build_namespace(int argc, char** argv) {
     }
 
     /* Full output path with lib<base><ext>, anchored under target_dir. */
-    char out_path[1280];
+    char out_path[2400];
     snprintf(out_path, sizeof(out_path), "%s/lib%s%s", target_dir, base_name, lib_ext);
 
     /* Step 5: build the synthetic .ae as --emit=lib, then re-link with
@@ -5125,7 +5151,13 @@ static int cross_collect_core_list(char out[][CROSS_SRC_PATH_MAX], int max,
         if (*p == '\0' || *p == '#') continue;                 /* comment / blank */
         size_t plen = strlen(p);
         if (plen < 2 || strcmp(p + plen - 2, ".c") != 0) continue;
-        snprintf(out[count], CROSS_SRC_PATH_MAX, "%s/%s", base, p);
+        int need = snprintf(out[count], CROSS_SRC_PATH_MAX, "%s/%s", base, p);
+        if (need < 0 || need >= CROSS_SRC_PATH_MAX) {
+            /* A truncated source path would compile the wrong file or
+             * fail obscurely at the C compiler; skip it loudly instead. */
+            fprintf(stderr, "Warning: source path too long, skipped: %s/%s\n", base, p);
+            continue;
+        }
         count++;
     }
     fclose(f);
@@ -6513,7 +6545,7 @@ static int cmd_examples(int argc, char** argv) {
             while (fgets(c_line, sizeof(c_line), c_pipe)) {
                 c_line[strcspn(c_line, "\n\r")] = '\0';
                 if (strlen(c_line) == 0) continue;
-                char c_path[512];
+                char c_path[1100];
 #ifdef _WIN32
                 snprintf(c_path, sizeof(c_path), "%s\\%s", src_dir, c_line);
 #else
@@ -7425,7 +7457,7 @@ static int cmd_version_use(const char* version) {
             }
             fclose(avf_bak);
             if (cur_ver[0]) {
-                char cur_vtag[64];
+                char cur_vtag[66];
                 if (cur_ver[0] != 'v') snprintf(cur_vtag, sizeof(cur_vtag), "v%s", cur_ver);
                 else { strncpy(cur_vtag, cur_ver, sizeof(cur_vtag) - 1); cur_vtag[sizeof(cur_vtag)-1] = '\0'; }
                 char cur_ver_dir[512];

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -214,7 +214,9 @@ static bool g_emit_csrc = false;  // #996 --emit=csrc: emit .c + catalog .h, no 
 // and records the .so path + rpath here so build_gcc_cmd links it.
 // Empty for the common all-source build. POSIX-only (the prepass is
 // gated on dlopen availability); stays empty on Windows.
+#ifndef _WIN32
 static char g_binimport_link[4096] = "";
+#endif
 
 // Extra link flags accumulated by the host-bridge import prepass: when
 // a program `import`s `contrib.host.<lang>`, the bridge's static lib
@@ -228,7 +230,9 @@ static char g_binimport_link[4096] = "";
 // hello-world binary to dlopen libpython at runtime). Empty unless
 // `prepare_host_bridge_imports` found a match. POSIX-only (the host
 // bridges aren't built / linked on Windows).
+#ifndef _WIN32
 static char g_host_bridge_link[2048] = "";
+#endif
 
 // Mirror of runtime/aether_lib_meta.h's catalog structs, kept
 // layout-compatible so `ae` can dlopen a `--emit=lib` artifact and walk
@@ -505,6 +509,52 @@ static void tc_seed_lib_dirs_from_env(void) {
     if (env && *env) tc_lib_dir_append(env);
 }
 
+#ifdef _WIN32
+/* Windows twin of the POSIX walk below (#1235). This walk was compiled out
+ * on Windows, so lib-dir contents never entered the cache key: only the
+ * directory's own mtime did, and that does not change on an edit-in-place.
+ * Every module edit under lib/ therefore served a stale cached binary until
+ * `ae cache clear`. FindFirstFileA works on both MinGW and MSVC; dirent.h
+ * does not exist under MSVC, hence a native walk rather than un-guarding
+ * the POSIX one. Semantics mirror the POSIX twin exactly: bounded depth,
+ * shared entry cap, relative-path + content folding. */
+static int hash_lib_dir_entries(const char* dir, const char* rel,
+                                unsigned long long* acc, int* count, int depth) {
+    if (depth > 8 || *count >= 4096) return *count;
+    char pattern[1024];
+    snprintf(pattern, sizeof(pattern), "%s\\*", dir);
+    WIN32_FIND_DATAA fd;
+    HANDLE h = FindFirstFileA(pattern, &fd);
+    if (h == INVALID_HANDLE_VALUE) return *count;
+    do {
+        const char* name = fd.cFileName;
+        if (name[0] == '.') continue;  // skip . / .. / dotfiles
+        char full[1024];
+        snprintf(full, sizeof(full), "%s\\%s", dir, name);
+        char childrel[1024];
+        if (rel && rel[0])
+            snprintf(childrel, sizeof(childrel), "%s/%s", rel, name);
+        else
+            snprintf(childrel, sizeof(childrel), "%s", name);
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            hash_lib_dir_entries(full, childrel, acc, count, depth + 1);
+            continue;
+        }
+        size_t nlen = strlen(name);
+        int interesting = 0;
+        if (nlen > 3 && strcmp(name + nlen - 3, ".ae") == 0) interesting = 1;
+        else if (nlen > 2 && (strcmp(name + nlen - 2, ".c") == 0 ||
+                              strcmp(name + nlen - 2, ".h") == 0)) interesting = 1;
+        if (!interesting) continue;
+        *acc ^= fnv64_str(childrel);
+        *acc = (*acc * 1099511628211ULL) ^ fnv64_file(full);
+        (*count)++;
+    } while (FindNextFileA(h, &fd) && *count < 4096);
+    FindClose(h);
+    return *count;
+}
+#endif
+
 #ifndef _WIN32
 /* Recursively fold every source file (.ae/.c/.h) under `dir` into `*acc`
  * (name + resolved mtime + size), returning the count hashed. Modules live in
@@ -609,7 +659,6 @@ static unsigned long long compute_cache_key(const char* ae_file,
      * stdlib/vendored-modules count. */
     if (tc.lib_dir_count == 0) {
         pos += snprintf(key_buf + pos, sizeof(key_buf) - pos, ":lib=(default)");
-#ifndef _WIN32
         /* #1025 Bug A: with no --lib flag and no $AETHER_LIB_DIR, the compiler
          * still searches the default lib dir (module_add_lib_dir(
          * AETHER_DEFAULT_LIB_DIR) in aether_module.c) — the canonical
@@ -626,7 +675,6 @@ static unsigned long long compute_cache_key(const char* ae_file,
                                 ":dlent=%d:dlh=%016llx", n, entry_hash);
             }
         }
-#endif
     }
     for (int i = 0; i < tc.lib_dir_count; i++) {
         pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
@@ -636,7 +684,6 @@ static unsigned long long compute_cache_key(const char* ae_file,
             pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
                             ":lmt=%lld", (long long)lst.st_mtime);
         }
-#ifndef _WIN32
         /* Recurse the whole lib-dir tree — modules live in subdirectories
          * (#623 follow-up: a top-level-only walk missed every std/contrib
          * module in a subdir, so editing one served a stale cached binary). */
@@ -649,7 +696,6 @@ static unsigned long long compute_cache_key(const char* ae_file,
                                 ":lent=%d:lh=%016llx", n, entry_hash);
             }
         }
-#endif
     }
 
     snprintf(key_buf + pos, sizeof(key_buf) - pos, ":%s:%s",
@@ -2158,8 +2204,13 @@ static int get_extra_sources_for_bin(const char* ae_file, char* out, size_t out_
 // gcc inlines / merges blocks, and the .gcov line attribution gets
 // scrambled (a hit on line 7 might show up on line 9).
 static const char* opt_flags(bool optimize) {
-    if (g_coverage) return "-O0 -g --coverage";
-    return optimize ? "-O2" : "-O0 -g";
+    /* -Wformat: with the interop lowering no longer casting literal format
+     * strings to void* (#1252), the C compiler can check printf-family
+     * extern calls; #line directives map its warning to the user's .ae
+     * source. User cflags from aether.toml append after these flags, so
+     * -Wno-format remains available to opt out. */
+    if (g_coverage) return "-O0 -g --coverage -Wformat";
+    return optimize ? "-O2 -Wformat" : "-O0 -g -Wformat";
 }
 
 static void build_gcc_cmd(char* cmd, size_t size,
@@ -5899,7 +5950,10 @@ static int cmd_build(int argc, char** argv) {
             const char* extra = extra_files[0] ? extra_files : NULL;
             build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, !quick, extra);
         }
-        build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_quiet(cmd);
+        /* Warnings-visible like the `ae run` path: with #1252 fixed the C
+         * compiler's -Wformat findings map to the user's .ae lines, and a
+         * fully quiet compile would hide them. Errors still re-run loud. */
+        build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
         if (build_ret != 0) {
             // Retry with visible output for error messages
             if (is_wasm) {
@@ -6643,9 +6697,11 @@ static int cmd_repl(void) {
     if (inner < help_len + 3) inner = help_len + 3;
     printf("  ┌"); for (int i = 0; i < inner; i++) printf("─"); printf("┐\n");
     printf("  │   Aether %s REPL", AE_VERSION);
-    for (int i = title_len; i < inner; i++) printf(" "); printf("│\n");
+    for (int i = title_len; i < inner; i++) printf(" ");
+    printf("│\n");
     printf("  │   :help for commands");
-    for (int i = help_len; i < inner; i++) printf(" "); printf("│\n");
+    for (int i = help_len; i < inner; i++) printf(" ");
+    printf("│\n");
     printf("  └"); for (int i = 0; i < inner; i++) printf("─"); printf("┘\n");
     printf("\n");
 


### PR DESCRIPTION
## Summary

Three issue-tracker bugs, all reproduced before fixing and covered by new tests. Two came out of the Aedis/Redis port's C-interop reproducers; the third is the Windows cache regression.

## `-Wformat` works through extern calls again

Closes #1252

The lowering cast literal format strings to `void*`, stripping the constant the C compiler's format check reads: `printf("value is %s\n", 42)` compiled silently. String literals are `char[]` in C and convert to `void*` implicitly, so they now pass into `ptr` parameters bare; the cast remains for non-literal `const char*` expressions, which is what it existed for.

End to end: `ae` now passes `-Wformat` when compiling generated C (aether.toml cflags append after it, so `-Wno-format` opts out), and `ae build` surfaces compiler warnings the way `ae run` already did. The `#line` mapping lands the diagnostic on the user's source:

```
fmtbug.ae:4:25: warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
```

Verified the examples suite compiles with zero format warnings under the new flag.

## Struct fields named `read`/`write` are callable

Closes #1251

A field named after a libc symbol was renamed to `ae_read` at the member-call site while the struct definition kept the plain name, so the emitted C referenced a member that does not exist. Fields are struct members, not linker symbols: the libc-collision rename (`safe_c_name`) no longer applies on the member-call path, only C-keyword mangling does, matching the definition side. The receiver had the same latent bug (a local is not a linker symbol either) and got the same correction. Redis-style vtables (`rio.read`, `rio.write`) now port cleanly, which was the blocker behind the report.

## Windows: `lib/` edits invalidate the build cache

Closes #1235

Root cause was plain: the lib-dir content walk feeding the cache key sat inside `#ifndef _WIN32`, so on Windows only the directory's own mtime was hashed, and that does not change on an edit-in-place. Every module edit under `lib/` served a stale cached binary until `ae cache clear`, matching the report exactly (and explaining why it never reproduced on macOS).

The walk now has a native `FindFirstFileA` implementation mirroring the POSIX one exactly: bounded depth, shared entry cap, relative-path plus content folding. `dirent.h` does not exist under MSVC, hence a native walk rather than un-guarding POSIX code. MinGW cross-compile verified.

## Also fixed on the way

Cross-compiling `ae.c` for the Windows work surfaced pre-existing GCC findings invisible to clang: two misleading-indentation sites and two POSIX-only globals unused on Windows. Fixed; the branch reduces the MinGW strict-warning count and adds none.

## Tests

- `test_issue1251_field_named_read.ae`: vtable fields with libc-colliding names, call through both, assert results
- `wformat_extern_literal`: proves the format diagnostic fires, does not fail the build, and is attributed to the `.ae` file
- `cache_libdir_invalidation`: edits a `lib/` module in place keeping byte length identical (so only content hashing can catch it), through both `ae run` and `ae build` with a fresh `-o`; runs on every platform including the MSYS2 CI job


## Second commit: driver-mtime cache coverage + zero MinGW strict warnings

Two follow-ups applied in the same PR rather than deferred:

- **Rebuilding `ae` itself now invalidates the cache.** The key hashed aetherc's mtime but not the driver's, and the flags ae passes to the C compiler (now including `-Wformat`) are part of the output. Verified live: `touch build/ae` forces a miss, an unchanged rerun still hits.
- **`ae.c` is now clean under MinGW GCC's full `-Wall -Wextra -Werror`: 15 findings on main, zero on this branch.** Nine format-truncation sites fixed by sizing derived-path buffers past their sources (the codebase's established pattern); the cross-compile source-list join instead gets a real length check that reports and skips an overlong path, because silent truncation there could compile the wrong file.

Local zig cross-compile smoke: 19/20 cases pass; the suite self-skips on GitHub CI (no zig toolchain). The single failing case also predates this branch (it is not in the source-collection path this PR touches; a broken `cross_collect_core_list` would fail every target, and 13+ targets link and run). Identifying and fixing that case is in progress and will be reported precisely.