### PR TITLE
fix: a closure env owns the strings it captures, and gives them back (#1398)

### DIFF
--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -4383,9 +4383,14 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
      * (magic-less, e.g. from an @heap extern) still can't be retained
      * — rare in capture position; noted in the ask. */
     print_line(gen, "extern void string_retain(const char*);");
+    /* #1398: string_retain cannot take a reference to a magic-less pointer, so
+       a plain malloc'd heap string was captured borrowed and freed by the
+       enclosing scope while a stored closure still held it. The env now owns a
+       real reference and gives it back in its generated teardown. */
+    print_line(gen, "extern const char* aether_string_capture_owned(const char*);");
+    print_line(gen, "extern void aether_string_release_captured(const char*);");
     print_line(gen, "static inline const char* aether_str_capture(const char* s) {");
-    print_line(gen, "    if (s) string_retain(s);");
-    print_line(gen, "    return s;");
+    print_line(gen, "    return aether_string_capture_owned(s);");
     print_line(gen, "}");
     /* Prototypes for the magic-aware string builtins the codegen emits
      * directly (char_at -> string_char_at, str_eq / match-on-string ->

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -107,7 +107,22 @@ void emit_closure_env_drained_call(CodeGenerator* gen, ASTNode* call,
     fprintf(gen->output, "; ");
     arg_drain_bind(closure_node, nm);          /* now substitutes in the call */
     generate_expression(gen, call);
-    fprintf(gen->output, "; if (%s.env) free((void*)%s.env); }", nm, nm);
+    /* #1398: member-aware teardown, so the env gives back the references its
+       string captures own. Falls back to free() only when the closure is not
+       in the registry (no captures, hence nothing owned). */
+    int env_id = -1;
+    for (int ci = 0; ci < gen->closure_count; ci++) {
+        if (gen->closures[ci].closure_node == closure_node) {
+            env_id = gen->closures[ci].id;
+            break;
+        }
+    }
+    if (env_id >= 0) {
+        fprintf(gen->output, "; if (%s.env) _closure_env_%d_free((void*)%s.env); }",
+                nm, env_id, nm);
+    } else {
+        fprintf(gen->output, "; if (%s.env) free((void*)%s.env); }", nm, nm);
+    }
     arg_drain_truncate(saved);                 /* frees nm */
 }
 
@@ -1625,6 +1640,10 @@ static void emit_closure_env_typedef(CodeGenerator* gen, int ci) {
      * / parameter (no link symbol involved), so raw is both correct
      * and consistent. See new_string_len_something.md §3. */
     fprintf(gen->output, "typedef struct {\n");
+    /* #1398: first field by contract, so a runtime owner (list_free, the
+       worker pool) can release a captured env it has no type for. Must stay
+       first and must match _AeEnvHeader in the runtime. */
+    fprintf(gen->output, "    void (*_dtor)(void*);\n");
     if (cap_count == 0) {
         fprintf(gen->output, "    int _dummy;\n");
     } else {
@@ -1645,6 +1664,33 @@ static void emit_closure_env_typedef(CodeGenerator* gen, int ci) {
         }
     }
     fprintf(gen->output, "} _closure_env_%d;\n\n", id);
+
+    /* #1398: the env owns a reference per retained-string capture, so teardown
+       has to be member-aware. Promoted captures share a heap cell rather than
+       owning a reference and are skipped. */
+    fprintf(gen->output, "static void _closure_env_%d_free(void* _p) {\n", id);
+    fprintf(gen->output, "    if (!_p) return;\n");
+    {
+        int released = 0;
+        for (int i = 0; i < cap_count; i++) {
+            int is_promoted = 0;
+            for (int p2 = 0; p2 < parent_promoted_count; p2++) {
+                if (parent_promoted[p2] && strcmp(parent_promoted[p2], captures[i]) == 0) {
+                    is_promoted = 1;
+                    break;
+                }
+            }
+            if (is_promoted) continue;
+            if (!capture_is_retained_string(gen, captures[i], parent_func)) continue;
+            if (!released) {
+                fprintf(gen->output, "    _closure_env_%d* _e = (_closure_env_%d*)_p;\n", id, id);
+                released = 1;
+            }
+            fprintf(gen->output, "    aether_string_release_captured(_e->%s);\n", captures[i]);
+        }
+    }
+    fprintf(gen->output, "    free(_p);\n");
+    fprintf(gen->output, "}\n\n");
 }
 
 // Emit all hoisted closure environment structs and static functions.
@@ -1895,6 +1941,7 @@ void emit_closure_definitions(CodeGenerator* gen) {
             }
             fprintf(gen->output, ") {\n");
             fprintf(gen->output, "    _closure_env_%d* _e = malloc(sizeof(_closure_env_%d));\n", id, id);
+            fprintf(gen->output, "    _e->_dtor = _closure_env_%d_free;\n", id);
             for (int i = 0; i < cap_count; i++) {
                 if (capture_is_retained_string(gen, captures[i], parent_func)) {
                     /* env owns a reference — see aether_str_capture preamble */
@@ -5649,7 +5696,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
             } else {
                 // Heap-allocate the environment (portable, no use-after-free)
                 fprintf(gen->output, "\n#if AETHER_GCC_COMPAT\n");
-                fprintf(gen->output, "({ _closure_env_%d* _e = malloc(sizeof(_closure_env_%d)); ", id, id);
+                fprintf(gen->output, "({ _closure_env_%d* _e = malloc(sizeof(_closure_env_%d)); _e->_dtor = _closure_env_%d_free; ", id, id, id);
                 for (int i = 0; i < cap_count; i++) {
                     if (capture_is_retained_string(gen, captures[i], cl_parent_func)) {
                         /* env owns a reference — see aether_str_capture preamble */

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -5273,8 +5273,12 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                         if (is_first_assignment) {
                             for (int ci = 0; ci < gen->closure_count; ci++) {
                                 if (gen->closures[ci].id == cid && gen->closures[ci].capture_count > 0) {
-                                    // Create a synthetic defer: free(var.env)
-                                    ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, "free",
+                                    /* #1398: member-aware teardown so the env
+                                       releases what its captures own. */
+                                    char envfree[64];
+                                    snprintf(envfree, sizeof(envfree),
+                                             "_closure_env_%d_free", cid);
+                                    ASTNode* free_call = create_ast_node(AST_FUNCTION_CALL, envfree,
                                         stmt->line, stmt->column);
                                     char env_access[256];
                                     snprintf(env_access, sizeof(env_access), "%s.env", safe_c_name(stmt->value));

--- a/runtime/aether_runtime.h
+++ b/runtime/aether_runtime.h
@@ -39,6 +39,10 @@ void aether_args_init(int argc, char** argv);
 int aether_args_count(void);
 const char* aether_args_get(int index);
 
+// Reclaim a closure environment through the destructor stored in its first
+// field. Safe on NULL and on an env with no destructor. #1398
+void aether_closure_env_free(void* env);
+
 // Return argv[0] — the path the OS launched the current process with.
 // Borrowed pointer into the OS argv storage; do not free. Returns NULL
 // when aether_args_init has not been called.

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -206,6 +206,19 @@ int list_add_string_owned(ArrayList* list, const void* item) {
  * every target we build for. */
 typedef struct { void (*fn)(void); void* env; } AeClosureBox;
 
+/* #1398: a closure env's first field is a pointer to its generated destructor,
+ * which releases the references its string captures own. Lets an owner with no
+ * type for the env reclaim it correctly. Must match the `_dtor` field codegen
+ * emits first in every env struct. */
+typedef struct { void (*dtor)(void*); } _AeEnvHeader;
+
+void aether_closure_env_free(void* env) {
+    if (!env) return;
+    _AeEnvHeader* h = (_AeEnvHeader*)env;
+    if (h->dtor) { h->dtor(env); return; }
+    free(env);
+}
+
 /* Add a heap-allocated closure BOX the list owns (owned_flags == 2).
  * Unlike a string value, the box also owns its captured `env`, so
  * list_free frees env first, then the box. Routed from codegen when a
@@ -281,7 +294,9 @@ void list_free(ArrayList* list) {
                 /* Owned closure box: reclaim the captured env, then the
                  * box. env is NULL for a non-capturing closure (no-op). */
                 void* env = ((AeClosureBox*)it)->env;
-                if (env) free(env);
+                /* #1398: through the env's own destructor, so the references
+                 * its string captures own are released, not just the struct. */
+                if (env) aether_closure_env_free(env);
                 free(it);
             } else if (is_aether_string(it)) {
                 string_release(it);

--- a/std/fs/aether_fs.c
+++ b/std/fs/aether_fs.c
@@ -3009,10 +3009,14 @@ char* path_rel(const char* base, const char* target) {
  * is malloc'd by _aether_box_closure and OWNED by the callee. */
 typedef struct { void (*fn)(void); void* env; } AeFsClosure;
 
+extern void aether_closure_env_free(void* env);
+
 static void fs_closure_free(void* box) {
     if (!box) return;
     AeFsClosure* clo = (AeFsClosure*)box;
-    if (clo->env) free(clo->env);
+    /* #1398: through the env's own destructor, so the references its string
+     * captures own are released, not just the struct. */
+    if (clo->env) aether_closure_env_free(clo->env);
     free(box);
 }
 

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -760,6 +760,24 @@ size_t aether_string_length(const void* s) {
     return str_len(s);
 }
 
+/* #1398: a closure env must OWN each string it captures. string_retain is a
+ * no-op on a magic-less pointer, so a plain malloc'd `-> string` was captured
+ * borrowed and freed by the enclosing scope while a stored closure still held
+ * it. Retains an AetherString in place; promotes anything else to a refcounted
+ * copy. Balanced by aether_string_release_captured at env teardown. */
+const char* aether_string_capture_owned(const char* s) {
+    if (!s) return s;
+    if (is_aether_string(s)) {
+        string_retain(s);
+        return s;
+    }
+    return (const char*)string_new(s);
+}
+
+void aether_string_release_captured(const char* s) {
+    if (s) string_release(s);
+}
+
 AetherString* string_from_int(int value) {
     char buffer[32];
     snprintf(buffer, sizeof(buffer), "%d", value);

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -182,6 +182,11 @@ const char* string_to_cstr(const void* str);
 const char* aether_string_data(const void* s);
 size_t      aether_string_length(const void* s);
 
+// Closure-capture ownership (#1398). capture_owned returns a pointer the
+// caller owns a reference to; release_captured gives it back.
+const char* aether_string_capture_owned(const char* s);
+void        aether_string_release_captured(const char* s);
+
 AetherString* string_from_int(int value);
 // 64-bit sibling of string_from_int. Uses `long long` so it covers
 // Aether's `long` type across platforms where `long` is 32-bit (MSVC).

--- a/std/worker/aether_worker.c
+++ b/std/worker/aether_worker.c
@@ -160,19 +160,21 @@ static WorkerJob* ready_pop(void) {
 
 /* ---- job execution ----------------------------------------------------- */
 
-/* Reclaim a job's per-job closure environments. The env is a plain malloc
- * block the compiler heap-allocated for the closure's captures; because we
- * received the closures through an extern boundary, codegen does NOT free them
- * (the env-drain is suppressed — closure_extern_retains_no_uaf), so ownership
- * is ours once the closures have fired. Freeing here keeps a long-lived app
- * (thousands of worker.run calls) from leaking an env per job. NOTE: if a
- * capture is a retained AetherString, its refcount is not released by this
- * plain free (the retain-on-capture ref is never released by design) — that
- * residual is the language's existing bounded per-closure behaviour, not new.
+/* Reclaim a job's per-job closure environments. The env is heap-allocated by
+ * the compiler for the closure's captures; because we received the closures
+ * through an extern boundary, codegen does NOT free them (the env-drain is
+ * suppressed, closure_extern_retains_no_uaf), so ownership is ours once the
+ * closures have fired.
+ *
+ * Goes through the env's own destructor (#1398), so the references its string
+ * captures own are released too. A plain free reclaimed the struct and leaked
+ * every captured string, which is what `worker.run` capturing a path did.
  * The poster env is host-owned (installed once) and is never touched here. */
+extern void aether_closure_env_free(void* env);
+
 static void free_job_envs(WorkerJob* job) {
-    if (job->work.env) free(job->work.env);
-    if (job->done.env) free(job->done.env);
+    if (job->work.env) aether_closure_env_free(job->work.env);
+    if (job->done.env) aether_closure_env_free(job->done.env);
 }
 
 /* Run the work closure, then route the completion. Called on a worker thread


### PR DESCRIPTION
## Root cause

`aether_str_capture` called `string_retain`, which is a **documented no-op on a
magic-less pointer**. A plain malloc'd `-> string` was therefore captured
**borrowed**, and the enclosing scope's loop-carried reassignment and scope-exit
free really freed it while a stored closure still held the pointer.

The capture preamble already recorded this as a known residual:

> *"a PLAIN-malloc heap string (magic-less, e.g. from an @heap extern) still
> can't be retained — rare in capture position; noted in the ask"*

That also explains every shape the report **could not reduce**: a literal is
static, `string.concat` returns a real `AetherString` so retain works, and
`args_get` returns an `argv` pointer correctly classified non-heap. Only the
magic-less heap case dangles.

## Taking a reference is only half of it

An owned reference never returned is a leak, and the previous design accepted
exactly that trade ("the env's reference is intentionally never released ... a
bounded leak per closure creation"). Measured, not assumed: promotion **alone**
turned three closure tests from 0 leaks into 2, 6 and 2.

## So the env owns and releases

- `aether_string_capture_owned` retains an `AetherString` in place and promotes
  anything else to a refcounted copy; `aether_string_release_captured` balances it.
- **Every env struct carries `void (*_dtor)(void*)` as its FIRST field**, set at
  both construction sites, so an owner holding only a `void*` can reclaim an env
  it has no type for.
- Codegen emits a per-closure `_closure_env_N_free` that releases each owned
  string capture then frees the struct. Promoted captures share a heap cell
  rather than owning a reference, and are skipped.
- **All four owners** now go through it: the scope-exit defer, the argument
  drain, `list_free`'s owned-closure-box path, and `fs_closure_free`.

The env header is what made the **escaping** case solvable. A closure stored in
a list outlives its scope, so no codegen-emitted teardown can run; `list_free`
owns it but has only a `void*`. With the destructor inside the env, each owner
needed one line rather than a redesign.

## Verification

macOS leak gate: **0 failures**. Every closure test at 0 leaks, including the
two escaping cases that regressed at the halfway point:

| test | before fix | promotion only | final |
|---|---|---|---|
| `test_closure_captured_libc_name` | 0 | 6 | **0** |
| `test_closure_captures_ptr_and_string` | 0 | 2 | **0** |
| `test_closure_capture_stored_in_list` | 0 | 2 | **0** |
| `test_fs_walk` | 0 | 2 | **0** |

Closes #1398
