### PR TITLE
ci: fail when the release archive is missing a symbol its own sources define (#1395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **The release archive is checked against the sources it ships** (#1395).
+  0.467.0 shipped `std/worker/aether_worker.c` defining `aether_worker_wait`
+  next to a `libaether.a` built from an older tree that did not export it, so
+  `worker.wait()` and `worker.map()` failed to link. Nothing failed on our side;
+  it failed at the user's link step, and only for the function added last.
+  `make check-archive-exports` (run as part of the release-archive smoke test)
+  now fails when a symbol a std module declares `extern`, and a std C source
+  defines, is absent from the archive. Externs with no std definition are libc
+  or optional-dependency symbols and are skipped, which keeps it free of false
+  positives. Verified both directions: it passes on a freshly built archive and
+  flags six stale symbols on the installed 0.467.0-era one, including the
+  `aether_worker_wait` from the report.
+
+## [current]
+
 ### Fixed
 
 - **A heap string passed to a `std.bytes` reader no longer leaks.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ version number before tagging the release.
   positives. Verified both directions: it passes on a freshly built archive and
   flags six stale symbols on the installed 0.467.0-era one, including the
   `aether_worker_wait` from the report.
+- **The install smoke test reports why it failed.** `install.sh` ran with its
+  output sent to `/dev/null`, so a genuine break printed `[FAIL] Install smoke
+  test` and nothing else; diagnosing it meant reproducing locally. Its output is
+  now captured and the last 30 lines are printed when it fails.
 
 ## [current]
 

--- a/Makefile
+++ b/Makefile
@@ -964,7 +964,8 @@ test-install: compiler ae stdlib
 	@echo "==================================="
 	@tmpdir=$$(mktemp -d) && \
 	echo "  Installing to $$tmpdir..." && \
-	./install.sh "$$tmpdir" < /dev/null > /dev/null 2>&1 && \
+	{ ./install.sh "$$tmpdir" < /dev/null > "$$tmpdir/install.log" 2>&1 || \
+	  { echo "  install.sh failed:"; tail -30 "$$tmpdir/install.log" | sed 's/^/      /'; false; }; } && \
 	echo "  Testing ae version..." && \
 	AETHER_HOME="$$tmpdir" "$$tmpdir/bin/ae$(EXE_EXT)" version > /dev/null 2>&1 && \
 	echo "  Testing ae init + ae run..." && \

--- a/Makefile
+++ b/Makefile
@@ -984,7 +984,17 @@ test-install: compiler ae stdlib
 # extracts it (simulating `ae version install`), and verifies ae init + ae run
 # work from the extracted layout. This catches archive structure bugs that
 # test-install (which tests install.sh) would miss.
-test-release-archive: compiler ae stdlib
+# #1395: a release archive built from an older tree than the sources it ships
+# links fine for us and fails at the user's build, silently until someone calls
+# the one function added last. Verified here, next to the archive packaging.
+.PHONY: check-archive-exports
+check-archive-exports: stdlib
+	@echo "==================================="
+	@echo "  Archive Export Check"
+	@echo "==================================="
+	@sh scripts/check_archive_exports.sh build/libaether.a
+
+test-release-archive: compiler ae stdlib check-archive-exports
 	@echo "==================================="
 	@echo "  Release Archive Smoke Test"
 	@echo "==================================="

--- a/scripts/check_archive_exports.sh
+++ b/scripts/check_archive_exports.sh
@@ -26,9 +26,11 @@ declared="$(mktemp)"
 defined="$(mktemp)"
 trap 'rm -f "$exported" "$declared" "$defined"' EXIT
 
-# Exported text symbols, with the Mach-O leading underscore stripped.
+# Exported text symbols, verbatim. Mach-O prefixes an underscore and ELF does
+# not, so the lookup below accepts either spelling rather than stripping it
+# here, which would corrupt a symbol whose name legitimately starts with '_'.
 nm -g "$ARCHIVE" 2>/dev/null | awk '$2=="T"||$2=="D"||$2=="S"{print $3}' \
-    | sed 's/^_//' | sort -u > "$exported"
+    | sort -u > "$exported"
 
 # Names declared `extern` by a std module.
 grep -rhoE '^extern[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' \
@@ -44,7 +46,8 @@ missing=0
 while read -r name; do
     [ -n "$name" ] || continue
     grep -qx "$name" "$defined"  || continue   # not ours: libc / optional dep
-    grep -qx "$name" "$exported" && continue   # present, good
+    grep -qx "$name" "$exported" && continue   # ELF spelling
+    grep -qx "_$name" "$exported" && continue  # Mach-O spelling
     echo "  [FAIL] $name is declared extern by a std module and defined in a std"
     echo "         source, but $ARCHIVE does not export it (stale archive)."
     missing=$((missing + 1))

--- a/scripts/check_archive_exports.sh
+++ b/scripts/check_archive_exports.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Fails when libaether.a is missing a symbol the shipped std sources declare.
+#
+# The 0.467.0 release shipped std/worker/aether_worker.c defining
+# aether_worker_wait alongside an archive built from an older tree that did not
+# export it (#1395). Nothing failed until a user called the one function added
+# last, and then it failed at THEIR link step, not ours.
+#
+# For every `extern NAME(...)` in a std module.ae, if a std C source defines
+# NAME, the archive must export it. Externs with no std definition are libc or
+# optional-dependency symbols and are skipped, which is what keeps this free of
+# false positives.
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARCHIVE="${1:-$ROOT/build/libaether.a}"
+
+if [ ! -f "$ARCHIVE" ]; then
+    echo "  [SKIP] archive export check: $ARCHIVE not built"
+    exit 0
+fi
+
+exported="$(mktemp)"
+declared="$(mktemp)"
+defined="$(mktemp)"
+trap 'rm -f "$exported" "$declared" "$defined"' EXIT
+
+# Exported text symbols, with the Mach-O leading underscore stripped.
+nm -g "$ARCHIVE" 2>/dev/null | awk '$2=="T"||$2=="D"||$2=="S"{print $3}' \
+    | sed 's/^_//' | sort -u > "$exported"
+
+# Names declared `extern` by a std module.
+grep -rhoE '^extern[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' \
+    "$ROOT"/std/*/module.ae "$ROOT"/std/*/*/module.ae 2>/dev/null \
+    | awk '{print $2}' | sort -u > "$declared"
+
+# Names a std C source actually defines at file scope.
+grep -rhoE '^[A-Za-z_][A-Za-z0-9_ *]*[ *]([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\(' \
+    "$ROOT"/std/*/*.c "$ROOT"/std/*/*/*.c 2>/dev/null \
+    | sed -E 's/.*[ *]([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\($/\1/' | sort -u > "$defined"
+
+missing=0
+while read -r name; do
+    [ -n "$name" ] || continue
+    grep -qx "$name" "$defined"  || continue   # not ours: libc / optional dep
+    grep -qx "$name" "$exported" && continue   # present, good
+    echo "  [FAIL] $name is declared extern by a std module and defined in a std"
+    echo "         source, but $ARCHIVE does not export it (stale archive)."
+    missing=$((missing + 1))
+done < "$declared"
+
+if [ "$missing" -ne 0 ]; then
+    echo "  $missing symbol(s) missing. The archive does not match the shipped sources."
+    exit 1
+fi
+
+echo "  [PASS] archive exports every std-defined extern"


### PR DESCRIPTION
## What happened

0.467.0 shipped `std/worker/aether_worker.c` defining `aether_worker_wait` next
to a `libaether.a` built from an older tree that did not export it, so
`worker.wait()` and `worker.map()` failed to link.

Nothing failed on our side. It failed at the **user's** link step, and only for
the one function added last, which is exactly why it shipped.

## Current tree is fine; the gate is the fix

Verified before writing anything:

| | exports `aether_worker_wait` |
|---|---|
| `std/worker/aether_worker.c` (source) | defines it |
| freshly built `build/libaether.a` | **yes** |
| installed 0.467.0-era archive | **no** |

So the tree is correct and the archive was stale. Rebuilding it fixes today;
only a gate stops it recurring, which is what the issue asks for.

## The check

`scripts/check_archive_exports.sh` compares the archive against the sources
shipped beside it: for every `extern NAME(...)` a std `module.ae` declares, if a
std C source defines `NAME`, the archive must export it.

Externs with **no** std definition are libc or optional-dependency symbols and
are skipped. That is what keeps this free of false positives, and it is why the
check is symbol-presence via `nm` rather than compiling a program that calls
every extern: the latter needs valid arguments for hundreds of signatures and
would be far more fragile.

Wired into `test-release-archive`, next to the packaging it protects, so it runs
as part of `make ci` step 9.

## Verified both directions

A gate that only passes proves nothing, so:

- **passes** on a freshly built archive from this tree
- **fails** on the installed 0.467.0-era archive, reporting `aether_worker_wait`
  from the report **plus five more of the same class the report did not know
  about**: `fs_is_socket`, `os_user_id_raw`, `path_separator`, `string_join`,
  `string_seq_join`

```
[FAIL] aether_worker_wait is declared extern by a std module and defined in a std
       source, but .../libaether.a does not export it (stale archive).
...
6 symbol(s) missing. The archive does not match the shipped sources.
```

Closes #1395
