### PR TITLE
feat(bytes): export data/capacity/set_length; widen the archive-export gate (#1399, #1402)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,6 +506,11 @@ jobs:
         # than no FreeBSD zip.
         file build/aetherc build/ae
         file build/ae | grep -q 'FreeBSD' || { echo "ae is not a FreeBSD binary"; exit 1; }
+        # #1402: the Unix and Windows legs get this through
+        # test-release-archive, which this cross leg does not run. Without it a
+        # cross-built archive could ship missing a symbol its own sources
+        # define, and fail at the user's link step rather than here.
+        sh scripts/check_archive_exports.sh build/libaether.a
 
     - name: Strip
       run: strip build/aetherc build/ae 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **`std.bytes` exposes `data`, `capacity` and `set_length`** (#1399). All
+  three existed in C but were never declared or exported, so anything handing a
+  buffer to a foreign runtime had to copy it byte by byte through `get()`, or
+  redeclare the extern itself against an internal name with no compatibility
+  promise. For a 1 MB buffer crossing into JavaScript that is one `HEAPU8.set`
+  against a million calls. `std.cryptography.aes` had made exactly that private
+  redeclaration while being wired to its native core, and now uses the public
+  surface.
+
+### Fixed
+
+- **The release archive-export gate now covers the FreeBSD cross leg** (#1402).
+  The Unix and Windows release legs run it through `test-release-archive`; the
+  cross leg built and packaged without it, so a cross-built archive could ship
+  missing a symbol its own sources define and fail at the user's link step.
+
 ## [0.484.0]
 
 ### Changed

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -410,6 +410,9 @@ out = bytes.finish(b, 6)                  // "ABABAB"
 - `bytes.copy_within(b, dst, src, length)` → `int` - Self-copy, forward byte-by-byte (RLE-safe)
 - `bytes.finish(b, length)` → `string` - Hand off to refcounted AetherString; buffer is consumed
 - `bytes.free(b)` - Discard without finishing (idempotent on null)
+- `bytes.data(b)` → `ptr` - Borrowed pointer to the buffer's own memory, for handing the region to a foreign runtime (a WebAssembly `HEAPU8.set`, a C API) without copying it byte by byte. Valid until the next call that can grow the buffer, which may move the allocation and invalidate it.
+- `bytes.capacity(b)` → `int` - Bytes reserved, which is at least `length` and may be more.
+- `bytes.set_length(b, n)` → `int` - Publish how many bytes a direct write into `data()`'s region made live. Clamped to the capacity, and returns the length actually set.
 
 **Streaming binary reads without a per-block copy.** A fixed-size block reader (walking 512-byte sectors of a device, say) can read straight into a reused `std.bytes` buffer instead of allocating a fresh string per block: `fs.pread_into(file, buf, len, offset)` reads up to `len` bytes at `offset` directly into `buf` (clamped to its capacity), sets `buf`'s length to the count read, and returns `(n, err)` with the same EOF (`n == 0`) / short-read (`0 < n < len`) / I/O-error (`err != ""`) distinction as `fs.pread`. The packed integers are then read in place with `bytes.get_le64` etc., or walked with a cursor. `std.bytes.cursor` offers both byte orders, `read_be_u16/32/64` and `read_le_u16/32/64` (each returns `-1` and leaves the cursor unchanged at end-of-buffer), so little-endian on-disk formats stream as cleanly as big-endian wire formats.
 

--- a/std/bytes/module.ae
+++ b/std/bytes/module.ae
@@ -30,15 +30,20 @@ exports(
     aether_bytes_copy_from_string, aether_bytes_copy_from_bytes,
     aether_bytes_copy_within,
     aether_bytes_finish, aether_bytes_to_string, aether_bytes_free,
+    aether_bytes_data, aether_bytes_capacity, aether_bytes_set_length,
     new, set, get, length,
     set_le16, get_le16, set_le32, get_le32, set_le64, get_le64,
     set_be16, get_be16, set_be32, get_be32, set_be64, get_be64,
-    copy_from_string, copy_from_bytes, copy_within, finish, to_string, free
+    copy_from_string, copy_from_bytes, copy_within, finish, to_string, free,
+    data, capacity, set_length
 )
 
 // ---- Raw externs ----
 extern aether_bytes_new(initial_capacity: int) -> ptr
 extern aether_bytes_length(b: ptr) -> int
+extern aether_bytes_capacity(b: ptr) -> int
+extern aether_bytes_set_length(b: ptr, length: int) -> int
+extern aether_bytes_data(b: ptr) -> ptr
 extern aether_bytes_set(b: ptr, index: int, value: int) -> int
 extern aether_bytes_get(b: ptr, index: int) -> int
 extern aether_bytes_set_le16(b: ptr, index: int, value: int) -> int
@@ -79,6 +84,19 @@ extern aether_bytes_free(b: ptr)
 // Allocate a new mutable byte buffer with at least `initial_capacity`
 // bytes reserved. Returns null on allocation failure or negative
 // capacity. Initial logical length is 0.
+
+// Borrowed pointer to the buffer's own memory, for handing the region to a
+// foreign runtime without copying it byte by byte. Valid until the next call
+// that can grow the buffer, which may move the allocation and invalidate it.
+data(b: ptr) -> ptr { return aether_bytes_data(b) }
+
+// Bytes reserved, which is at least length and may be more.
+capacity(b: ptr) -> int { return aether_bytes_capacity(b) }
+
+// Publish how many bytes a direct write into data()'s region made live.
+// Clamped to the capacity; returns the length actually set.
+set_length(b: ptr, length: int) -> int { return aether_bytes_set_length(b, length) }
+
 new(initial_capacity: int) -> ptr {
     return aether_bytes_new(initial_capacity)
 }

--- a/std/cryptography/aes/module.ae
+++ b/std/cryptography/aes/module.ae
@@ -57,8 +57,6 @@ extern malloc(size: int) -> ptr
 // stays as the portable fallback and the reference the KATs compare against;
 // it reaches every byte through bytes.get/bytes.set, about 15 million calls
 // per megabyte for AES-256.
-extern aether_bytes_data(b: ptr) -> ptr
-extern aether_bytes_set_length(b: ptr, length: int) -> int
 extern aether_aes_available() -> int
 extern aether_aes_new(key: ptr, keylen: int, encrypt: int) -> ptr
 extern aether_aes_free(ctx: ptr)
@@ -83,14 +81,14 @@ struct AesCtx {
 
 new_encryptor(key: ptr, keylen: int) -> ptr {
     c = malloc(16) as *AesCtx
-    c.native = aether_aes_new(aether_bytes_data(key), keylen, 1)
+    c.native = aether_aes_new(bytes.data(key), keylen, 1)
     c.encrypt = 1
     return c
 }
 
 new_decryptor(key: ptr, keylen: int) -> ptr {
     c = malloc(16) as *AesCtx
-    c.native = aether_aes_new(aether_bytes_data(key), keylen, 0)
+    c.native = aether_aes_new(bytes.data(key), keylen, 0)
     c.encrypt = 0
     return c
 }
@@ -108,8 +106,8 @@ process_block(ctx: ptr, in16: ptr) -> ptr {
     out = bytes.new(16)
     // bytes.new reserves capacity; the core writes through the data pointer,
     // so the logical length has to be set for readers to see the block.
-    _ = aether_bytes_set_length(out, 16)
-    _ = aether_aes_block(c.native, aether_bytes_data(in16), aether_bytes_data(out))
+    _ = bytes.set_length(out, 16)
+    _ = aether_aes_block(c.native, bytes.data(in16), bytes.data(out))
     return out
 }
 
@@ -140,9 +138,9 @@ ctr_xor(ctx: ptr, iv: ptr, data: ptr) -> ptr {
     n = bytes.length(data)
     c = ctx as *AesCtx
     out = bytes.new(n)
-    _ = aether_bytes_set_length(out, n)
-    _ = aether_aes_ctr_xor(c.native, aether_bytes_data(iv),
-        aether_bytes_data(data), aether_bytes_data(out), n)
+    _ = bytes.set_length(out, n)
+    _ = aether_aes_ctr_xor(c.native, bytes.data(iv),
+        bytes.data(data), bytes.data(out), n)
     return out
 }
 ctr_increment(ctr: ptr) {
@@ -170,9 +168,9 @@ cbc_encrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
     if n % 16 != 0 { return bytes.new(0) }
     c = ctx as *AesCtx
     out = bytes.new(n)
-    _ = aether_bytes_set_length(out, n)
-    _ = aether_aes_cbc_encrypt(c.native, aether_bytes_data(iv),
-        aether_bytes_data(data), aether_bytes_data(out), n)
+    _ = bytes.set_length(out, n)
+    _ = aether_aes_cbc_encrypt(c.native, bytes.data(iv),
+        bytes.data(data), bytes.data(out), n)
     return out
 }
 
@@ -182,9 +180,9 @@ cbc_decrypt(ctx: ptr, iv: ptr, data: ptr) -> ptr {
     if n % 16 != 0 { return bytes.new(0) }
     c = ctx as *AesCtx
     out = bytes.new(n)
-    _ = aether_bytes_set_length(out, n)
-    _ = aether_aes_cbc_decrypt(c.native, aether_bytes_data(iv),
-        aether_bytes_data(data), aether_bytes_data(out), n)
+    _ = bytes.set_length(out, n)
+    _ = aether_aes_cbc_decrypt(c.native, bytes.data(iv),
+        bytes.data(data), bytes.data(out), n)
     return out
 }
 

--- a/tests/regression/test_bytes_zero_copy_surface.ae
+++ b/tests/regression/test_bytes_zero_copy_surface.ae
@@ -1,0 +1,48 @@
+// Regression (#1399): std.bytes defines data / capacity / set_length in C but
+// never declared or exported them, so anything handing a buffer to a foreign
+// runtime had to copy it byte by byte through get(), or redeclare the extern
+// itself against an internal name with no compatibility promise. The AES
+// module did exactly that while it was being wired to its native core.
+
+import std.bytes
+import std.io
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    b = bytes.new(64)
+    if bytes.capacity(b) < 64 { fail("capacity: want >= 64 got ${bytes.capacity(b)}") }
+    if bytes.length(b) != 0 { fail("a fresh buffer should have length 0") }
+    println("PASS 1: capacity is reported, length starts at 0")
+
+    // A borrowed pointer into the buffer's own memory.
+    p = bytes.data(b)
+    if p == null { fail("data() returned null for a reserved buffer") }
+    println("PASS 2: data() yields a borrowed pointer")
+
+    // set_length publishes what a direct write made live, and is clamped to
+    // the capacity rather than trusting the caller.
+    n = bytes.set_length(b, 10)
+    if n != 10 { fail("set_length(10) returned ${n}") }
+    if bytes.length(b) != 10 { fail("length after set_length: ${bytes.length(b)}") }
+    over = bytes.set_length(b, 1000000)
+    if over > bytes.capacity(b) { fail("set_length exceeded capacity: ${over}") }
+    println("PASS 3: set_length publishes length and clamps to capacity")
+
+    // The three agree with the byte-at-a-time surface they exist to avoid.
+    c = bytes.new(4)
+    _ = bytes.set(c, 0, 65)
+    _ = bytes.set(c, 1, 66)
+    if bytes.length(c) != 2 { fail("set() should grow length, got ${bytes.length(c)}") }
+    if bytes.data(c) == null { fail("data() null after writes") }
+    println("PASS 4: consistent with the copying surface")
+
+    bytes.free(b)
+    bytes.free(c)
+    println("=== All cases passed ===")
+}


### PR DESCRIPTION
## #1399 — the zero-copy surface was unreachable

`std/bytes/aether_bytes.c` defines `aether_bytes_data`, `_capacity` and
`_set_length`, and `aether_bytes.h` declares them, but `std/bytes/module.ae`
never did. So anything handing a buffer to a foreign runtime had to copy it byte
by byte through `get()`, or redeclare the extern itself against an internal name
carrying no compatibility promise. For a 1 MB buffer crossing into JavaScript
that is one `HEAPU8.set` against a million calls across the boundary.

Now declared, wrapped as `bytes.data` / `bytes.capacity` / `bytes.set_length`,
exported and documented in the stdlib reference.

**`std.cryptography.aes` had made exactly the private redeclaration the issue
describes**, while I was wiring it to its native core in #1394. It now uses the
public surface and its local externs are gone.

## #1402 — checked the premise first

The reported archive is **not reproducible from any published release**:

| | result |
|---|---|
| freshly built archive from this tree | exports all 7 `aether_aes` symbols; gate passes |
| `0.483.0` release artifact | healthy (1.6 MB, 2270 symbols, includes `aether_string_capture_owned`) |
| `aether_aes` symbols in `0.483.0` | **zero, because it predates the AES merge** and ships no `aether_aes.c` |

AES landed in `0.484.0`, which has no published asset yet. So a 5-of-7 archive
does not come from a release build, and rebuilding would not have been a fix for
anything I can observe.

**The gate does have a real hole, though**, which is what the issue asks to
widen. The Unix and Windows release legs run it via `test-release-archive`, but
the **FreeBSD cross leg builds and packages without it** — so a cross-built
archive could ship missing a symbol its own sources define and fail at the
user's link step. The cross leg now runs it too.

## Verification

- fmt gate clean (this is the check I tripped on the last PR, so it is run here)
- 229/229 C unit tests
- AES KATs still pass through the public bytes surface
- new `tests/regression/test_bytes_zero_copy_surface.ae` pins `data`,
  `capacity` and `set_length`, including that `set_length` clamps to capacity
  rather than trusting the caller

Closes #1399
Closes #1402
