### PR TITLE
fix(codegen): munch-proof octal string escapes; binary-safe generated C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ next version number before tagging the release.
   freed its temporaries; the direct-argument form never did, for every heap
   producer. Both forms now route through owned-print helpers that print and
   free in one step; bound identifiers keep their scope-exit free.
+- **String-literal emission: hex-escape maximal munch corrupted bytes, and
+  binary bytes made the generated C a binary file.** A C hex escape has no
+  length limit, so an emitted `"\x01a"` re-lexed as the single byte 0x1A
+  whenever a hex-escaped byte preceded a hex-digit character; and bytes above
+  0x7F (decoded `\x` escapes, e.g. CBOR/MsgPack test vectors) were written
+  raw, producing invalid-UTF-8 output that text tools mishandle
+  platform-dependently (surfaced as phantom checksum mismatches on Windows
+  CI). The emitter now writes zero-padded octal (`\001`, munch-proof by
+  construction) and keeps only valid UTF-8 sequences raw, so generated C is
+  always valid text. Regression:
+  `tests/regression/test_string_escape_bytes.ae`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![Windows](https://github.com/aether-lang-org/aether/actions/workflows/windows.yml/badge.svg)](https://github.com/aether-lang-org/aether/actions/workflows/windows.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS%20%7C%20WASM%20%7C%20Embedded-lightgrey)]()
+[![Website](https://img.shields.io/badge/website-aether--lang.dev-8A2BE2)](https://aether-lang.dev/)
 
 Erlang-style actors, Rust-grade capability discipline, and Go-flavored ergonomics, compiled to readable C.
+
+**Website: [aether-lang.dev](https://aether-lang.dev/)**
 
 ## Overview
 

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -1999,6 +1999,24 @@ static ASTNode* current_fn_body_block(CodeGenerator* gen) {
     return NULL;
 }
 
+/* Length of the valid UTF-8 sequence starting at `s`, or 1 if the
+ * bytes do not form one (lone continuation byte, truncated sequence,
+ * overlong-agnostic on purpose: structural validity is enough here).
+ * Used by the string-literal emitter to keep human text readable in
+ * generated C while byte-escaping everything that is not valid text. */
+static int utf8_sequence_length(const char* s) {
+    unsigned char c0 = (unsigned char)s[0];
+    int len;
+    if ((c0 & 0xE0) == 0xC0) len = 2;
+    else if ((c0 & 0xF0) == 0xE0) len = 3;
+    else if ((c0 & 0xF8) == 0xF0) len = 4;
+    else return 1;
+    for (int i = 1; i < len; i++) {
+        if (((unsigned char)s[i] & 0xC0) != 0x80) return 1;
+    }
+    return len;
+}
+
 void generate_expression(CodeGenerator* gen, ASTNode* expr) {
     if (!expr) return;
 
@@ -2034,7 +2052,31 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         case '"': fprintf(gen->output, "\\\""); break;
                         default:
                             if (ch < 0x20 || ch == 0x7F) {
-                                fprintf(gen->output, "\\x%02x", ch);
+                                /* Zero-padded OCTAL, never \x: a C hex
+                                 * escape has no length limit, so
+                                 * "\x01a" re-lexes as byte 0x1A (silent
+                                 * corruption when the next char is a
+                                 * hex digit). \001 is exactly three
+                                 * digits and cannot munch. */
+                                fprintf(gen->output, "\\%03o", ch);
+                            } else if (ch >= 0x80) {
+                                /* Bytes above ASCII: emit a VALID UTF-8
+                                 * sequence raw so human text stays
+                                 * readable in the generated C; escape
+                                 * anything else (decoded \x binary,
+                                 * e.g. CBOR/MsgPack test vectors) so
+                                 * the output stays valid text and every
+                                 * downstream tool (grep/awk/editors)
+                                 * treats it uniformly on all platforms. */
+                                int seq = utf8_sequence_length(str);
+                                if (seq > 1) {
+                                    for (int b = 0; b < seq; b++) {
+                                        fprintf(gen->output, "%c", str[b]);
+                                    }
+                                    str += seq - 1;
+                                } else {
+                                    fprintf(gen->output, "\\%03o", ch);
+                                }
                             } else {
                                 fprintf(gen->output, "%c", *str);
                             }
@@ -4874,7 +4916,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                             s++; hd++; \
                                         } \
                                         s--; \
-                                        if (hd > 0) fprintf(gen->output, "\\x%02x", hval & 0xFF); \
+                                        if (hd > 0) fprintf(gen->output, "\\%03o", hval & 0xFF); \
                                         else        fprintf(gen->output, "\\\\x"); \
                                     } else if (esc >= '0' && esc <= '7') { \
                                         s++; \
@@ -4882,7 +4924,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                         while (od < 3 && *(s+1) >= '0' && *(s+1) <= '7') { \
                                             s++; oval = oval * 8 + (*s - '0'); od++; \
                                         } \
-                                        fprintf(gen->output, "\\x%02x", oval & 0xFF); \
+                                        fprintf(gen->output, "\\%03o", oval & 0xFF); \
                                     } else { \
                                         fprintf(gen->output, "\\\\"); \
                                     } \
@@ -4890,7 +4932,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                                 } \
                                 default: \
                                     if ((unsigned char)*s < 0x20 || *s == 0x7F) \
-                                        fprintf(gen->output, "\\x%02x", (unsigned char)*s); \
+                                        fprintf(gen->output, "\\%03o", (unsigned char)*s); \
                                     else \
                                         fputc(*s, gen->output); \
                                     break; \

--- a/tests/regression/test_string_escape_bytes.ae
+++ b/tests/regression/test_string_escape_bytes.ae
@@ -1,0 +1,72 @@
+// Regression: the C string-literal emitter wrote \x hex escapes, and a
+// C hex escape has no length limit, so "\x01a" re-lexed as the single
+// byte 0x1A instead of 0x01 then 'a' (silent data corruption whenever a
+// hex-escaped byte preceded a hex-digit character). Bytes above ASCII
+// were also emitted raw, making the generated C a binary file that
+// text tools mishandle platform-dependently. The emitter now writes
+// zero-padded octal (munch-proof by construction) and keeps only valid
+// UTF-8 sequences raw.
+//
+// What this test guards:
+//   1. A hex escape followed by a hex-digit char stays two bytes
+//   2. High bytes (>0x7F) round-trip exactly
+//   3. Control bytes round-trip exactly
+//   4. Escapes inside interpolation segments behave the same
+
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+expect_byte(s: string, idx: int, want: int, label: string) {
+    // char_at returns a signed char; mask to compare as a raw byte.
+    got = string.char_at(s, idx) & 0xFF
+    if got != want {
+        fail("${label}: byte[${idx}] expected ${want}, got ${got}")
+    }
+}
+
+main() {
+    munch = "\x01a"
+    if string.length(munch) != 2 {
+        n = string.length(munch)
+        fail("munch guard: expected 2 bytes, got ${n}")
+    }
+    expect_byte(munch, 0, 1, "munch guard")
+    expect_byte(munch, 1, 97, "munch guard")
+    println("PASS 1: hex escape before a hex digit stays two bytes")
+
+    high = "\x82\x01"
+    if string.length(high) != 2 {
+        fail("high bytes: expected 2 bytes")
+    }
+    expect_byte(high, 0, 130, "high byte")
+    expect_byte(high, 1, 1, "high byte")
+    println("PASS 2: bytes above 0x7F round-trip exactly")
+
+    // NUL stays out: a literal is a C string, so an embedded \x00
+    // truncates strlen-based length by design (string.from_char /
+    // string.new_with_length are the NUL-carrying constructors).
+    ctl = "\x01\x1f\x7f"
+    if string.length(ctl) != 3 {
+        fail("control bytes: expected 3 bytes")
+    }
+    expect_byte(ctl, 1, 31, "control byte")
+    expect_byte(ctl, 2, 127, "control byte")
+    println("PASS 3: control bytes round-trip exactly")
+
+    tail = "fee"
+    combo = "\x0d${tail}"
+    if string.length(combo) != 4 {
+        fail("interp: expected 4 bytes")
+    }
+    expect_byte(combo, 0, 13, "interp escape")
+    expect_byte(combo, 1, 102, "interp escape")
+    println("PASS 4: escapes in interpolation segments unchanged")
+
+    println("=== All cases passed ===")
+}


### PR DESCRIPTION
## Codegen: munch-proof string escapes; generated C is always valid text

Follow-up to #1335, whose fmt gate diagnostics (od proving two "differing" Windows files byte-identical) traced the CI anomalies to the generated C itself being a binary file. Two defects in the string-literal emitter:

1. **Hex-escape maximal munch corrupted bytes.** A C hex escape has no length limit, so an emitted `"\x01a"` re-lexes as the single byte 0x1A: silent data corruption whenever a hex-escaped byte precedes a hex-digit character.
2. **Bytes above 0x7F were emitted raw.** Decoded `\x` escapes (CBOR/MsgPack test vectors and any binary payload) produced invalid-UTF-8 output that text tools mishandle platform-dependently; this is what made grep/cksum/awk behave inconsistently on the Windows runners, and #1335's gate settle-recheck currently papers over it.

The literal emitter now writes zero-padded octal (`\001`: exactly three digits, munch-proof by construction), keeps only structurally valid UTF-8 sequences raw (human text stays readable in generated C), and byte-escapes everything else. The interpolation-segment emitter gets the same octal treatment.

Regression: `tests/regression/test_string_escape_bytes.ae` verifies runtime byte values for the munch shape, high bytes, control bytes, and interpolation segments. The cbor test's emitted C drops from 8 raw binary bytes to 0.

## Verification

- `make test` 229/229, `make test-ae` 918 passing (remaining locals are the known sandbox artifacts), determinism + fmt gates green on this branch
- `-Werror` and MinGW cross-compile of the changed TU clean
- `ae run` of the escape-sensitive suite (print_char, box_drawing, bytes_to_string, interp_escape_combo, cbor) all pass
