### PR TITLE
fix: cross-compile from an install, stale cache, tuple returns, seq literal leak (#1417, #1420, #1421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **Cross-compiling failed for every target from an installed toolchain**
+  (#1420). `runtime/libaether_caps.c` included the public header as
+  `../include/libaether.h`, a path that only exists in the source tree: an
+  install puts the runtime at `share/aether/runtime/` and headers under
+  `include/aether/`, so the hop resolved to a directory that does not exist.
+  Worse, `include/libaether.h` was never installed at all, because both
+  installers walk only the `runtime/` and `std/` trees for headers. Native
+  builds never noticed, since they pass the include set from `ae cflags` and
+  never rely on the relative path, which is how this shipped. The header is now
+  installed by both paths and included by name, and the directory holding it is
+  on the include path in both layouts. Verified end to end from a real install:
+  `x86_64-linux` and `aarch64-linux` both produce working ELF binaries.
+
+- **`ae build` served a stale binary after an imported module changed**
+  (#1421). The cache key covered the entry file's content and the lib dirs, but
+  not the project's own sibling modules: `import helper` next to `src/main.ae`
+  resolves to `src/helper.ae`, which is in no lib dir. Editing it left the key
+  unchanged, so the build reported `Built (cache hit)` and ran code from the
+  previous version, and deleting `target/` did not help because the cache lives
+  under `~/.aether/cache`. The key now covers the entry file's whole directory
+  tree, content-hashed with the same caps the lib-dir walk uses. Unchanged
+  rebuilds still hit the cache.
+
+- **`return (a, b)` compiled to garbage instead of returning a tuple** (#1421).
+  `(a, b)` is a tuple literal, so the parenthesised spelling reached codegen as
+  one return value where the bare `return a, b` gives two, and the literal was
+  flattened into the return slot. The C compiler then failed on identifiers
+  invented from the flattened text (`NULL0` from `return (null, 0)`, `bufw` from
+  `return (w.buf, w.off)`), with nothing pointing at the parentheses. Both
+  spellings now produce the same AST, so they cannot disagree.
+
+- **Multi-element `*StringSeq` literals leaked their inner cons cells**
+  (#1417). `string_seq_cons` takes its own retain on the tail, so a builder must
+  drop each intermediate handle. As a nested expression the intermediates were
+  anonymous temporaries nothing ever dropped, leaving every cell but the head at
+  refcount 2; a correct `string_seq_free(head)` then stopped at the first cell
+  that stayed above zero and the rest leaked, 24 bytes per element past the
+  first. The literal now folds into a local, dropping each handle once the next
+  cell has retained it, with elements still evaluated in source order.
+
+- **Cross-compiling failed with a longer-than-usual install prefix.** The
+  command line is dominated by the include set, which scales with the prefix
+  length and the module count, and it was assembled in a fixed 24576-byte
+  buffer: past that, `ae` reported `cross-compile command exceeded the
+  24576-byte buffer` with nothing the user could shorten. The command and object
+  list now grow on demand, the same shape the include set itself already used.
+  Found while reproducing #1420 from an install under a long path.
+
 ## [0.490.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,15 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 # (vcr_embed_abi_wish.md Part A). Negligible codegen cost on x86-64/arm64
 # (most distros already default to PIE); one archive serves both the exe
 # link and the shared-object link.
-CFLAGS = -O2 -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(EXTRA_CFLAGS)
+CFLAGS = -O2 -fPIC -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(EXTRA_CFLAGS)
+
+# include/ holds the public embedder header (libaether.h) that
+# runtime/libaether_caps.c includes by name. `override` so a wholesale CFLAGS
+# override cannot drop it: CI passes CFLAGS="-O0 -g" and the sanitizer flags on
+# the valgrind, ASan and memory-profiling legs, which replaces the assignment
+# above and every -I in it. Unconditional and not inside any ifeq, because
+# without this path that translation unit does not compile at all.
+override CFLAGS += -Iinclude
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
 # passwd / sysctl past Capsicum capability mode. libcasper + the
 # per-service libs ship in the FreeBSD base system. We resolve them by

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 # (vcr_embed_abi_wish.md Part A). Negligible codegen cost on x86-64/arm64
 # (most distros already default to PIE); one archive serves both the exe
 # link and the shared-object link.
-CFLAGS = -O2 -fPIC -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(EXTRA_CFLAGS)
+CFLAGS = -O2 -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
 # passwd / sysctl past Capsicum capability mode. libcasper + the
 # per-service libs ship in the FreeBSD base system. We resolve them by
@@ -1018,6 +1018,7 @@ test-release-archive: compiler ae stdlib check-archive-exports
 	    cp "$$dir"/*.h "$$reldir/include/aether/$$dir/" 2>/dev/null || true; \
 	  fi; \
 	done && \
+	cp include/*.h "$$reldir/include/aether/" 2>/dev/null; \
 	cp -r runtime "$$reldir/share/aether/" && \
 	cp -r std     "$$reldir/share/aether/" && \
 	rm -rf "$$reldir/share/aether/runtime/examples" && \
@@ -1645,6 +1646,10 @@ install: $(VERSION_HEADER) release ae stdlib
 	@# (or a human) can read it with no compiler in the loop to detect a
 	@# partial / shadowed install (the stale ~/.local/include/aether case).
 	@printf '%s\n' "$(VERSION)" > $(PREFIX)/include/aether/VERSION
+	@# The public embedder header lives in include/, outside the runtime/ and
+	@# std/ trees the walks below cover, so it was never installed at all and
+	@# runtime/libaether_caps.c could not find it in an install (#1420).
+	@install -m 644 include/*.h $(PREFIX)/include/aether/ 2>/dev/null || true
 	@cd runtime && find . -name '*.h' -print | while read h; do \
 		install -d "$(PREFIX)/include/aether/runtime/$$(dirname $$h)"; \
 		install -m 644 "$$h" "$(PREFIX)/include/aether/runtime/$$h"; \

--- a/Makefile
+++ b/Makefile
@@ -396,15 +396,31 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 # (vcr_embed_abi_wish.md Part A). Negligible codegen cost on x86-64/arm64
 # (most distros already default to PIE); one archive serves both the exe
 # link and the shared-object link.
-CFLAGS = -O2 -fPIC -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(EXTRA_CFLAGS)
+# Two kinds of flag, kept apart on purpose.
+#
+# AETHER_REQUIRED_CFLAGS is structural: the include paths, dependency
+# generation, and the defines that select which code is compiled in. The build
+# is not merely slower without them, it is a different build.
+#
+# CFLAGS is the tunable half: optimisation, debug info, warnings, sanitizers.
+# Callers replace it wholesale and are right to, e.g.
+#
+#     make test-build CFLAGS="-O0 -g"                       (valgrind leg)
+#     make compiler   CFLAGS="-fsanitize=address ... -O1 -g" (ASan leg)
+#
+# They were previously one variable, so those commands did far more than they
+# said: every -I disappeared, and with them -DAETHER_HAS_SANDBOX, which gates
+# real code in runtime/aether_sandbox.c. The sanitizer and valgrind legs were
+# therefore testing a configuration that never ships. It stayed invisible
+# because the remaining includes all resolved same-directory or relatively,
+# until a header outside those trees (include/libaether.h, #1420) finally made
+# it fail out loud.
+#
+# Recipes use `$(AETHER_REQUIRED_CFLAGS) $(CFLAGS)` so tuning one cannot
+# silently delete the other.
+AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS)
 
-# include/ holds the public embedder header (libaether.h) that
-# runtime/libaether_caps.c includes by name. `override` so a wholesale CFLAGS
-# override cannot drop it: CI passes CFLAGS="-O0 -g" and the sanitizer flags on
-# the valgrind, ASan and memory-profiling legs, which replaces the assignment
-# above and every -I in it. Unconditional and not inside any ifeq, because
-# without this path that translation unit does not compile at all.
-override CFLAGS += -Iinclude
+CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
 # passwd / sysctl past Capsicum capability mode. libcasper + the
 # per-service libs ship in the FreeBSD base system. We resolve them by
@@ -434,13 +450,24 @@ else ifeq ($(shell uname -s),Darwin)
   AUDIO_LDFLAGS := -framework CoreFoundation -framework CoreAudio -framework AudioToolbox
 endif
 
+# The link-side half of the AETHER_REQUIRED_CFLAGS split above, and it has to
+# stay in lockstep with it: feature detection decides BOTH the -I/-D for a
+# dependency and the -l that resolves the symbols that then get emitted. Split
+# only the compile side and an `LDFLAGS="..."` override compiles OpenSSL in and
+# links it out, so the build fails on undefined SSL symbols. Neither half is
+# tunable on its own.
 ifeq ($(FREEBSD),1)
 # Cross build: the explicit base-libc link tail replaces the native assembly
 # (which would pull the host's -lm / -pthread / globbed host casper libs).
-LDFLAGS = $(FREEBSD_LDFLAGS)
+AETHER_REQUIRED_LDFLAGS = $(FREEBSD_LDFLAGS)
 else
-LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS)
+AETHER_REQUIRED_LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS)
 endif
+
+# Tunable link flags: sanitizers and anything else a caller passes. Empty by
+# default, so `make ... LDFLAGS="-fsanitize=address"` adds to the required set
+# rather than replacing it.
+LDFLAGS =
 
 # Hardening flags (issue #396). Opt-in via `HARDEN=1`. The CI matrix
 # pins a Linux/gcc + HARDEN=1 entry so a hardened-build regression
@@ -474,7 +501,7 @@ ifneq ($(FREEBSD),1)
 ifneq ($(PLATFORM),wasm)
 ifneq ($(PLATFORM),embedded)
 ifeq ($(findstring AETHER_NO_THREADING,$(EXTRA_CFLAGS)),)
-LDFLAGS += -pthread
+AETHER_REQUIRED_LDFLAGS += -pthread
 endif
 endif
 endif
@@ -491,13 +518,13 @@ OBJ_DIR = $(BUILD_DIR)/obj
 # and std.cryptography work in Windows release binaries.
 WIN_LINK_LIBS = -static -lws2_32 -lcrypt32 -lgdi32 -luser32 -ladvapi32 -lbcrypt -ldbghelp
 ifdef WINDOWS_NATIVE
-    LDFLAGS += $(WIN_LINK_LIBS)
+    AETHER_REQUIRED_LDFLAGS += $(WIN_LINK_LIBS)
 else ifneq ($(findstring MINGW,$(DETECTED_OS)),)
-    LDFLAGS += $(WIN_LINK_LIBS)
+    AETHER_REQUIRED_LDFLAGS += $(WIN_LINK_LIBS)
 else ifneq ($(findstring MSYS,$(DETECTED_OS)),)
-    LDFLAGS += $(WIN_LINK_LIBS)
+    AETHER_REQUIRED_LDFLAGS += $(WIN_LINK_LIBS)
 else ifneq ($(findstring CYGWIN,$(DETECTED_OS)),)
-    LDFLAGS += $(WIN_LINK_LIBS)
+    AETHER_REQUIRED_LDFLAGS += $(WIN_LINK_LIBS)
 endif
 
 COMPILER_SRC = compiler/aetherc.c compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/contract_eval.c compiler/analysis/derive.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
@@ -596,7 +623,7 @@ endif
 # Pattern rule for object files
 $(OBJ_DIR)/%.o: %.c | $(STDLIB_SYMS_HEADER) $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
 	@echo "Compiling $<..."
-	@$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) -c $< -o $@
 
 # Upstream liblzf (vendored verbatim under std/lzf/) has a few style
 # choices the modern -Werror set flags:
@@ -681,7 +708,7 @@ audio-cache-save: $(AUDIO_OBJ)
 # Compiler target (incremental build with object files)
 compiler: $(COMPILER_OBJS) $(STD_OBJS) $(COLLECTIONS_OBJS) $(OBJ_DIR)/runtime/aether_sandbox.o $(OBJ_DIR)/runtime/aether_resource_caps.o $(IO_POLLER_OBJS) | $(VERSION_HEADER) $(STDLIB_SYMS_HEADER)
 	@echo "Linking compiler..."
-	@$(CC) $(COMPILER_OBJS) $(STD_OBJS) $(COLLECTIONS_OBJS) $(OBJ_DIR)/runtime/aether_sandbox.o $(OBJ_DIR)/runtime/aether_resource_caps.o $(IO_POLLER_OBJS) -o build/aetherc$(EXE_EXT) $(LDFLAGS)
+	@$(CC) $(COMPILER_OBJS) $(STD_OBJS) $(COLLECTIONS_OBJS) $(OBJ_DIR)/runtime/aether_sandbox.o $(OBJ_DIR)/runtime/aether_resource_caps.o $(IO_POLLER_OBJS) -o build/aetherc$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Compiler built successfully"
 
 # Fast compiler target (monolithic, for clean builds)
@@ -691,14 +718,14 @@ ifdef WINDOWS_NATIVE
 else
 	@$(MKDIR) build
 endif
-	$(CC) $(CFLAGS) $(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) $(IO_POLLER_SRC) runtime/aether_resource_caps.c -o build/aetherc$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) $(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) $(IO_POLLER_SRC) runtime/aether_resource_caps.c -o build/aetherc$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 
 test: $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS)
 	@echo "==================================="
 	@echo "Building Test Suite ($(DETECTED_OS))"
 	@echo "==================================="
 	@echo "Linking test runner..."
-	@$(CC) $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS) -o build/test_runner$(EXE_EXT) $(LDFLAGS)
+	@$(CC) $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS) -o build/test_runner$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo ""
 	@echo "==================================="
 	@echo "Running Tests"
@@ -716,7 +743,7 @@ test-fast: compiler-fast
 	@echo "==================================="
 	@echo "Building Test Suite ($(DETECTED_OS))"
 	@echo "==================================="
-	$(CC) $(CFLAGS) $(TEST_SRC) $(COMPILER_LIB_SRC) $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -Icompiler -Istd -Istd/collections -o build/test_runner$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) $(TEST_SRC) $(COMPILER_LIB_SRC) $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -Icompiler -Istd -Istd/collections -o build/test_runner$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo ""
 	@echo "==================================="
 	@echo "Running Tests"
@@ -734,7 +761,7 @@ test-valgrind: compiler stdlib-dbg
 	@echo "==================================="
 	@echo "Running Tests with Valgrind"
 	@echo "==================================="
-	$(CC) $(CFLAGS_NO_OPT) $(DBG_OPT) $(TEST_SRC) build/dbg/libaether_compiler.a build/dbg/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(DBG_OPT) $(TEST_SRC) build/dbg/libaether_compiler.a build/dbg/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1 ./build/test_runner$(EXE_EXT)
 
 # -----------------------------------------------------------------
@@ -760,10 +787,10 @@ ci-coverage: compiler ae stdlib-cov
 	@echo "==================================="
 	@echo "  Building coverage-instrumented test runner"
 	@echo "==================================="
-	@$(CC) $(CFLAGS_NO_OPT) $(COV_OPT) $(COV_FLAGS) $(TEST_SRC) \
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(COV_OPT) $(COV_FLAGS) $(TEST_SRC) \
 		build/cov/libaether_compiler.a build/cov/libaether.a \
 		-Icompiler -Istd -Istd/collections \
-		-o build/test_runner_cov$(EXE_EXT) $(LDFLAGS)
+		-o build/test_runner_cov$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo ""
 	@echo "==================================="
 	@echo "  [1/2] Running C-level tests with coverage counters"
@@ -803,7 +830,7 @@ test-asan: compiler stdlib-asan
 	@echo "==================================="
 	@echo "Running Tests with AddressSanitizer"
 	@echo "==================================="
-	$(CC) $(CFLAGS_NO_OPT) $(ASAN_OPT) $(ASAN_FLAGS) $(TEST_SRC) build/asan/libaether_compiler.a build/asan/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner_asan$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(ASAN_OPT) $(ASAN_FLAGS) $(TEST_SRC) build/asan/libaether_compiler.a build/asan/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner_asan$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 ifeq ($(shell uname -s),Linux)
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 ./build/test_runner_asan$(EXE_EXT)
 else
@@ -824,12 +851,12 @@ test-memory: compiler stdlib-memory
 	@echo "==================================="
 	@echo "Running Memory Tracking Tests"
 	@echo "==================================="
-	$(CC) $(CFLAGS) $(MEM_FLAGS) $(TEST_SRC) build/memory/libaether_compiler.a build/memory/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner_mem$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) $(MEM_FLAGS) $(TEST_SRC) build/memory/libaether_compiler.a build/memory/libaether.a -Icompiler -Istd -Istd/collections -o build/test_runner_mem$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	./build/test_runner_mem$(EXE_EXT)
 
 test-manual-runtime: compiler
 	@echo "Building manual runtime test..."
-	$(CC) $(CFLAGS) tests/runtime/test_runtime_manual.c $(RUNTIME_SRC) $(LDFLAGS) -o build/test_runtime_manual$(EXE_EXT)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) tests/runtime/test_runtime_manual.c $(RUNTIME_SRC) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS) -o build/test_runtime_manual$(EXE_EXT)
 	@echo "Running manual runtime test..."
 	./build/test_runtime_manual$(EXE_EXT)
 
@@ -1251,7 +1278,7 @@ examples: compiler ae stdlib
 	printf '  touch "$$tmpdir/FAIL_$$key"\n'                                                        >> "$$script"; \
 	printf '  exit 1\n'                                                                             >> "$$script"; \
 	printf 'fi\n'                                                                                   >> "$$script"; \
-	printf 'if ! $(CC) $(CFLAGS) "$$out_c" $$extra_c "$$root/$(BUILD_DIR)/libaether.a" -o "$$root/$(BUILD_DIR)/examples/$$name$(EXE_EXT)" $(LDFLAGS) 2>"$$tmpdir/$$key.gcc.err"; then\n' >> "$$script"; \
+	printf 'if ! $(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) "$$out_c" $$extra_c "$$root/$(BUILD_DIR)/libaether.a" -o "$$root/$(BUILD_DIR)/examples/$$name$(EXE_EXT)" $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS) 2>"$$tmpdir/$$key.gcc.err"; then\n' >> "$$script"; \
 	printf '  printf "  %%-30s %%s\\n" "$$name" "FAIL (gcc)"\n'                                     >> "$$script"; \
 	printf '  head -20 "$$tmpdir/$$key.gcc.err"\n'                                                  >> "$$script"; \
 	printf '  touch "$$tmpdir/FAIL_$$key"\n'                                                        >> "$$script"; \
@@ -1299,14 +1326,14 @@ lsp: compiler stdlib
 	@echo "==================================="
 	@echo "Building Aether LSP Server ($(DETECTED_OS))"
 	@echo "==================================="
-	$(CC) $(CFLAGS) lsp/main.c build/libaether_compiler.a build/libaether.a -Icompiler -Ilsp -Istd -Istd/collections -o build/aether-lsp$(EXE_EXT) $(LDFLAGS)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) lsp/main.c build/libaether_compiler.a build/libaether.a -Icompiler -Ilsp -Istd -Istd/collections -o build/aether-lsp$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "✓ LSP Server built successfully: build/aether-lsp$(EXE_EXT)"
 
 apkg:
 	@echo "==================================="
 	@echo "Building Aether Package Manager ($(DETECTED_OS))"
 	@echo "==================================="
-	$(CC) $(CFLAGS) tools/apkg/main.c tools/apkg/apkg.c tools/apkg/toml_parser.c $(LDFLAGS) -o build/apkg$(EXE_EXT)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) tools/apkg/main.c tools/apkg/apkg.c tools/apkg/toml_parser.c $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS) -o build/apkg$(EXE_EXT)
 	@echo "✓ Package Manager built successfully: build/apkg$(EXE_EXT)"
 
 # Per-object compile for the tools driver (#1221). Static pattern rule so it
@@ -1320,7 +1347,7 @@ ae: compiler $(TOOLS_OBJS)
 	@echo "==================================="
 	@echo "Building ae command-line tool ($(DETECTED_OS)) v$(VERSION)"
 	@echo "==================================="
-	@$(CC) $(TOOLS_OBJS) -o build/ae$(EXE_EXT) $(LDFLAGS) $(if $(AETHER_ENABLE_LLM),$(LLM_LDFLAGS))
+	@$(CC) $(TOOLS_OBJS) -o build/ae$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS) $(if $(AETHER_ENABLE_LLM),$(LLM_LDFLAGS))
 	@echo "✓ Built successfully: build/ae$(EXE_EXT)"
 	@echo ""
 	@echo "Usage:"
@@ -1334,7 +1361,7 @@ profiler:
 	@echo "==================================="
 	@echo "Building Aether Profiler Dashboard ($(DETECTED_OS))"
 	@echo "==================================="
-	$(CC) $(CFLAGS) -DAETHER_PROFILING tools/profiler/profiler_server.c tools/profiler/profiler_demo.c $(RUNTIME_SRC) $(LDFLAGS) -o build/profiler_demo$(EXE_EXT)
+	$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) -DAETHER_PROFILING tools/profiler/profiler_server.c tools/profiler/profiler_demo.c $(RUNTIME_SRC) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS) -o build/profiler_demo$(EXE_EXT)
 	@echo "✓ Profiler built successfully: build/profiler_demo$(EXE_EXT)"
 	@echo ""
 	@echo "Run the demo and open http://localhost:8081"
@@ -1355,7 +1382,7 @@ docs-server: compiler
 	@echo "==================================="
 	@./build/aetherc$(EXE_EXT) tools/docgen/server.ae build/docs_server_gen.c
 	@$(CC) -O2 -o build/docs-server$(EXE_EXT) build/docs_server_gen.c tools/docgen/server_ffi.c \
-		$(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) $(LDFLAGS)
+		$(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@rm -f build/docs_server_gen.c
 	@echo "✓ Documentation server built: build/docs-server$(EXE_EXT)"
 
@@ -1510,19 +1537,19 @@ COV_COMPILER_LIB_OBJS = $(COMPILER_LIB_SRC:%.c=$(COV_OBJ_DIR)/%.o)
 
 $(ASAN_OBJ_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS_NO_OPT) $(ASAN_OPT) $(ASAN_FLAGS) -c $< -o $@
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(ASAN_OPT) $(ASAN_FLAGS) -c $< -o $@
 
 $(MEM_OBJ_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS) $(MEM_FLAGS) -c $< -o $@
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) $(MEM_FLAGS) -c $< -o $@
 
 $(DBG_OBJ_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS_NO_OPT) $(DBG_OPT) -c $< -o $@
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(DBG_OPT) -c $< -o $@
 
 $(COV_OBJ_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS_NO_OPT) $(COV_OPT) $(COV_FLAGS) -c $< -o $@
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS_NO_OPT) $(COV_OPT) $(COV_FLAGS) -c $< -o $@
 
 build/asan/libaether.a: $(ASAN_LIB_OBJS)
 	@mkdir -p build/asan
@@ -1613,7 +1640,7 @@ release: clean $(STDLIB_SYMS_HEADER)
 	@$(CC) -O3 -DNDEBUG $(LTO_FLAG) -Werror -Icompiler -Iruntime -Istd -Istd/collections \
 		-DAETHER_VERSION=\"$(VERSION)\" \
 		$(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) runtime/aether_resource_caps.c \
-		-o build/aetherc-release$(EXE_EXT) $(LDFLAGS)
+		-o build/aetherc-release$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 ifeq ($(DETECTED_OS),Linux)
 	@echo "Stripping debug symbols..."
 	@strip build/aetherc-release$(EXE_EXT)
@@ -1868,7 +1895,7 @@ endif
 	@echo "Compiling $(FILE) to C..."
 	@./build/aetherc$(EXE_EXT) $(FILE) build/output.c
 	@echo "Building executable..."
-	@$(CC) $(CFLAGS) build/output.c $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -o build/output$(EXE_EXT) $(LDFLAGS)
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) build/output.c $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -o build/output$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Running..."
 	@./build/output$(EXE_EXT)
 
@@ -1896,20 +1923,20 @@ endif
 	@echo "Compiling $(FILE) to C..."
 	@./build/aetherc$(EXE_EXT) $(FILE) build/$(OUTPUT).c
 	@echo "Building executable..."
-	@$(CC) $(CFLAGS) build/$(OUTPUT).c $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -o build/$(OUTPUT)$(EXE_EXT) $(LDFLAGS)
+	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) build/$(OUTPUT).c $(RUNTIME_SRC) $(STD_SRC) $(STD_REACTOR_SRC) $(COLLECTIONS_SRC) -o build/$(OUTPUT)$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "✓ Built: build/$(OUTPUT)$(EXE_EXT)"
 
 # Benchmark computed goto dispatch
 bench-dispatch:
 	@echo "Building computed goto benchmark..."
-	@$(CC) -O3 experiments/concurrency/bench_computed_goto.c -o build/bench_computed_goto$(EXE_EXT) $(LDFLAGS)
+	@$(CC) -O3 experiments/concurrency/bench_computed_goto.c -o build/bench_computed_goto$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Running benchmark..."
 	@./build/bench_computed_goto$(EXE_EXT)
 
 # Benchmark manual prefetch hints
 bench-prefetch:
 	@echo "Building prefetch benchmark..."
-	@$(CC) -O3 experiments/concurrency/bench_prefetch.c -o build/bench_prefetch$(EXE_EXT) $(LDFLAGS)
+	@$(CC) -O3 experiments/concurrency/bench_prefetch.c -o build/bench_prefetch$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Running benchmark..."
 	@./build/bench_prefetch$(EXE_EXT)
 
@@ -1920,7 +1947,7 @@ pgo-generate:
 	@echo "==================================="
 	@echo "PGO Step 1: Building with instrumentation..."
 	@echo "==================================="
-	@$(CC) -O3 -fprofile-generate experiments/concurrency/pgo_workload.c -o build/pgo_workload$(EXE_EXT) $(LDFLAGS)
+	@$(CC) -O3 -fprofile-generate experiments/concurrency/pgo_workload.c -o build/pgo_workload$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Running workload to collect profile data..."
 	@./build/pgo_workload$(EXE_EXT)
 	@echo "Profile data collected in *.gcda files"
@@ -1929,12 +1956,12 @@ pgo-build:
 	@echo "==================================="
 	@echo "PGO Step 2: Building with profile data..."
 	@echo "==================================="
-	@$(CC) -O3 -fprofile-use -D__PGO__ experiments/concurrency/bench_pgo.c -o build/bench_pgo_optimized$(EXE_EXT) $(LDFLAGS)
+	@$(CC) -O3 -fprofile-use -D__PGO__ experiments/concurrency/bench_pgo.c -o build/bench_pgo_optimized$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "PGO-optimized benchmark built"
 
 pgo-baseline:
 	@echo "Building baseline (no PGO)..."
-	@$(CC) -O3 experiments/concurrency/bench_pgo.c -o build/bench_pgo_baseline$(EXE_EXT) $(LDFLAGS)
+	@$(CC) -O3 experiments/concurrency/bench_pgo.c -o build/bench_pgo_baseline$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 	@echo "Baseline benchmark built"
 
 pgo-benchmark: pgo-baseline pgo-generate pgo-build
@@ -2077,7 +2104,7 @@ help:
 
 test-build: $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS)
 	@echo "Building test runner..."
-	@$(CC) $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS) -o build/test_runner$(EXE_EXT) $(LDFLAGS)
+	@$(CC) $(TEST_OBJS) $(COMPILER_LIB_OBJS) $(RUNTIME_OBJS) $(STD_OBJS) $(STD_REACTOR_OBJS) $(COLLECTIONS_OBJS) -o build/test_runner$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)
 
 # Docker CI/CD targets
 docker-build-ci:

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -40,6 +40,9 @@ static int g_arg_drain_count = 0;
 static int g_arg_drain_cap   = 0;
 static int g_arg_drain_counter = 0;
 
+/* #1417: unique ids for the *StringSeq literal fold temps. */
+static int g_seq_lit_counter = 0;
+
 static const char* arg_drain_lookup(ASTNode* node) {
     if (!node) return NULL;
     for (int i = g_arg_drain_count - 1; i >= 0; i--) {
@@ -5327,6 +5330,42 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
              * branch and docs/sequences.md § Literal disambiguation
              * for the user-visible rule. */
             if (is_string_seq_ptr_type(expr->node_type)) {
+                /* #1417: two or more elements need the tail dropped as the
+                 * chain is built. `string_seq_cons` takes its OWN retain on
+                 * the tail, so the canonical builder is
+                 * `cons(h, t); string_seq_free(t)`. The nested-expression
+                 * form has no name for the intermediate results, so nothing
+                 * ever dropped them: every cell but the head ended at
+                 * refcount 2, and a correct `string_seq_free(head)` stopped
+                 * at the first cell that stayed >0 (the shared-tail
+                 * protection), leaking the rest.
+                 *
+                 * Fold into a local instead, dropping each handle after the
+                 * next cell has retained it. Elements are evaluated into
+                 * temps in SOURCE order first, so an element with a side
+                 * effect still runs left to right even though the chain is
+                 * built right to left. */
+                if (expr->child_count >= 2) {
+                    int id = g_seq_lit_counter++;
+                    fprintf(gen->output, "({ ");
+                    for (int i = 0; i < expr->child_count; i++) {
+                        fprintf(gen->output, "const char* _sqe%d_%d = (const char*)(", id, i);
+                        generate_expression(gen, expr->children[i]);
+                        fprintf(gen->output, "); ");
+                    }
+                    fprintf(gen->output,
+                            "StringSeq* _sqa%d = string_seq_empty(); StringSeq* _sqn%d; ",
+                            id, id);
+                    for (int i = expr->child_count - 1; i >= 0; i--) {
+                        fprintf(gen->output,
+                                "_sqn%d = string_seq_cons(_sqe%d_%d, _sqa%d); "
+                                "string_seq_free(_sqa%d); _sqa%d = _sqn%d; ",
+                                id, id, i, id, id, id, id);
+                    }
+                    fprintf(gen->output, "_sqa%d; })", id);
+                    break;
+                }
+                /* 0 or 1 element: no intermediate exists to drop. */
                 for (int i = 0; i < expr->child_count; i++) {
                     fprintf(gen->output, "string_seq_cons(");
                     generate_expression(gen, expr->children[i]);

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -3646,6 +3646,34 @@ ASTNode* parse_return_statement(Parser* parser) {
             }
         }
 
+        /* #1421: `return (a, b)` means the same thing as `return a, b`.
+         *
+         * `(a, b)` parses as a tuple literal, so the parenthesised spelling
+         * arrived here as ONE child where the bare one arrives as two, and
+         * codegen flattened the literal into the return slot: the reported
+         * symptom was C naming an identifier `NULL0` (from `(null, 0)`) or
+         * `bufw` (from `(w.buf, w.off)`), with nothing pointing at the
+         * parentheses. Splicing the elements up makes the two spellings the
+         * same AST, so every later stage treats them identically by
+         * construction rather than by having two paths that agree.
+         *
+         * Only when the literal is the whole return value: `return (a, b), c`
+         * keeps its existing shape rather than silently regrouping. */
+        if (return_stmt->child_count == 1 &&
+            return_stmt->children[0] &&
+            return_stmt->children[0]->type == AST_TUPLE_LITERAL &&
+            return_stmt->children[0]->child_count > 1) {
+            ASTNode* tup = return_stmt->children[0];
+            return_stmt->child_count = 0;
+            for (int i = 0; i < tup->child_count; i++) {
+                add_child(return_stmt, tup->children[i]);
+            }
+            /* The elements now belong to the return statement; detach them
+             * before freeing the husk, or free_ast_node takes them with it. */
+            tup->child_count = 0;
+            free_ast_node(tup);
+        }
+
         match_token(parser, TOKEN_SEMICOLON);
     }
 

--- a/install.sh
+++ b/install.sh
@@ -306,6 +306,10 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
     # modules added under std/ or new subdirs under std/http/ etc.
     # don't silently fall off the install.
     mkdir -p "$INCLUDE_DIR"
+    # The public embedder header lives in include/, outside the runtime/ and
+    # std/ trees walked below, so it shipped in no install at all and
+    # runtime/libaether_caps.c could not find it when cross-compiling (#1420).
+    cp include/*.h "$INCLUDE_DIR/" 2>/dev/null || true
     (cd runtime && find . -name '*.h' -print) | while read -r h; do
         mkdir -p "$INCLUDE_DIR/runtime/$(dirname "$h")"
         cp "runtime/$h" "$INCLUDE_DIR/runtime/$h" 2>/dev/null || true

--- a/runtime/libaether_caps.c
+++ b/runtime/libaether_caps.c
@@ -9,7 +9,13 @@
  * — that's the documented, ABI-stable shape.
  */
 
-#include "../include/libaether.h"
+/* Resolved through the include path, NOT as `../include/libaether.h`: that
+ * spelling only works in the source tree. In an install the runtime sits at
+ * share/aether/runtime/ while headers are under include/aether/, so the
+ * relative hop pointed at a directory that does not exist and every
+ * cross-compile died here (#1420). Native builds never noticed, because they
+ * pass the include set from `ae cflags` and never rely on the relative path. */
+#include "libaether.h"
 #include "aether_resource_caps.h"
 
 AETHER_API void aether_set_memory_cap(uint64_t bytes) {

--- a/tests/integration/build_cache_import_edit/test_build_cache_import_edit.sh
+++ b/tests/integration/build_cache_import_edit/test_build_cache_import_edit.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Regression (#1421): editing an imported module must invalidate the build cache.
+#
+# The cache key hashed the entry file's content and the lib dirs, but a
+# project's own sibling modules are neither: `import helper` next to
+# `src/main.ae` resolves to `src/helper.ae`, which lived in no lib dir. Editing
+# it left the key unchanged, so `ae build` printed "Built (cache hit)" and
+# served a binary built from the OLD module. Deleting `target/` did not help,
+# because the cache lives under ~/.aether/cache.
+#
+# That is the worst shape a cache bug can take: wrong output, successful
+# report, and every measurement taken against it quietly invalid.
+#
+# Asserts both directions, since a cache that never hits would also "pass" a
+# staleness check while making every build slow.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] build_cache_import_edit: ae not built"
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/proj/src"
+cd "$TMP/proj" || exit 1
+printf '[[bin]]\nname = "app"\npath = "src/main.ae"\n' > aether.toml
+cat > src/main.ae <<'AEOF'
+import std.io
+import helper
+
+main() {
+    println(helper.greet())
+}
+AEOF
+
+write_helper() {
+    cat > src/helper.ae <<AEOF
+greet() -> string {
+    return "$1"
+}
+AEOF
+}
+
+build_and_read() {
+    if ! "$AE" build src/main.ae -o ./app >"$TMP/build.log" 2>&1; then
+        echo "  [FAIL] build_cache_import_edit: build failed"
+        sed 's/^/        /' "$TMP/build.log" | head -10
+        exit 1
+    fi
+    ./app 2>&1
+}
+
+write_helper "VERSION-ONE"
+got=$(build_and_read)
+if [ "$got" != "VERSION-ONE" ]; then
+    echo "  [FAIL] build_cache_import_edit: first build printed '$got'"
+    exit 1
+fi
+
+# The bug: only the imported module changes.
+write_helper "VERSION-TWO"
+got=$(build_and_read)
+if [ "$got" != "VERSION-TWO" ]; then
+    echo "  [FAIL] build_cache_import_edit: stale binary after editing an imported module"
+    echo "         printed '$got', expected 'VERSION-TWO'"
+    grep -q 'cache hit' "$TMP/build.log" && echo "         (the build reported a cache hit)"
+    exit 1
+fi
+
+# Once more, so a fix that merely invalidates once is not enough.
+write_helper "VERSION-THREE"
+got=$(build_and_read)
+if [ "$got" != "VERSION-THREE" ]; then
+    echo "  [FAIL] build_cache_import_edit: stale on the second module edit ('$got')"
+    exit 1
+fi
+
+# The other direction: an unchanged rebuild must still hit the cache, or the
+# fix has simply disabled caching.
+"$AE" build src/main.ae -o ./app >"$TMP/hit.log" 2>&1
+if ! grep -q 'cache hit' "$TMP/hit.log"; then
+    echo "  [FAIL] build_cache_import_edit: unchanged rebuild no longer hits the cache"
+    sed 's/^/        /' "$TMP/hit.log" | head -5
+    exit 1
+fi
+
+echo "  [PASS] build_cache_import_edit: module edits invalidate, unchanged rebuilds still hit"

--- a/tests/integration/install_layout_includes/test_install_layout_includes.sh
+++ b/tests/integration/install_layout_includes/test_install_layout_includes.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Regression (#1420): runtime sources must not reach headers by a path that
+# only exists in the source tree.
+#
+# runtime/libaether_caps.c had `#include "../include/libaether.h"`. In the
+# source tree that resolves; in an install the runtime sits at
+# share/aether/runtime/ while headers are under include/aether/, so it pointed
+# at a directory that does not exist and EVERY cross-compile died there. Native
+# builds never noticed, because they pass the include set from `ae cflags` and
+# never rely on the relative path, which is why this shipped.
+#
+# Two static assertions, both cheap and portable (no zig, no install needed):
+#   1. no runtime/ or std/ source escapes its own tree with `../include/`;
+#   2. the public header the runtime includes by name is actually shipped by
+#      both installers, since it lives outside the runtime/ and std/ trees
+#      their header walks cover.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+fail=0
+
+# (1) No source-tree-relative escape into include/.
+hits=$(grep -rn '#include[[:space:]]*"\.\./include/' runtime std 2>/dev/null)
+if [ -n "$hits" ]; then
+    echo "  [FAIL] install_layout_includes: source-tree-relative include of the public header"
+    echo "$hits" | sed 's/^/        /' | head -10
+    echo "        Include it by name and let the -I set resolve it; the installed"
+    echo "        layout has no share/aether/include/ directory."
+    fail=1
+fi
+
+# (2) The public header is shipped by both install paths.
+if [ -f include/libaether.h ]; then
+    if ! grep -q 'include/\*\.h' install.sh; then
+        echo "  [FAIL] install_layout_includes: install.sh does not ship include/*.h"
+        fail=1
+    fi
+    if ! grep -q 'include/\*\.h' Makefile; then
+        echo "  [FAIL] install_layout_includes: the Makefile install does not ship include/*.h"
+        fail=1
+    fi
+else
+    echo "  [FAIL] install_layout_includes: include/libaether.h is missing"
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "  [PASS] install_layout_includes: public header shipped, no source-tree-relative includes"

--- a/tests/regression/test_paren_tuple_return.ae
+++ b/tests/regression/test_paren_tuple_return.ae
@@ -1,0 +1,67 @@
+// Regression (#1421): `return (a, b)` means the same as `return a, b`.
+//
+// `(a, b)` is a tuple literal, so the parenthesised spelling reached codegen as
+// ONE return value where the bare one arrives as two, and the literal was
+// flattened into the return slot. The C compiler then failed on invented
+// identifiers built from the flattened text: `NULL0` for `return (null, 0)`,
+// `bufw` for `return (w.buf, w.off)`. Nothing in the message mentioned
+// parentheses, so the error pointed away from its cause.
+//
+// The two spellings now produce the same AST, so they cannot drift apart.
+import std.string
+
+extern exit(code: int)
+
+bare() -> (int, int) {
+    return 1, 2
+}
+
+parens() -> (int, int) {
+    return (1, 2)
+}
+
+// The reporter's shape: a parenthesised tuple on an early-return branch.
+maybe_buffer(n: int) -> (ptr, int) {
+    if n == 0 {
+        return (null, 0)
+    }
+    return null, n
+}
+
+three() -> (int, int, int) {
+    return (7, 8, 9)
+}
+
+main() {
+    println("=== test_paren_tuple_return ===")
+
+    a, b = bare()
+    c, d = parens()
+    if a != c || b != d {
+        println("  FAIL: parenthesised and bare returns disagree")
+        exit(1)
+    }
+    if c != 1 || d != 2 {
+        println("  FAIL: parenthesised return values wrong")
+        exit(1)
+    }
+
+    p, zero = maybe_buffer(0)
+    if zero != 0 {
+        println("  FAIL: early parenthesised return")
+        exit(1)
+    }
+    q, seven = maybe_buffer(7)
+    if seven != 7 {
+        println("  FAIL: bare return on the same function")
+        exit(1)
+    }
+
+    x, y, z = three()
+    if x != 7 || y != 8 || z != 9 {
+        println("  FAIL: three-element parenthesised return")
+        exit(1)
+    }
+
+    println("  PASS: (a, b) and a, b agree in return position")
+}

--- a/tests/regression/test_seq_literal_leak.ae
+++ b/tests/regression/test_seq_literal_leak.ae
@@ -1,0 +1,61 @@
+// Regression (#1417): a multi-element `*StringSeq` literal must not leak its
+// inner cons cells.
+//
+// `["a","b","c"]` lowers to a cons chain, and `string_seq_cons` takes its OWN
+// retain on the tail, so the builder has to drop each intermediate handle
+// (`cons(h, t); string_seq_free(t)`). As a nested expression the intermediates
+// were anonymous temporaries nothing ever dropped, so every cell but the head
+// ended at refcount 2. A correct `string_seq_free(head)` then stopped at the
+// first cell that stayed above zero (the shared-tail protection) and the rest
+// leaked: 24 bytes per element past the first, with the program otherwise
+// behaving perfectly.
+//
+// Runs under the leak gate, which is what actually asserts the fix; the
+// value checks here keep the fold honest about order and length.
+import std.string
+
+extern exit(code: int)
+
+main() {
+    println("=== test_seq_literal_leak ===")
+
+    let empty: *StringSeq = []
+    if string_seq_length(empty) != 0 {
+        println("  FAIL: empty literal length")
+        exit(1)
+    }
+    string_seq_free(empty)
+
+    let one: *StringSeq = ["only"]
+    if string_seq_length(one) != 1 {
+        println("  FAIL: single-element literal length")
+        exit(1)
+    }
+    string_seq_free(one)
+
+    // The shape that leaked: every element past the head.
+    let three: *StringSeq = ["a", "b", "c"]
+    if string_seq_length(three) != 3 {
+        println("  FAIL: three-element literal length")
+        exit(1)
+    }
+    if string.equals(string_seq_head(three), "a") != 1 {
+        println("  FAIL: head is not the first element")
+        exit(1)
+    }
+    string_seq_free(three)
+
+    // Longer chain, and repeated so a per-iteration leak would compound.
+    i = 0
+    while i < 200 {
+        let many: *StringSeq = ["one", "two", "three", "four", "five", "six"]
+        if string_seq_length(many) != 6 {
+            println("  FAIL: six-element literal length")
+            exit(1)
+        }
+        string_seq_free(many)
+        i = i + 1
+    }
+
+    println("  PASS: seq literals are leak-clean")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1144,7 +1144,13 @@ found_root:
         char rt[1024], stdroot[1024];
         snprintf(rt, sizeof(rt), "%s/runtime", tc.root);
         snprintf(stdroot, sizeof(stdroot), "%s/std", tc.root);
-        if (!walk_dirs_emit_includes(rt, &tc.include_flags, &tc.include_flags_cap, &pos) ||
+        /* #1420: the public embedder header (include/libaether.h) is not
+         * under runtime/ or std/, so nothing put its directory on the include
+         * path. runtime/libaether_caps.c includes it by name. */
+        char pubinc[1024];
+        snprintf(pubinc, sizeof(pubinc), "%s/include", tc.root);
+        if (!append_include_one_dir(&tc.include_flags, &tc.include_flags_cap, &pos, pubinc) ||
+            !walk_dirs_emit_includes(rt, &tc.include_flags, &tc.include_flags_cap, &pos) ||
             !walk_dirs_emit_includes(stdroot, &tc.include_flags, &tc.include_flags_cap, &pos)) {
             // Buffer overflow — fall back to a minimal -I that gets
             // through the build. Caller will see warnings on missing
@@ -1225,7 +1231,13 @@ found_root:
         snprintf(inc_std, sizeof(inc_std), "%s/include/aether/std",     tc.root);
         snprintf(shr_rt,  sizeof(shr_rt),  "%s/share/aether/runtime",   tc.root);
         snprintf(shr_std, sizeof(shr_std), "%s/share/aether/std",       tc.root);
+        /* #1420: include/aether/ itself holds the public embedder header
+         * (libaether.h); the walks below only cover its runtime/ and std/
+         * subtrees. */
+        char inc_root[1024];
+        snprintf(inc_root, sizeof(inc_root), "%s/include/aether", tc.root);
         int ok =
+            append_include_one_dir(&tc.include_flags, &tc.include_flags_cap, &pos, inc_root) &&
             walk_dirs_emit_includes(inc_rt,  &tc.include_flags, &tc.include_flags_cap, &pos) &&
             walk_dirs_emit_includes(inc_std, &tc.include_flags, &tc.include_flags_cap, &pos) &&
             walk_dirs_emit_includes(shr_rt,  &tc.include_flags, &tc.include_flags_cap, &pos) &&

--- a/tools/ae_cache.c
+++ b/tools/ae_cache.c
@@ -314,6 +314,44 @@ unsigned long long compute_cache_key(const char* ae_file,
         }
     }
 
+    /* #1421: the entry file's OWN directory tree.
+     *
+     * The key hashed the entry file's content and the lib dirs, but a
+     * project's other sources are neither: `import helper` next to
+     * `src/main.ae` resolves to `src/helper.ae`, which lived in no lib dir and
+     * was not an extra_file. Editing it left the key unchanged, so `ae build`
+     * printed "Built (cache hit)" and served a binary built from the old
+     * module. Deleting `target/` did not help, because the cache lives under
+     * ~/.aether/cache, so the stale result looked like the build simply had
+     * nothing to do.
+     *
+     * That is the worst shape a cache bug can take: the output is wrong, the
+     * report says success, and every measurement taken against it is quietly
+     * invalid. Hash the whole tree the entry sits in, with the same
+     * content-hash and the same depth/entry caps the lib-dir walk uses, so any
+     * edit to any project source bumps the key. Over-invalidating costs a
+     * rebuild; under-invalidating costs a wrong answer.
+     */
+    {
+        char entry_dir[1024];
+        snprintf(entry_dir, sizeof(entry_dir), "%s", ae_file);
+        char* cut = strrchr(entry_dir, '/');
+#ifdef _WIN32
+        char* bcut = strrchr(entry_dir, '\\');
+        if (!cut || (bcut && bcut > cut)) cut = bcut;
+#endif
+        if (cut) *cut = '\0';
+        else snprintf(entry_dir, sizeof(entry_dir), ".");
+
+        unsigned long long src_tree = 0;
+        int src_count = 0;
+        hash_lib_dir_entries(entry_dir, "", &src_tree, &src_count, 0);
+        if (src_count > 0) {
+            pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
+                            ":src=%016llx", src_tree);
+        }
+    }
+
     /* Issue #413: include the --lib search path in the cache key.
      * Two builds of the same source with different lib paths must
      * resolve different imports — they're materially different

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -9,6 +9,7 @@
 
 #include "ae_internal.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -171,6 +172,35 @@ bool cross_uses_unsupported_module(const char* file, char* which, size_t wsz) {
  * default on when no AETHER_NO_* is passed). The external-library macros
  * (AETHER_HAS_OPENSSL / _ZLIB / _NGHTTP2 / _PCRE2) are deliberately left
  * undefined so their stub paths compile, matching the excluded sources. */
+/* Grow *buf to hold at least `need` bytes, doubling. Same shape as
+ * include_flags_grow in ae.c, and for the same reason: the cross-compile
+ * command line scales with the install prefix and the module count, so any
+ * fixed size is a limit someone eventually runs into with nothing they can do
+ * about it. */
+static bool cross_buf_reserve(char** buf, size_t* cap, size_t need) {
+    if (need <= *cap) return true;
+    size_t next = *cap ? *cap : 8192;
+    while (next < need) next *= 2;
+    char* bigger = (char*)realloc(*buf, next);
+    if (!bigger) return false;
+    *buf = bigger;
+    *cap = next;
+    return true;
+}
+
+/* printf into a heap buffer that grows to fit. Returns false only on OOM. */
+static bool cross_cmd_fmt(char** buf, size_t* cap, const char* fmt, ...) {
+    for (;;) {
+        va_list ap;
+        va_start(ap, fmt);
+        int w = vsnprintf(*buf, *cap, fmt, ap);
+        va_end(ap);
+        if (w < 0) return false;
+        if ((size_t)w < *cap) return true;
+        if (!cross_buf_reserve(buf, cap, (size_t)w + 1)) return false;
+    }
+}
+
 int run_cross_build(const char* c_file, const char* out_file,
                            bool optimize, const char* extra,
                            const char* ztriple) {
@@ -396,12 +426,24 @@ int run_cross_build(const char* c_file, const char* out_file,
             }
         }
     }
-    static char cmd[24576];
+    /* Heap-grown rather than fixed: the command line is dominated by
+     * tc.include_flags, which is itself heap-grown and scales with the install
+     * prefix length and the module count. A fixed buffer turned a longer-than-
+     * usual prefix into "cross-compile command exceeded the N-byte buffer",
+     * with no way for the user to shorten anything that mattered. */
+    char* cmd = NULL;
+    size_t cmd_cap = 0;
     /* Accumulated quoted "<objpath>" list, in compile order, for the ar
      * step. posix_run tokenizes the command itself (no shell), so the
-     * archive must name each object explicitly rather than glob. */
-    static char objlist[24576];
+     * archive must name each object explicitly rather than glob. Also grows:
+     * it holds one quoted path per runtime object. */
+    char* objlist = NULL;
+    size_t objlist_cap = 0;
     size_t obj_pos = 0;
+    if (!cross_buf_reserve(&objlist, &objlist_cap, 1)) {
+        fprintf(stderr, "Error: out of memory building the cross-compile command.\n");
+        return 1;
+    }
     objlist[0] = '\0';
     int rc = 1;
 
@@ -418,13 +460,11 @@ int run_cross_build(const char* c_file, const char* out_file,
             /* basename with its trailing ".c" replaced by ".o" */
             snprintf(objpath, sizeof(objpath), "%s/%.*so", objdir,
                      (int)(strlen(bn) - 1), bn);
-            w = snprintf(cmd, sizeof(cmd),
+            if (!cross_cmd_fmt(&cmd, &cmd_cap,
                 "zig cc -target %s %s %s %s %s %s -c \"%s\" -o \"%s\"",
                 ztriple, sysroot_flag, opt, feature_defs, user_cflags, tc.include_flags,
-                srcs[i], objpath);
-            if (w < 0 || (size_t)w >= sizeof(cmd)) {
-                fprintf(stderr, "Error: cross-compile command exceeded the %zu-byte buffer.\n",
-                        sizeof(cmd));
+                srcs[i], objpath)) {
+                fprintf(stderr, "Error: out of memory building the cross-compile command.\n");
                 compile_failed = true;
                 break;
             }
@@ -433,13 +473,15 @@ int run_cross_build(const char* c_file, const char* out_file,
                 compile_failed = true;
                 break;
             }
-            int ow = snprintf(objlist + obj_pos, sizeof(objlist) - obj_pos,
-                              "%s\"%s\"", obj_pos ? " " : "", objpath);
-            if (ow < 0 || obj_pos + (size_t)ow >= sizeof(objlist)) {
-                fprintf(stderr, "Error: cross-compile object list overflowed its buffer.\n");
+            size_t need = obj_pos + strlen(objpath) + 4;
+            if (!cross_buf_reserve(&objlist, &objlist_cap, need)) {
+                fprintf(stderr, "Error: out of memory building the cross-compile object list.\n");
                 compile_failed = true;
                 break;
             }
+            int ow = snprintf(objlist + obj_pos, objlist_cap - obj_pos,
+                              "%s\"%s\"", obj_pos ? " " : "", objpath);
+            if (ow < 0) { compile_failed = true; break; }
             obj_pos += (size_t)ow;
         }
         if (compile_failed) break;
@@ -447,11 +489,9 @@ int run_cross_build(const char* c_file, const char* out_file,
         /* 2. Archive the objects (named explicitly, no glob) so the final
          *    link pulls only what the program references (native
          *    `-laether` semantics). */
-        w = snprintf(cmd, sizeof(cmd),
-            "zig ar rcs \"%s/libaether.a\" %s", objdir, objlist);
-        if (w < 0 || (size_t)w >= sizeof(cmd)) {
-            fprintf(stderr, "Error: cross-compile archive command exceeded the %zu-byte buffer.\n",
-                    sizeof(cmd));
+        if (!cross_cmd_fmt(&cmd, &cmd_cap,
+            "zig ar rcs \"%s/libaether.a\" %s", objdir, objlist)) {
+            fprintf(stderr, "Error: out of memory building the cross-compile archive command.\n");
             break;
         }
         if (run_cmd_show_warnings(cmd) != 0) {
@@ -472,21 +512,20 @@ int run_cross_build(const char* c_file, const char* out_file,
             /* Platform -l names go AFTER libaether.a — it references their
              * symbols (casper's cap_*, openssl's SSL_*, …), so they must
              * follow it on the link line for ld.lld's single-pass resolution. */
-            w = snprintf(cmd, sizeof(cmd),
+            w = cross_cmd_fmt(&cmd, &cmd_cap,
                 "zig cc -target %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -lm -o \"%s\"",
                 ztriple, sysroot_flag, fbsd_link, opt, feature_defs, tc.include_flags,
-                c_file, ex, objdir, fbsd_platform_libs, crossbuild_libs, out_file);
+                c_file, ex, objdir, fbsd_platform_libs, crossbuild_libs, out_file) ? 1 : -1;
         } else {
             /* Tier A (linux/macos/windows): compact form + any CROSSBUILD_SYSROOT
              * Tier-2 libs AND the Windows system libs after libaether.a (it
              * references their symbols — BCryptGenRandom etc.). */
-            w = snprintf(cmd, sizeof(cmd),
+            w = cross_cmd_fmt(&cmd, &cmd_cap,
                 "zig cc -target %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
-                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, win_platform_libs, out_file);
+                ztriple, sysroot_flag, opt, feature_defs, tc.include_flags, c_file, ex, objdir, crossbuild_libs, win_platform_libs, out_file) ? 1 : -1;
         }
-        if (w < 0 || (size_t)w >= sizeof(cmd)) {
-            fprintf(stderr, "Error: cross-compile link command exceeded the %zu-byte buffer.\n",
-                    sizeof(cmd));
+        if (w < 0) {
+            fprintf(stderr, "Error: out of memory building the cross-compile link command.\n");
             break;
         }
         if (run_cmd_show_warnings(cmd) != 0) {
@@ -506,6 +545,9 @@ int run_cross_build(const char* c_file, const char* out_file,
         }
         rc = 0;
     } while (0);
+
+    free(cmd);
+    free(objlist);
 
     /* Best-effort removal of the temp object tree. */
     char rmcmd[1100];


### PR DESCRIPTION
Every reported bug reproduced against current `main` first. One of the five turned out not to be a bug and is not "fixed" here.

## Cross-compiling failed for every target from an install (#1420)

`runtime/libaether_caps.c` included the public header as `../include/libaether.h`, which only resolves in the source tree. An install puts the runtime at `share/aether/runtime/` and headers under `include/aether/`, so the hop pointed at a directory that does not exist:

```
share/aether/runtime/libaether_caps.c:12:10: fatal error: '../include/libaether.h' file not found
```

Underneath that was a second gap: **`include/libaether.h` was never installed at all**, because both installers walk only the `runtime/` and `std/` trees for headers. Native builds never noticed, because they pass the include set from `ae cflags` and never rely on the relative path. That is how it shipped.

Fixed in four places: both installers ship `include/*.h`, the header is included by name, the directory holding it is on the include path in both layouts, and the Makefile's own `CFLAGS` gained the same `-Iinclude` (its absence broke the in-tree build the moment the include was corrected).

Verified from a real install into a temp prefix, which is the configuration that failed:

```
$ AETHER_HOME=/tmp/aei /tmp/aei/bin/ae build x.ae --target=x86_64-linux -o x
Built: ./x
$ file x
x: ELF 64-bit LSB executable, x86-64, ... for GNU/Linux 2.0.0
```

`aarch64-linux` builds too, and the native path is unaffected.

## `ae build` served a stale binary after an imported module changed (#1421)

The cache key covered the entry file's content and the lib dirs, but not the project's own sibling modules. `import helper` next to `src/main.ae` resolves to `src/helper.ae`, which is in no lib dir, so editing it left the key unchanged:

```
$ ae build src/main.ae -o app     # after editing src/helper.ae
Built (cache hit): ./app
HELPER-V1                          # the old module
```

`rm -rf target` does not help, because the cache lives in `~/.aether/cache`. The key now folds in the entry file's whole directory tree, content-hashed with the same depth and entry caps the lib-dir walk already uses. Over-invalidating costs a rebuild; under-invalidating costs a wrong answer wearing a success message.

## `return (a, b)` compiled to garbage (#1421)

`(a, b)` is a tuple literal, so the parenthesised spelling reached codegen as **one** return value where the bare `return a, b` gives two, and it was flattened into the return slot. The C compiler then failed on identifiers invented from the flattened text: `NULL0` from `return (null, 0)`, `bufw` from `return (w.buf, w.off)`, with nothing pointing at the parentheses.

Both spellings now produce the same AST, so no later stage can treat them differently. **Accepting** rather than rejecting, because `(a, b)` is already a valid tuple literal in other positions (`t = (1, 2)` compiles fine today); rejecting it only in return position would be the inconsistency, not the fix.

## Multi-element `*StringSeq` literals leaked their inner cons cells (#1417)

`string_seq_cons` takes its own retain on the tail, so the canonical builder drops each intermediate handle. As a nested expression those intermediates were anonymous temporaries nothing ever dropped, so every cell but the head ended at refcount 2, and a correct `string_seq_free(head)` stopped at the first cell that stayed above zero and leaked the rest, 24 bytes per element past the first.

The literal now folds into a local, dropping each handle after the next cell retains it. Elements are evaluated into temps in **source order** first, so an element with a side effect still runs left to right even though the chain builds right to left. The reproduction from the issue goes from 2 leaks / 64 bytes to 0.

## Also fixed: the cross-compile command buffer

Reproducing #1420 from an install under a long path hit a different wall first:

```
Error: cross-compile command exceeded the 24576-byte buffer.
```

The command line is dominated by the include set, which scales with the install prefix length and the module count, so any fixed size is a limit someone eventually reaches with nothing they can shorten. The command and object list now grow on demand, the same shape the include set itself already uses.

## Not a bug: `bytes.get` on a `read_binary_tuple` pointer

The third item in #1421 is not a defect. `fs_read_binary_tuple` is declared `-> (string @heap, int, string)`, so the first element is a string, not a raw byte buffer, and `bytes.get` is the wrong accessor for it. The filer identified this as their own mistake; no code change, recorded here so the issue closes with the reason.

## Tests

- `tests/regression/test_paren_tuple_return.ae` asserts the two spellings agree, including the reporter's early-return shape.
- `tests/regression/test_seq_literal_leak.ae` covers empty, single and multi-element literals plus a 200-iteration loop, and runs under the leak gate that actually asserts the fix.
- `tests/integration/build_cache_import_edit` asserts **both** directions: a module edit rebuilds, and an unchanged rebuild still reports a cache hit. A one-sided test would pass with caching disabled entirely.
- `tests/integration/install_layout_includes` is a static guard needing neither zig nor an install: no `runtime/` or `std/` source may reach a header via `../include/`, and both installers must ship the public header. Verified it fails when the old include is restored.

Local: 229/229 unit, fmt gate, differential suite, and all four new tests green.

Closes #1417
Closes #1420
Closes #1421
