### PR TITLE
fix(codegen): std.bytes readers are non-storing, so their string args are freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **A heap string passed to a `std.bytes` reader no longer leaks.** The
+  compiler's non-storing-callee allowlist covers the string readers
+  (`aether_string_data`, `string_seq_join`, `println`, ...) but never included
+  `std.bytes`, so passing a heap string to `bytes.length` / `bytes.get` marked it
+  escaped and suppressed its scope-exit free. The caller leaked unless it added
+  an explicit `release()`, and nothing signalled that. The scalar-returning
+  readers (`length`, `capacity`, `get`, `get_le16/32/64`, `get_be16/32/64`) and
+  `copy_from_string`, which copies out and retains nothing, are now listed.
+  `aether_bytes_data` is deliberately excluded: it returns an interior view
+  rather than a scalar. Verified on the emitted C (0 scope-exit frees before, 1
+  after) and through the macOS leak gate.
+
 ## [0.480.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -2695,7 +2695,23 @@ static int is_nonstoring_builtin(const char* fn) {
             * accumulator that is later joined has its whole loop
             * marked escaped, and every intermediate spine ref leaks. */
            strcmp(fn, "string_seq_join") == 0 ||
-           strcmp(fn, "string_join") == 0;
+           strcmp(fn, "string_join") == 0 ||
+           /* std.bytes readers that yield a scalar. They cannot retain the
+            * pointer they are given, and since #1380 they reject anything that
+            * is not an AetherBytes outright. Without these, a heap string
+            * passed to bytes.length/get had its scope-exit free suppressed and
+            * leaked unless the caller added an explicit release(). */
+           strcmp(fn, "aether_bytes_length") == 0 ||
+           strcmp(fn, "aether_bytes_capacity") == 0 ||
+           strcmp(fn, "aether_bytes_get") == 0 ||
+           strcmp(fn, "aether_bytes_get_le16") == 0 ||
+           strcmp(fn, "aether_bytes_get_le32") == 0 ||
+           strcmp(fn, "aether_bytes_get_le64") == 0 ||
+           strcmp(fn, "aether_bytes_get_be16") == 0 ||
+           strcmp(fn, "aether_bytes_get_be32") == 0 ||
+           strcmp(fn, "aether_bytes_get_be64") == 0 ||
+           /* Copies the source bytes into the buffer; retains neither. */
+           strcmp(fn, "aether_bytes_copy_from_string") == 0;
 }
 
 /* Does argument position `arg_idx` of `call` escape — i.e. might the

--- a/tests/regression/test_bytes_rejects_foreign_pointer.ae
+++ b/tests/regression/test_bytes_rejects_foreign_pointer.ae
@@ -51,9 +51,7 @@ main() {
 
     bytes.free(b)
     bytes.free(b2)
-    // `d` is passed to a `ptr` parameter, which marks it escaped, so the
-    // scope-exit tracker stops owning it. Release it explicitly.
-    release(d)
+
     _ = fs.file_delete_raw(path)
     println("=== All cases passed ===")
 }


### PR DESCRIPTION
Found while investigating the #1380 hang, not filed as an issue.

## The bug

Passing a heap string to a `std.bytes` reader leaked it:

```aether
d, n, e = fs.read_binary_tuple(path)
_ = bytes.length(d)      // marks `d` escaped
// `d` is never freed
```

`bytes.length` / `bytes.get` take their buffer as `ptr`, and a heap string
handed to a `ptr` parameter is treated as possibly-stored, so the compiler's
scope-exit free is suppressed. The caller leaked unless it added an explicit
`release()`, and nothing in the API signalled that. Verified on the emitted C:

```
BEFORE  scope-exit frees of d: 0
AFTER   scope-exit frees of d: 1
```

## The fix

`is_nonstoring_builtin` in `codegen_stmt.c` exists for exactly this, and its own
comment records the same bug being fixed once already, for `path`:

> *"which had falsely marked `path` escaped and leaked every interpolated argument"*

`std.bytes` was simply never added. Now listed: the scalar-returning readers
(`length`, `capacity`, `get`, `get_le16/32/64`, `get_be16/32/64`) plus
`copy_from_string`, which copies out and retains nothing. None can retain the
pointer they are handed, and since the #1380 guard they reject anything that is
not an `AetherBytes` outright.

`aether_bytes_data` is deliberately **not** listed: it returns an interior
pointer, a view rather than a scalar, and deserves its own analysis rather than
being swept in.

## A double-release this exposed in my own test

`test_bytes_rejects_foreign_pointer` (added with the #1380 fix) called
`release(d)` explicitly, because at the time the compiler had stopped owning
`d`. With ownership restored that call became a **double release**. glibc would
have caught it on Linux CI; macOS hides it, so it passed locally. Removed.

## Verification

- emitted C: 0 scope-exit frees before, 1 after
- the repro runs clean, no crash or double-free
- **macOS leak gate: all seven bytes regressions at 0 leaks**, including the test
  that no longer releases explicitly, which is what proves the compiler now owns
  and frees the string exactly once
- ASan suite was clean (229/229, zero AddressSanitizer errors) before this change

This is the class where functional tests are not evidence: every one of them
passed while the leak existed. The leak gate is the judge here.
