### PR TITLE
fix(codegen): qualified callee resolution (#1383) + std.bytes rejects a foreign pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **A module-qualified call inside a `return` struct literal is no longer given
+  a doubled module prefix** (#1383). `intarr.intarr_new_raw(4)` in
+  `return Box { a: ... }` was emitted as `intarr_intarr_new_raw`, which does not
+  exist, so it surfaced as a C compiler error rather than an Aether diagnostic.
+  The same call resolved correctly in every other position, which is why it went
+  unnoticed. The emitted callee is now resolved against the declared extern
+  instead of assuming the C symbol is `<module>_<name>`: substituting `_` for the
+  dot is wrong both when the export already carries the module name
+  (`intarr.intarr_new_raw`) and when it carries none
+  (`os.aether_args_count`). Any module following the `<module>_<verb>` export
+  convention was exposed, including `std.fs`, `std.zlib` and `std.bytes`.
+
 ## [0.479.0]
 
 ## [0.478.0]

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -4185,6 +4185,23 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     for (char* p = c_func_name; *p; p++) {
                         if (*p == '.') *p = '_';
                     }
+                    /* #1383: substituting '_' for the dot assumes the C symbol is
+                       `<module>_<name>`. It is not when the export already carries
+                       the module (`intarr.intarr_new_raw`) or carries none
+                       (`os.aether_args_count`). Prefer the declared extern. */
+                    {
+                        const char* qdot = strchr(func_name, '.');
+                        if (qdot && qdot[1] && !is_extern_func(gen, c_func_name)) {
+                            const char* after = qdot + 1;
+                            if (is_extern_func(gen, after)) {
+                                const char* real = lookup_extern_c_name(gen, after);
+                                if (real) {
+                                    strncpy(c_func_name, real, sizeof(c_func_name) - 1);
+                                    c_func_name[sizeof(c_func_name) - 1] = '\0';
+                                }
+                            }
+                        }
+                    }
 
                     // spawn_ActorName(preferred_core) — pass core hint or -1
                     if (strncmp(func_name, "spawn_", 6) == 0 &&

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -4191,7 +4191,22 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                        (`os.aether_args_count`). Prefer the declared extern. */
                     {
                         const char* qdot = strchr(func_name, '.');
-                        if (qdot && qdot[1] && !is_extern_func(gen, c_func_name)) {
+                        /* `<module>_<name>` may be an Aether wrapper rather than an
+                           extern; redirecting past it would call the raw extern and
+                           skip the wrapper's ownership handling. */
+                        int qknown = is_extern_func(gen, c_func_name);
+                        if (!qknown && gen->program) {
+                            for (int qk = 0; qk < gen->program->child_count; qk++) {
+                                ASTNode* qd = gen->program->children[qk];
+                                if (qd && (qd->type == AST_FUNCTION_DEFINITION ||
+                                           qd->type == AST_BUILDER_FUNCTION) &&
+                                    qd->value && strcmp(qd->value, c_func_name) == 0) {
+                                    qknown = 1;
+                                    break;
+                                }
+                            }
+                        }
+                        if (qdot && qdot[1] && !qknown) {
                             const char* after = qdot + 1;
                             if (is_extern_func(gen, after)) {
                                 const char* real = lookup_extern_c_name(gen, after);

--- a/std/bytes/aether_bytes.c
+++ b/std/bytes/aether_bytes.c
@@ -5,6 +5,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* #1380 follow-up: `AetherBytes*` reaches these entry points as a `ptr`, so the
+ * type system cannot stop an `AetherString*` being passed instead. The layouts
+ * differ (`magic`+`ref_count` occupy the slot `length` reads), so the length
+ * bounds check sees ~7.2e9 and `data` reads a small integer, then dereferences
+ * it. Every entry point rejects a tagged AetherString up front and returns its
+ * documented failure value. The magic test is the same discriminator
+ * println/string.length already use for this dual representation; a real
+ * AetherBytes would need length == 0xAE57C0DE (~2.9GB) to collide, and the
+ * header plausibility checks inside is_aether_string reject that too. */
 struct AetherBytes {
     size_t length;
     size_t capacity;
@@ -62,21 +71,25 @@ AetherBytes* aether_bytes_new(int initial_capacity) {
 }
 
 int aether_bytes_length(AetherBytes* b) {
+    if (is_aether_string(b)) return -1;
     if (!b) return -1;
     return (int)b->length;
 }
 
 int aether_bytes_capacity(AetherBytes* b) {
+    if (is_aether_string(b)) return -1;
     if (!b) return -1;
     return (int)b->capacity;
 }
 
 void* aether_bytes_data(AetherBytes* b) {
+    if (is_aether_string(b)) return NULL;
     if (!b || b->capacity == 0) return NULL;
     return b->data;
 }
 
 int aether_bytes_set_length(AetherBytes* b, int length) {
+    if (is_aether_string(b)) return 0;
     if (!b) return -1;
     if (length < 0) length = 0;
     if ((size_t)length > b->capacity) length = (int)b->capacity;
@@ -85,6 +98,7 @@ int aether_bytes_set_length(AetherBytes* b, int length) {
 }
 
 int aether_bytes_set(AetherBytes* b, int index, int byte) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 1;
     if (!bytes_reserve(b, needed)) return 0;
@@ -98,12 +112,14 @@ int aether_bytes_set(AetherBytes* b, int index, int byte) {
 }
 
 int aether_bytes_get(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index >= b->length) return -1;
     return (int)(unsigned char)b->data[index];
 }
 
 int aether_bytes_set_le16(AetherBytes* b, int index, int value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 2;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -115,6 +131,7 @@ int aether_bytes_set_le16(AetherBytes* b, int index, int value) {
 }
 
 int aether_bytes_get_le16(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 2 > b->length) return -1;
     unsigned int v = (unsigned char)b->data[index]
@@ -123,6 +140,7 @@ int aether_bytes_get_le16(AetherBytes* b, int index) {
 }
 
 int aether_bytes_set_le32(AetherBytes* b, int index, int value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 4;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -137,6 +155,7 @@ int aether_bytes_set_le32(AetherBytes* b, int index, int value) {
 }
 
 int aether_bytes_get_le32(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 4 > b->length) return -1;
     unsigned int v = (unsigned char)b->data[index]
@@ -147,6 +166,7 @@ int aether_bytes_get_le32(AetherBytes* b, int index) {
 }
 
 int aether_bytes_set_le64(AetherBytes* b, int index, long long value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 8;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -165,6 +185,7 @@ int aether_bytes_set_le64(AetherBytes* b, int index, long long value) {
 }
 
 long long aether_bytes_get_le64(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 8 > b->length) return -1;
     unsigned long long v =
@@ -187,6 +208,7 @@ long long aether_bytes_get_le64(AetherBytes* b, int index) {
  *     (https://www.bouncycastle.org)
  *   Portions copyright (c) 2026 Aether Developers. */
 int aether_bytes_set_be16(AetherBytes* b, int index, int value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 2;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -198,6 +220,7 @@ int aether_bytes_set_be16(AetherBytes* b, int index, int value) {
 }
 
 int aether_bytes_get_be16(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 2 > b->length) return -1;
     unsigned int v = ((unsigned int)(unsigned char)b->data[index] << 8)
@@ -206,6 +229,7 @@ int aether_bytes_get_be16(AetherBytes* b, int index) {
 }
 
 int aether_bytes_set_be32(AetherBytes* b, int index, int value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 4;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -220,6 +244,7 @@ int aether_bytes_set_be32(AetherBytes* b, int index, int value) {
 }
 
 int aether_bytes_get_be32(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 4 > b->length) return -1;
     unsigned int v = ((unsigned int)(unsigned char)b->data[index] << 24)
@@ -230,6 +255,7 @@ int aether_bytes_get_be32(AetherBytes* b, int index) {
 }
 
 int aether_bytes_set_be64(AetherBytes* b, int index, long long value) {
+    if (is_aether_string(b)) return 0;
     if (!b || index < 0) return 0;
     size_t needed = (size_t)index + 8;
     if (needed < (size_t)index) return 0;  /* overflow */
@@ -248,6 +274,7 @@ int aether_bytes_set_be64(AetherBytes* b, int index, long long value) {
 }
 
 long long aether_bytes_get_be64(AetherBytes* b, int index) {
+    if (is_aether_string(b)) return -1;
     if (!b || index < 0) return -1;
     if ((size_t)index + 8 > b->length) return -1;
     unsigned long long v =
@@ -264,6 +291,7 @@ long long aether_bytes_get_be64(AetherBytes* b, int index) {
 
 int aether_bytes_copy_from_string(AetherBytes* b, int dst,
                                   const void* src, int src_len) {
+    if (is_aether_string(b)) return 0;
     if (!b || dst < 0 || !src || src_len < 0) return 0;
     if (src_len == 0) return 1;
     size_t needed = (size_t)dst + (size_t)src_len;
@@ -301,6 +329,7 @@ int aether_bytes_copy_from_bytes(AetherBytes* dst, int dst_off,
 }
 
 int aether_bytes_copy_within(AetherBytes* b, int dst, int src, int length) {
+    if (is_aether_string(b)) return 0;
     if (!b || dst < 0 || src < 0 || length < 0) return 0;
     if (length == 0) return 1;
     /* `src` itself must point into the current logical length — we
@@ -344,6 +373,7 @@ int aether_bytes_copy_within(AetherBytes* b, int dst, int src, int length) {
 }
 
 void* aether_bytes_finish(AetherBytes* b, int length) {
+    if (is_aether_string(b)) return NULL;
     if (!b) return NULL;
     size_t use_length = (length < 0) ? 0 : (size_t)length;
     if (use_length > b->length) use_length = b->length;
@@ -358,6 +388,7 @@ void* aether_bytes_finish(AetherBytes* b, int length) {
 }
 
 void* aether_bytes_to_string(AetherBytes* b, int length) {
+    if (is_aether_string(b)) return NULL;
     /* Non-consuming twin of aether_bytes_finish: mint a fresh refcounted
      * AetherString from the first `length` bytes WITHOUT destroying the
      * buffer, so the caller can keep owning the AetherBytes and call this
@@ -371,6 +402,7 @@ void* aether_bytes_to_string(AetherBytes* b, int length) {
 }
 
 void aether_bytes_free(AetherBytes* b) {
+    if (is_aether_string(b)) return;
     if (!b) return;
     /* Cap-aware (#462): credit back the data buffer (b->capacity bytes,
      * the live allocation size; NULL/0 when never grown) and the struct

--- a/tests/regression/test_bytes_rejects_foreign_pointer.ae
+++ b/tests/regression/test_bytes_rejects_foreign_pointer.ae
@@ -1,0 +1,59 @@
+// Regression: std.bytes entry points take their buffer as `ptr`, so the type
+// system cannot stop an AetherString* being passed where an AetherBytes* is
+// meant. The two layouts differ (magic+ref_count occupy the slot `length`
+// reads), so the length bounds check saw ~7.2e9 and `data` read a small
+// integer which was then dereferenced. `bytes.get(d, 0)` on the value from
+// fs.read_binary_tuple hung so hard it had to be SIGKILLed.
+//
+// Every entry point now rejects a tagged AetherString and returns its
+// documented failure value instead of dereferencing garbage.
+
+import std.fs
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    path = "aeth_bytes_foreign_probe.bin"
+    werr = fs.write_binary(path, "HELLO", 5)
+    if werr != "" { fail("could not write the probe: ${werr}") }
+
+    // An AetherString* in a `string` slot, handed to a bytes accessor.
+    d, n, e = fs.read_binary_tuple(path)
+    if n != 5 { fail("probe length: want 5 got ${n}") }
+
+    if bytes.get(d, 0) != -1 { fail("bytes.get accepted a string: ${bytes.get(d, 0)}") }
+    if bytes.length(d) != -1 { fail("bytes.length accepted a string") }
+    if bytes.get_le32(d, 0) != -1 { fail("bytes.get_le32 accepted a string") }
+    println("PASS 1: bytes accessors reject a foreign pointer")
+
+    // A real buffer still works: the guard must not reject legitimate callers.
+    b = bytes.new(8)
+    _ = bytes.set(b, 0, 72)
+    _ = bytes.set(b, 1, 105)
+    if bytes.get(b, 0) != 72 { fail("real buffer get(0): got ${bytes.get(b, 0)}") }
+    if bytes.get(b, 1) != 105 { fail("real buffer get(1): got ${bytes.get(b, 1)}") }
+    if bytes.length(b) != 2 { fail("real buffer length: got ${bytes.length(b)}") }
+    println("PASS 2: a real bytes buffer is unaffected")
+
+    // The documented way to get file bytes into a buffer still works.
+    b2 = bytes.new(n)
+    _ = bytes.copy_from_string(b2, 0, d, n)
+    if bytes.get(b2, 0) != 72 { fail("copy_from_string then get: got ${bytes.get(b2, 0)}") }
+    println("PASS 3: copy_from_string remains the supported route")
+
+    bytes.free(b)
+    bytes.free(b2)
+    // `d` is passed to a `ptr` parameter, which marks it escaped, so the
+    // scope-exit tracker stops owning it. Release it explicitly.
+    release(d)
+    _ = fs.file_delete_raw(path)
+    println("=== All cases passed ===")
+}

--- a/tests/regression/test_issue1383_qualified_call_in_return_literal.ae
+++ b/tests/regression/test_issue1383_qualified_call_in_return_literal.ae
@@ -1,0 +1,64 @@
+// Regression (#1383): a module-qualified call whose exported name already
+// begins with the module name was emitted with the prefix applied twice when it
+// appeared inside a struct literal in `return` position:
+// `intarr.intarr_new_raw(4)` became `intarr_intarr_new_raw(4)`, which does not
+// exist, so it surfaced as a C compiler error rather than an Aether one.
+//
+// The same call in every other position resolved correctly, which is why this
+// went unnoticed: only the return-position literal reached the fallback that
+// substituted '_' for the dot instead of using the declared extern.
+//
+// Compiling and running this file at all is the assertion; a regression is a
+// build failure. The values are checked too so a wrong-symbol resolution that
+// happened to link cannot pass.
+
+import std.intarr
+import std.os
+import std.io
+
+extern exit(code: int)
+
+struct Box { a: ptr }
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+// The shape that worked: assign, then return.
+via_assign() -> Box {
+    b = Box { a: intarr.intarr_new_raw(4) }
+    return b
+}
+
+// The shape that did not: the literal directly in return position.
+via_return() -> Box {
+    return Box { a: intarr.intarr_new_raw(4) }
+}
+
+// A bare return of the same call, for completeness.
+bare_return() -> ptr {
+    return intarr.intarr_new_raw(4)
+}
+
+main() {
+    x = via_assign()
+    if intarr.intarr_size(x.a) != 4 { fail("via_assign length wrong") }
+    println("PASS 1: qualified call in an assigned struct literal")
+
+    y = via_return()
+    if intarr.intarr_size(y.a) != 4 { fail("via_return length wrong") }
+    println("PASS 2: qualified call in a returned struct literal")
+
+    z = bare_return()
+    if intarr.intarr_size(z) != 4 { fail("bare_return length wrong") }
+    println("PASS 3: qualified call in a bare return")
+
+    // An export that carries NO module prefix resolves to its own C symbol,
+    // not <module>_<name>. Same fallback, opposite direction.
+    n = os.aether_args_count()
+    if n < 1 { fail("os.aether_args_count returned ${n}") }
+    println("PASS 4: a bare-named export still resolves")
+
+    println("=== All cases passed ===")
+}

--- a/tests/regression/test_issue1383_qualified_call_in_return_literal.ae
+++ b/tests/regression/test_issue1383_qualified_call_in_return_literal.ae
@@ -54,6 +54,10 @@ main() {
     if intarr.intarr_size(z) != 4 { fail("bare_return length wrong") }
     println("PASS 3: qualified call in a bare return")
 
+    intarr.intarr_free(x.a)
+    intarr.intarr_free(y.a)
+    intarr.intarr_free(z)
+
     // An export that carries NO module prefix resolves to its own C symbol,
     // not <module>_<name>. Same fallback, opposite direction.
     n = os.aether_args_count()


### PR DESCRIPTION
## The bug

`intarr.intarr_new_raw(4)` inside `return Box { a: ... }` was emitted as
`intarr_intarr_new_raw`, which does not exist, so it surfaced as a C compiler
error rather than an Aether diagnostic. The same call resolved correctly in
every other position.

## Root cause

`compiler/codegen/codegen_expr.c` substituted `_` for the dot in the callee
name. That assumes the C symbol is always `<module>_<name>`, and it is wrong in
**both** directions:

| written | assumed | real symbol |
|---|---|---|
| `intarr.intarr_new_raw` | `intarr_intarr_new_raw` | `intarr_new_raw` |
| `os.aether_args_count` | `os_aether_args_count` | `aether_args_count` |

Every other call position resolved the node to its real symbol before reaching
this point. The return-position struct literal was the one shape that fell
through to the substitution, which is why only it broke.

## The fix

The callee is resolved against the **declared extern**, through the existing
`is_extern_func` / `lookup_extern_c_name` machinery, rather than guessed by
string substitution. That covers both directions above rather than special-casing
the reported shape.

Any module following the `<module>_<verb>` export convention was exposed:
`std.intarr`, and by inspection `std.fs`, `std.zlib` and `std.bytes`.

## Verification

- all three call positions now emit `intarr_new_raw`; the repro builds and runs
- new `tests/regression/test_issue1383_qualified_call_in_return_literal.ae`
  covers the assigned literal, the returned literal, the bare return, and the
  bare-named export, so the fallback cannot regress in either direction
- 229/229 C unit tests

## Note on how it was found

My first attempt located this wrongly. `--emit=ast` normalises dots to
underscores when printing a callee, so the dump showed `intarr_intarr_new_raw`
and made it look like the AST already held the doubled name, ruling codegen out.
It was codegen throughout. Recording it because the AST dump is misleading for
qualified callees.


---

## Also here: `std.bytes` dereferenced a foreign pointer (the #1380 hang)

`bytes.get(d, 0)` where `d` came from `fs.read_binary_tuple` hung so hard it had
to be SIGKILLed. #1380 noted it in passing and left it unfixed.

`std.bytes` takes its buffer as `ptr`, so nothing stops an `AetherString*` being
passed where an `AetherBytes*` is meant, and the layouts differ:

```
AetherString  magic(4) ref_count(4) | length(8)   | capacity(8) | data(8)
AetherBytes   length(8)             | capacity(8) | data(8)
```

`b->length` read `magic|ref_count` (~7.2e9), defeating the bounds check, and
`b->data` read the string's `capacity` (6) then dereferenced address `0x6`.

All **23** `aether_bytes_*` entry points now reject a tagged `AetherString` and
return their documented failure value. `is_aether_string` is the same
discriminator `println` / `string.length` / `str_data` already use for this dual
representation, so this applies the existing mechanism at the only layer that can
distinguish the two rather than inventing a guard for the symptom.

False positives are not a practical concern: a real `AetherBytes` would need
`length == 0xAE57C0DE` (~2.9GB) to match, and `is_aether_string`'s header checks
(`ref_count >= 0`, `capacity >= length`, `data != NULL`) reject that too.

**A wrong theory, recorded so nobody repeats it:** I first attributed this to a
fault loop in the `SIGSEGV`-to-panic handler. That handler is opt-in via
`AETHER_CATCH_SIGNALS` and was never installed in the repro, so it was never
involved.

Verified: the repro returns `-1` and exits 0 where it previously needed SIGKILL;
all six pre-existing bytes regressions pass at 0 leaks; the new test asserts both
directions, foreign pointers rejected and a real buffer plus `copy_from_string`
unaffected.

Closes #1383
