### PR TITLE
fix: point the self-updater at the repository the project owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ version number before tagging the release.
 
 ### Fixed
 
+- **The self-updater pointed at a repository path the project no longer owns.**
+  `AE_GITHUB_REPO` was still the pre-rename `nicolasmd87/aether`, which the
+  GitHub API answers with a 301. It kept working only because `curl -fsSL` and
+  `wget` follow redirects silently, and `ae upgrade` / `ae install` /
+  `ae version list` download release binaries from that path and install them.
+  A rename redirect lasts exactly as long as nobody claims the freed name: the
+  moment someone does, the redirect stops resolving here and the self-updater
+  installs whatever is at the old address. Repointed to
+  `aether-lang-dev/aether`, which resolves directly with no redirect, along
+  with the twelve other stale references (the download hint in `ae`, the
+  diagnostics wiki URL, `apkg`, the VS Code extension manifest and README, the
+  benchmark UI). The historical changelog archive is deliberately left alone:
+  those entries record the links as they were, and rewriting them would be
+  fiction rather than a fix. `tests/integration/canonical_repo_url` fails the
+  build if the stale path returns.
+
+## [current]
+
+### Fixed
+
 - **The cross-language benchmark suite excluded Aether, and said so quietly.**
   Every run printed `Aether... [SKIP] Build failed` for all five benchmarks
   while the other ten languages reported numbers, and then published a results

--- a/benchmarks/cross-language/visualize/index.html
+++ b/benchmarks/cross-language/visualize/index.html
@@ -172,7 +172,7 @@ tbody tr:hover { background: #1c2128; }
   Based on the <a href="https://dl.acm.org/doi/10.1145/2687357.2687368">Savina Actor Benchmark Suite</a> (Imam &amp; Sarkar, Rice University, 2014).<br>
   All languages compiled with highest optimization flags. Median of N runs reported. JVM/BEAM languages receive warmup runs before timed measurement.<br>
   Throughput = operations / wall-clock elapsed (CLOCK_MONOTONIC). Memory = peak RSS (/usr/bin/time). CV% = coefficient of variation (σ/μ).<br>
-  <a href="https://github.com/nicolasmd87/aether">Aether Programming Language</a> · Open source · MIT License
+  <a href="https://github.com/aether-lang-dev/aether">Aether Programming Language</a> · Open source · MIT License
 </div>
 
 <script>

--- a/compiler/aether_diagnostics.c
+++ b/compiler/aether_diagnostics.c
@@ -284,7 +284,7 @@ void print_diagnostic_colored(EnhancedDiagnostic* diag) {
 const char* get_error_docs_url(ErrorCode code) {
     static char url[128];
     snprintf(url, sizeof(url),
-             "https://github.com/nicolasmd87/aether/wiki/E%04d", code);
+             "https://github.com/aether-lang-dev/aether/wiki/E%04d", code);
     return url;
 }
 

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -1,7 +1,7 @@
 # Aether Language Support
 
 Visual Studio Code (and Cursor) support for the
-[Aether programming language](https://github.com/nicolasmd87/aether).
+[Aether programming language](https://github.com/aether-lang-dev/aether).
 
 ## What you get
 
@@ -175,7 +175,7 @@ main() {
 ## Reporting issues
 
 Open an issue at
-[github.com/nicolasmd87/aether/issues](https://github.com/nicolasmd87/aether/issues).
+[github.com/aether-lang-dev/aether/issues](https://github.com/aether-lang-dev/aether/issues).
 
 ## License
 

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -9,12 +9,12 @@
   "main": "./out/extension.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nicolasmd87/aether"
+    "url": "https://github.com/aether-lang-dev/aether"
   },
   "bugs": {
-    "url": "https://github.com/nicolasmd87/aether/issues"
+    "url": "https://github.com/aether-lang-dev/aether/issues"
   },
-  "homepage": "https://github.com/nicolasmd87/aether#readme",
+  "homepage": "https://github.com/aether-lang-dev/aether#readme",
   "keywords": [
     "aether",
     "actor",

--- a/tests/integration/canonical_repo_url/test_canonical_repo_url.sh
+++ b/tests/integration/canonical_repo_url/test_canonical_repo_url.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# The toolchain must reference the CURRENT repository path, not an old name
+# that only resolves through a GitHub rename redirect.
+#
+# `ae upgrade` / `ae install` download release binaries from AE_GITHUB_REPO and
+# install them. curl and wget both follow redirects silently, so a stale
+# owner/name keeps working right up until someone claims the freed path, at
+# which point the self-updater fetches its binaries from whatever now lives
+# there. It is not a broken link, it is an install path pointed at an address
+# the project no longer controls.
+#
+# The changelogs are exempt: they record links as they were written, and an
+# entry explaining this very fix has to be able to name the old path. They are
+# prose, not addresses anything fetches. Everything a user or a tool actually
+# follows (code, docs, editor manifests, UI links) stays covered.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+# Assembled from parts so this file does not itself contain the literal it
+# searches for, which would make the check fail on its own source.
+STALE_OWNER='nicolasmd87'
+STALE="$STALE_OWNER/aether"
+
+hits=$(grep -rn "$STALE" \
+        --exclude-dir=.git \
+        --exclude-dir=build \
+        --exclude-dir=target \
+        --exclude=CHANGELOG.md \
+        --exclude=CHANGELOG-archive.md \
+        . 2>/dev/null | grep -v '^\./benchmarks/json/corpus/')
+
+if [ -n "$hits" ]; then
+    echo "  [FAIL] canonical_repo_url: stale repository path still referenced"
+    echo "$hits" | sed 's/^/        /' | head -12
+    echo "        Use the current path; a rename redirect is not a durable target"
+    echo "        for anything that downloads and installs binaries."
+    exit 1
+fi
+
+# And the constant the self-updater actually uses must be the canonical one.
+if ! grep -q '#define AE_GITHUB_REPO "aether-lang-dev/aether"' tools/ae_version.c; then
+    echo "  [FAIL] canonical_repo_url: AE_GITHUB_REPO is not the canonical path"
+    grep -n 'define AE_GITHUB_REPO' tools/ae_version.c | sed 's/^/        /'
+    exit 1
+fi
+
+echo "  [PASS] canonical_repo_url: release and docs URLs use the current repository path"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1038,7 +1038,7 @@ static void discover_toolchain(void) {
     fprintf(stderr, "Or set AETHER_HOME to the extraction folder:\n");
     fprintf(stderr, "  set AETHER_HOME=C:\\aether\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "Download: https://github.com/nicolasmd87/aether/releases\n");
+    fprintf(stderr, "Download: https://github.com/aether-lang-dev/aether/releases\n");
 #else
     fprintf(stderr, "Run 'make compiler' to build it, or set $AETHER_HOME.\n");
 #endif

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -55,7 +55,14 @@
 #  define AE_ARCHIVE_EXT ".tar.gz"
 #endif
 
-#define AE_GITHUB_REPO "nicolasmd87/aether"
+/* The canonical repository path. It must be the CURRENT one, not an old name
+ * that still redirects: `ae upgrade` / `ae install` download release binaries
+ * from here and install them, and curl/wget both follow redirects silently. A
+ * stale owner/name only resolves while GitHub keeps the rename mapping and
+ * nobody else claims the freed path; the moment someone does, the redirect
+ * stops pointing here and the self-updater fetches its binaries from whatever
+ * is at the old address. */
+#define AE_GITHUB_REPO "aether-lang-dev/aether"
 
 // Download url → dest file. Uses curl/wget on POSIX, PowerShell on Windows.
 // Creates parent directories of dest if they don't exist.

--- a/tools/apkg/apkg.c
+++ b/tools/apkg/apkg.c
@@ -738,7 +738,7 @@ void apkg_print_help() {
     printf("    search <query>    Search for packages\n");
     printf("    help              Show this help message\n");
     printf("    version           Show version information\n\n");
-    printf("For more information, see: https://github.com/nicolasmd87/aether\n");
+    printf("For more information, see: https://github.com/aether-lang-dev/aether\n");
 }
 
 void apkg_print_version() {


### PR DESCRIPTION
Found while looking at `ae add` for #1360: the toolchain's self-updater points at a repository path the project no longer owns.

## What

`AE_GITHUB_REPO` in `tools/ae_version.c` was still the pre-rename `nicolasmd87/aether`. The GitHub API answers that with a **301**:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' https://api.github.com/repos/nicolasmd87/aether/releases
301
$ curl -sS -o /dev/null -w '%{http_code}\n' https://api.github.com/repos/aether-lang-dev/aether/releases
200
```

It kept working only because `ae_download` uses `curl -fsSL` and `wget`, both of which follow redirects silently.

## Why it is worth more than a link fix

`ae upgrade`, `ae install <v>` and `ae version list` fetch release binaries from that path **and install them**.

A GitHub rename redirect lasts exactly as long as nobody claims the freed name. The moment someone registers a repo at the old path, the redirect stops resolving here and the self-updater downloads and installs whatever is there instead, with no warning and no signature check standing in the way. That is an install path pointed at an address the project does not control.

## The fix

Repointed to `aether-lang-dev/aether`, which resolves directly with no redirect, along with the twelve other stale references:

| Where | What it is |
|---|---|
| `tools/ae_version.c` | the release API and download URLs (the one that matters) |
| `tools/ae.c` | the download hint printed when a prebuilt is missing |
| `compiler/aether_diagnostics.c` | the wiki URL the compiler emits in error messages |
| `tools/apkg/apkg.c` | informational URL |
| `editor/vscode/package.json`, `README.md` | the published extension manifest |
| `benchmarks/.../index.html` | UI footer link |

**Deliberately not rewritten:** `CHANGELOG-archive.md`. Those entries record the links as they were written at the time; changing them would make the history say something that was never true.

## Guard

`tests/integration/canonical_repo_url` fails the build if the stale path returns anywhere a user or a tool would follow it, and asserts `AE_GITHUB_REPO` is the canonical one. The changelogs are exempt, because they are prose rather than addresses anything fetches, and the entry describing this fix has to be able to name the old path.

Two things I got wrong on the way and fixed: the guard initially matched its own search pattern (it now assembles the pattern from parts), and then flagged my own CHANGELOG entry. Verified in both directions, including reintroducing the stale path into `compiler/aether_diagnostics.c` and confirming it fails.

## Verification

Clean build, 229/229 unit tests, fmt gate, differential suite, and `ae version list` now fetching against the canonical repo (`v0.495.0 * current`).
