### PR TITLE
fix(scheduler): park idle cores instead of spinning forever (#1517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **An idle program pegged every core** (#1517). The scheduler's extended-idle
+  branch called `scheduler_io_poll(sched, 1)` expecting it to block for a
+  millisecond. That function returns immediately when no descriptors are
+  registered, and the `aether_sched_yield()` after it also returns immediately
+  when nothing else is runnable, so the thread reset its counter to 5000 and
+  spun again. Nothing in the path ever slept. The report that opened the issue
+  was a leftover binary that had been running for five days at 650% CPU doing
+  no work.
+
+  A core with nothing registered with the poller now parks on a condition
+  variable. Producers signal it when they hand it work, so a message still
+  arrives without waiting out a timeout; the wait is timed as well, so a
+  producer that never signals costs latency rather than a hang. Cores that do
+  have descriptors registered are unchanged: the poll blocks for its timeout
+  and always did.
+
+  Measured on an 8-core M1 Pro, a program that does one thing and then idles
+  for two seconds:
+
+  | | CPU consumed |
+  |---|---:|
+  | before | 14,058,539 us (about 7 cores) |
+  | after | 5,661 us |
+
+  Throughput improves rather than regresses, because idle cores are no longer
+  competing with working ones for the machine. Medians over repeated runs:
+  thread_ring +18%, counting +187%, fork-join +17%, ping-pong within noise at
+  +2.5%. `tests/regression/test_scheduler_idle_cpu.ae` compares process CPU
+  time against wall time while quiescent and fails at 35x its budget against
+  the old scheduler.
+
+## [current]
+
 ### Added
 
 - **`contrib.vulkan`: offscreen GPU rendering** (#1495, phase 1). Instance,

--- a/runtime/scheduler/multicore_scheduler.c
+++ b/runtime/scheduler/multicore_scheduler.c
@@ -227,6 +227,42 @@ static AETHER_TLS int tls_overflow_any = 0; // fast gate: any pending at all?
 // that are still queued in scheduler threads' TLS overflow buffers.
 static atomic_int g_overflow_total = 0;
 
+// Idle park bounds (#1517). A core given work directly is signalled and does
+// not wait for these; the ceiling only bounds how long a core that could STEAL
+// from a busy neighbour stays asleep, and it pays that once before finding
+// work and staying awake. Measured at 32ms: 0.28% of one core while idle,
+// against 1.4% at 4ms, with no difference in fork-join throughput either way.
+#define PARK_MS_MIN 1
+#define PARK_MS_MAX 32
+
+static inline void aether_park_deadline(struct timespec* ts, int ms) {
+#if defined(CLOCK_REALTIME)
+    clock_gettime(CLOCK_REALTIME, ts);
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    ts->tv_sec = tv.tv_sec;
+    ts->tv_nsec = tv.tv_usec * 1000L;
+#endif
+    ts->tv_nsec += (long)ms * 1000000L;
+    ts->tv_sec  += ts->tv_nsec / 1000000000L;
+    ts->tv_nsec %= 1000000000L;
+}
+
+// Tell `target` it has work (#1517). Costs one acquire load on a line the
+// caller just wrote anyway; the mutex is touched only when someone is actually
+// asleep. The load-versus-park race is closed on the sleeper's side, which
+// sets `parked` and then re-checks its queues before waiting, so a producer
+// that sees parked==0 here has necessarily already made its message visible to
+// that re-check.
+static inline void sched_wake(Scheduler* target) {
+    if (atomic_load_explicit(&target->parked, memory_order_acquire)) {
+        pthread_mutex_lock(&target->park_mutex);
+        pthread_cond_signal(&target->park_cond);
+        pthread_mutex_unlock(&target->park_mutex);
+    }
+}
+
 static void overflow_append(int target, ActorBase* actor, Message msg) {
     if (unlikely(target < 0 || target > MAX_CORES)) {
         fprintf(stderr, "aether: overflow_append: target %d out of range [0, %d]\n",
@@ -334,6 +370,7 @@ static void overflow_flush(int from_core) {
                     // Actor migrated away — try to forward
                     if (queue_enqueue(&schedulers[ac].from_queues[from_idx], actor, msg)) {
                         atomic_fetch_add_explicit(&schedulers[ac].work_count, 1, memory_order_relaxed);
+                        sched_wake(&schedulers[ac]);
                         flushed++;
                     } else {
                         b->actors[start + rem] = actor;
@@ -474,6 +511,7 @@ void* AETHER_HOT scheduler_thread(void* arg) {
     atomic_fetch_add_explicit(&g_threads_ready, 1, memory_order_release);
 
     int idle_count = 0;
+    int park_ms = PARK_MS_MIN;
 
     while (atomic_load_explicit(&sched->running, memory_order_acquire)) {
         int work_done = 0;
@@ -540,6 +578,7 @@ void* AETHER_HOT scheduler_thread(void* arg) {
                     int forwarded = 0;
                     for (int r = 0; r < 8; r++) {
                         if (queue_enqueue(&schedulers[new_core].from_queues[sched->core_id], actor, msg)) {
+                            sched_wake(&schedulers[new_core]);
                             forwarded = 1; break;
                         }
                         int cur = atomic_load_explicit(&actor->assigned_core, memory_order_relaxed);
@@ -613,6 +652,7 @@ void* AETHER_HOT scheduler_thread(void* arg) {
                     int forwarded = 0;
                     for (int r = 0; r < 8; r++) {
                         if (queue_enqueue(&schedulers[new_core].from_queues[sched->core_id], actor, msg)) {
+                            sched_wake(&schedulers[new_core]);
                             forwarded = 1; break;
                         }
                         int cur = atomic_load_explicit(&actor->assigned_core, memory_order_relaxed);
@@ -903,17 +943,40 @@ void* AETHER_HOT scheduler_thread(void* arg) {
                 // Tight spin with architecture-specific pause
                 AETHER_PAUSE();
             } else {
-                // Extended idle: use I/O poller with short timeout instead of blind yield
-                int io_events = scheduler_io_poll(sched, 1);
+                // Extended idle. With descriptors registered the poller blocks
+                // for its timeout and that is the sleep. With none registered
+                // it returns immediately, which is what used to turn this
+                // branch into an unbounded spin (#1517): a program with no I/O
+                // pegged every core forever. Park on the condvar instead.
+                int io_events = scheduler_io_poll(sched, park_ms);
                 if (io_events > 0) {
-                    idle_count = 0;  // I/O activity — go back to active processing
+                    idle_count = 0;
+                    park_ms = PARK_MS_MIN;
+                } else if (sched->io_registered_count > 0) {
+                    // The poll above already blocked for park_ms.
+                    if (park_ms < PARK_MS_MAX) park_ms *= 2;
                 } else {
-                    aether_sched_yield();
-                    idle_count = 5000;
+                    pthread_mutex_lock(&sched->park_mutex);
+                    atomic_store_explicit(&sched->parked, 1, memory_order_release);
+                    // Publish `parked` BEFORE the last look at the queues. A
+                    // producer either sees parked==1 and signals, or its
+                    // enqueue happened before this check and is seen here.
+                    // Neither order sleeps on pending work.
+                    if (atomic_load_explicit(&sched->running, memory_order_acquire) &&
+                        !has_pending_cross_core(sched)) {
+                        struct timespec deadline;
+                        aether_park_deadline(&deadline, park_ms);
+                        pthread_cond_timedwait(&sched->park_cond,
+                                               &sched->park_mutex, &deadline);
+                    }
+                    atomic_store_explicit(&sched->parked, 0, memory_order_release);
+                    pthread_mutex_unlock(&sched->park_mutex);
+                    if (park_ms < PARK_MS_MAX) park_ms *= 2;
                 }
             }
         } else {
             idle_count = 0;
+            park_ms = PARK_MS_MIN;
             atomic_store_explicit(&sched->idle_cycles, 0, memory_order_relaxed);
         }
         
@@ -1025,6 +1088,10 @@ void scheduler_init(int cores) {
         // a NULL map that a non-zero capacity would let it index directly.
         schedulers[i].io_map_capacity = schedulers[i].io_map ? AETHER_IO_MAX_FDS : 0;
         schedulers[i].io_registered_count = 0;
+
+        pthread_mutex_init(&schedulers[i].park_mutex, NULL);
+        pthread_cond_init(&schedulers[i].park_cond, NULL);
+        atomic_store_explicit(&schedulers[i].parked, 0, memory_order_relaxed);
     }
 }
 
@@ -1093,6 +1160,14 @@ void scheduler_stop() {
         atomic_store_explicit(&schedulers[i].from_queues[MAX_CORES].tail,
                             atomic_load_explicit(&schedulers[i].from_queues[MAX_CORES].tail, memory_order_relaxed),
                             memory_order_release);
+    }
+
+    // And wake anyone parked on the condvar, or shutdown waits out their
+    // timeout for no reason (#1517).
+    for (int i = 0; i < num_cores; i++) {
+        pthread_mutex_lock(&schedulers[i].park_mutex);
+        pthread_cond_broadcast(&schedulers[i].park_cond);
+        pthread_mutex_unlock(&schedulers[i].park_mutex);
     }
 }
 
@@ -1693,6 +1768,7 @@ void scheduler_send_remote(ActorBase* actor, Message msg, int from_core) {
         if (queue_enqueue(&schedulers[target_core].from_queues[from_idx], actor, msg)) {
             atomic_fetch_add_explicit(&schedulers[target_core].work_count, 1,
                                        memory_order_relaxed);
+            sched_wake(&schedulers[target_core]);
             AETHER_STAT_INC(queue_sends);
             return;
         }
@@ -1715,6 +1791,7 @@ void scheduler_send_remote(ActorBase* actor, Message msg, int from_core) {
         AETHER_PAUSE();
     }
     atomic_fetch_add_explicit(&schedulers[target_core].work_count, 1, memory_order_relaxed);
+    sched_wake(&schedulers[target_core]);
     AETHER_STAT_INC(queue_sends);
 }
 

--- a/runtime/scheduler/multicore_scheduler.h
+++ b/runtime/scheduler/multicore_scheduler.h
@@ -145,6 +145,15 @@ typedef struct {
 
     AdaptiveBatchState batch_state;   // Adaptive batching (small, embedded)
 
+    // Idle park (#1517). A core with no work and nothing registered with the
+    // poller sleeps here instead of spinning. The sleeper sets `parked` and
+    // then re-checks its queues, so a producer that reads parked==0 has
+    // already made its message visible to that check. The wait is timed as
+    // well, so a path that never signals costs latency, never a hang.
+    pthread_mutex_t park_mutex;
+    pthread_cond_t  park_cond;
+    atomic_int      parked;
+
     // Per-core I/O event loop (platform-agnostic: epoll/kqueue/poll)
     AetherIoPoller io_poller;         // Platform I/O poller instance
     AetherIoEntry* io_map;            // fd → actor mapping (heap-allocated, grows on demand)

--- a/tests/regression/test_scheduler_idle_cpu.ae
+++ b/tests/regression/test_scheduler_idle_cpu.ae
@@ -18,7 +18,8 @@ import std.io
 import std.os
 import std.string
 
-extern usleep(us: int) -> int
+// sleep() is the Aether built-in, lowered to aether_sleep_ms, so this test
+// does not depend on usleep, which Windows does not have.
 extern clock() -> long
 
 message Tick { n: int }
@@ -48,10 +49,10 @@ main() {
     // Let the system settle past the deliberate 10000-iteration tight spin
     // before measuring, so this tests the deep-idle path and not the spin that
     // is there on purpose for latency.
-    usleep(300000)
+    sleep(300)
 
     start_cpu = clock()
-    usleep(2000000)
+    sleep(2000)
     used_us = clock() - start_cpu
 
     // CLOCKS_PER_SEC is 1000000 on Linux and macOS, so the delta is already

--- a/tests/regression/test_scheduler_idle_cpu.ae
+++ b/tests/regression/test_scheduler_idle_cpu.ae
@@ -1,0 +1,74 @@
+// #1517: an idle program must not burn CPU.
+//
+// The scheduler's extended-idle branch called scheduler_io_poll with a 1ms
+// timeout expecting it to block. With no descriptors registered that function
+// returns immediately, and the yield after it returns immediately too when no
+// other thread is runnable, so every scheduler thread spun forever. An idle
+// process pegged roughly one core per thread: the report that opened the issue
+// was a leftover binary at ~650% CPU for five days.
+//
+// clock() is process CPU time across all threads on POSIX, so comparing it
+// against wall time measures exactly the defect: 2 seconds of doing nothing
+// cost about 2s x cores of CPU before the fix and approximately none after.
+//
+// Skipped on Windows, where clock() returns wall time since process start
+// rather than CPU consumed, which would make the ratio meaningless.
+
+import std.io
+import std.os
+import std.string
+
+extern usleep(us: int) -> int
+extern clock() -> long
+
+message Tick { n: int }
+
+actor Worker {
+    receive {
+        Tick(n) -> {
+            // One message, then the whole system goes quiet. This is the state
+            // that used to spin: work has finished, nothing is registered with
+            // the poller, and nothing will arrive again.
+        }
+    }
+}
+
+main() {
+    println("=== scheduler idle CPU (#1517) ===")
+
+    if string.contains(os.platform(), "windows") == 1 {
+        println("SKIP: clock() measures wall time on Windows, not CPU")
+        println("All PASS")
+        return
+    }
+
+    w = spawn(Worker())
+    w ! Tick { n: 1 }
+
+    // Let the system settle past the deliberate 10000-iteration tight spin
+    // before measuring, so this tests the deep-idle path and not the spin that
+    // is there on purpose for latency.
+    usleep(300000)
+
+    start_cpu = clock()
+    usleep(2000000)
+    used_us = clock() - start_cpu
+
+    // CLOCKS_PER_SEC is 1000000 on Linux and macOS, so the delta is already
+    // microseconds of CPU. Two seconds of wall time on an idle system should
+    // cost single-digit milliseconds; the pre-fix behaviour was 2s per core,
+    // i.e. 2000000 or more with several cores running.
+    budget_us = 400000
+
+    println("cpu used while idle: ${used_us} us over 2000000 us of wall time")
+
+    if used_us < budget_us {
+        println("  PASS idle CPU is within budget")
+        println("")
+        println("All PASS")
+    } else {
+        println("  FAIL idle scheduler burned ${used_us} us of CPU, budget is ${budget_us}")
+        println("")
+        println("1 FAILURE(S)")
+    }
+}


### PR DESCRIPTION
## The bug

An idle Aether program never slept. Every scheduler thread spun, so an
otherwise-idle process pegged roughly one core per thread. Reproduced before
touching anything, with a program that sends one message and then waits four
seconds:

```
real 4.97   user 26.98   sys 0.40      # 5.5 cores, doing nothing
```

The mechanism is exactly as #1517 describes. The extended-idle branch calls
`scheduler_io_poll(sched, 1)` expecting a 1ms block, but that function returns
immediately when nothing is registered:

```c
static int scheduler_io_poll(Scheduler* sched, int timeout_ms) {
    if (sched->io_registered_count == 0) return 0;   // timeout_ms ignored
```

`aether_sched_yield()` then also returns immediately when no other thread is
runnable, and `idle_count = 5000` sends the thread back to tight spinning. No
path ever slept.

## The fix

Of the three directions the issue lists, this is the third: park on a condition
variable and wake on enqueue. The cheaper options were rejected because a plain
sleep puts its latency on **every** cross-core message, which is the wrong
trade for an actor runtime.

A core with no descriptors registered parks with a **timed** wait. Producers
call `sched_wake` on the target after enqueuing, so work arrives without waiting
out the timeout. The timeout bounds only a producer that never signals, which
downgrades a possible missed wakeup from a hang to bounded latency. Cores that
do have descriptors are untouched.

The park/enqueue race is closed on the sleeper's side: it sets `parked` and then
re-checks its queues under the mutex, so a producer that reads `parked == 0` has
already made its enqueue visible to that check. That ordering is what lets
`sched_wake` cost a single acquire load on a cacheline the producer just wrote.
An earlier version of this patch bumped a sequence counter on every send instead
and **measured 5% slower on ping-pong**, which is why it is not in the diff.

## Results

Idle CPU, 8-core M1 Pro, one message then two seconds of quiet:

| | CPU consumed |
|---|---:|
| before | 14,058,539 us (about 7 cores) |
| after | 5,661 us |

Throughput **improves**, because idle cores no longer compete with working ones
for the machine. Medians over repeated runs:

| benchmark | baseline | fixed | delta |
|---|---:|---:|---:|
| ping_pong | 11.70 M msg/s | 11.99 M msg/s | +2.5% (noise) |
| thread_ring | 20.56 M msg/s | 24.33 M msg/s | +18.3% |
| counting | 27.08 M msg/s | 77.76 M msg/s | +187% |
| fork_join | 23.5 ms | 19.5 ms | +16.9% faster |

`PARK_MS_MAX = 32` is set on measurement rather than taste. It bounds only how
long a core that could **steal** from a busy neighbour stays asleep, and it pays
that once before finding work and staying awake; a core handed work directly is
signalled. At 32ms an idle process uses 0.28% of one core, against 1.4% at 4ms,
and fork-join cannot tell the two apart.

## Test

`tests/regression/test_scheduler_idle_cpu.ae` compares process CPU time against
wall time while quiescent, using `clock()` so it needs no external tooling and
runs in the normal `.ae` suite on every platform.

```
against the old scheduler:  14058539 us of CPU for 2000000 us of wall  -> FAIL
after the fix:                  5661 us                                -> PASS
```

Skipped on Windows, where `clock()` returns wall time since process start rather
than CPU consumed, which would make the ratio meaningless.

## Verification

- `-Werror` build of compiler, `ae` and stdlib: zero warnings.
- 230/230 C unit tests; 89/89 examples.
- Full `.ae` suite: 978 passed, 8 failed, all in the known local-environment
  set (macOS `ld` rejecting the GNU-only `-Wl,--allow-multiple-definition`,
  gcov, sandbox-blocked interpreters, stale local version stamp, and `repl`,
  which fails identically without this change).
- Scheduler shutdown broadcasts to the condvar, so a parked thread does not
  delay exit by its timeout.

Closes #1517
