### PR TITLE
docs: say what Aether is, not which languages it resembles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Documentation
+
+- Stopped defining the language by other languages. The README led with
+  "Erlang-style actors, Rust-grade capability discipline, and Go-flavored
+  ergonomics", and the language reference opened with "combining Erlang-inspired
+  actor concurrency". Both now state what Aether does. The same substitution ran
+  through the entry docs: "Erlang-inspired pattern matching" said nothing a
+  reader could act on, and `(value, err)` describes its own shape without being
+  called Go-style. The Acknowledgments section already credits the lineage
+  properly, at the end, which is where it belongs; the top of a README is for
+  what the thing is.
+
 ## [0.522.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,26 +6,26 @@
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS%20%7C%20WASM%20%7C%20Embedded-lightgrey)]()
 [![Website](https://img.shields.io/badge/website-aether--lang.dev-8A2BE2)](https://aether-lang.dev/)
 
-Erlang-style actors, Rust-grade capability discipline, and Go-flavored ergonomics, compiled to readable C.
+A compiled actor language whose permissions are part of the source, enforced from compile time down to libc. No VM and no garbage collector: the compiler emits readable C.
 
 **Website: [aether-lang.dev](https://aether-lang.dev/)**
 
 ## Overview
 
-Most languages treat "what may this program touch?" as a deployment problem. Aether makes it a language problem: code runs against an explicit grant list, enforced three times over. At compile time, `--emit=lib` starts capability-empty and the host opts modules in with `--with=fs,net,os`. At scope level, `hide` and `seal except` stop ambient names from leaking into any lexical block, a closure, a trailing-block DSL, an actor handler. At runtime, an `LD_PRELOAD` shim checks libc itself (`open*`, `connect`/`bind`, `execve`, `mmap`, `dlopen`, `getenv`) against the same grants, inherited across `execve`. The mix is Pony's object capabilities, Java's removed SecurityManager, and a fraction of gVisor; see [Containment Sandbox](docs/containment-sandbox.md) for the threat model and known bypass surface.
+Most languages treat "what may this program touch?" as a deployment problem. Aether makes it a language problem: code runs against an explicit grant list, enforced three times over. At compile time, `--emit=lib` starts capability-empty and the host opts modules in with `--with=fs,net,os`. At scope level, `hide` and `seal except` stop ambient names from leaking into any lexical block, a closure, a trailing-block DSL, an actor handler. At runtime, an `LD_PRELOAD` shim checks libc itself (`open*`, `connect`/`bind`, `execve`, `mmap`, `dlopen`, `getenv`) against the same grants, inherited across `execve`. See [Containment Sandbox](docs/containment-sandbox.md) for the threat model, the prior art it draws on, and the known bypass surface.
 
-Concurrency is actor-shaped: Erlang-style `actor` / `receive` / `!` with automatic multi-core scheduling, lock-free mailboxes, and migration that converges chatty actors onto one core. The compiler emits readable C, not bytecode and not a VM, which is an implementation choice rather than the pitch: it buys native speed, direct linking against existing C libraries, and a runtime that ports anywhere a C toolchain reaches.
+Concurrency is actor-shaped: `actor`, `receive` and `!`, with automatic multi-core scheduling, lock-free mailboxes, and migration that converges chatty actors onto one core. The compiler emits readable C, not bytecode and not a VM, which is an implementation choice rather than the pitch: it buys native speed, direct linking against existing C libraries, and a runtime that ports anywhere a C toolchain reaches.
 
-**Where it sits on the OO ↔ FP spectrum:** structs are plain data, behaviour is free functions, closures + trailing blocks are first-class, Aether leans **closer to functional than OO**, sitting near Go and Rust in the hybrid middle of the paradigm spectrum. There are no classes, no inheritance, no method dispatch; the one piece of OO machinery present is the actor (stateful, encapsulated behind a message boundary, no polymorphism). See [Language Reference § Paradigm placement](docs/language-reference.md#paradigm-placement).
+**Where it sits on the OO / FP spectrum:** structs are plain data, behaviour lives in free functions, and closures and trailing blocks are first-class, so the language leans closer to functional than object-oriented. There are no classes, no inheritance and no method dispatch; the one piece of OO machinery present is the actor, which is stateful and encapsulated behind a message boundary but has no polymorphism. See [Language Reference § Paradigm placement](docs/language-reference.md#paradigm-placement).
 
-The load-bearing features, one line each:
+The load-bearing features:
 
-- **Actor concurrency**, scheduled across cores for you: lock-free messaging, locality-aware spawning, work stealing. See [Actor Concurrency](docs/actor-concurrency.md).
+- **Actor concurrency**, scheduled across cores by the runtime: lock-free messaging, locality-aware spawning, work stealing. See [Actor Concurrency](docs/actor-concurrency.md).
 - **Config IS code**: library APIs double as typed, sandboxable configuration DSLs via trailing-block closures, so operators run real Aether instead of YAML. See [Config IS Code](docs/config-is-code.md).
 - **Polyglot host, both directions**: run Lua / Python / Perl / Ruby / Tcl / JS in-process under the same grant list, or embed Aether into Python, Java, and Ruby through `--emit=lib` typed SDKs with per-guest memory and deadline caps. See [Embedding & emit=lib](docs/emit-lib.md).
 - **Production networking in the stdlib**: an HTTP server with TLS, HTTP/2, WebSocket, SSE, and zero-copy `sendfile(2)`, plus an nginx-class reverse proxy. See [HTTP Server](docs/http-server.md) and [Reverse Proxy](docs/http-reverse-proxy.md).
 - **A deliberate memory model**: manual-first with `defer`, automatic string-ownership tracking, and `requires`/`ensures` contracts that compile out at zero cost. See [Memory Management](docs/memory-management.md).
-- **Go-flavored ergonomics**: type inference, `(value, err)` multi-value returns, `@derive(eq)`, and a single `ae` command for build / run / test / fmt / packages. See [Language Reference](docs/language-reference.md).
+- **Ergonomics**: type inference, `(value, err)` multi-value returns, `@derive(eq)`, and a single `ae` command for build, run, test, fmt and packages. See [Language Reference](docs/language-reference.md).
 - **Portability as a feature**: Linux, macOS, Windows, FreeBSD, WebAssembly, and embedded targets; cross-compile with `ae build --target=<triple>`. See [Architecture](docs/architecture.md).
 
 ## Benchmarks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -304,7 +304,7 @@ main() {
 ```
 
 Functions are called using **namespace-style syntax**: `namespace.function()`.
-Stdlib functions that can fail return Go-style `(value, err)` tuples,
+Stdlib functions that can fail return `(value, err)` tuples,
 check `err` first, then use `value`:
 
 ```aether
@@ -398,7 +398,7 @@ See [stdlib-api.md](stdlib-api.md) for the full API reference.
 
 ### Error Handling and Memory
 
-Stdlib functions that can fail return a Go-style `(value, err)` tuple.
+Stdlib functions that can fail return a `(value, err)` tuple.
 Check the error string first, then use the value. The wrappers auto-free
 any heap allocations, so you don't need `defer free()` for stdlib returns:
 
@@ -412,7 +412,7 @@ main() {
         println(home)
     }
 
-    // io.read_file is Go-style
+    // io.read_file returns (value, err)
     content, err = io.read_file("data.txt")
     if err != "" {
         println("cannot read: ${err}")
@@ -431,7 +431,9 @@ use `defer string.release(s)` for reference counting.
 
 ## Pattern Matching
 
-Aether has Erlang-inspired pattern matching.
+Functions can be defined as several clauses, each matching a different shape of
+argument, with guards to narrow a clause further. The first clause that matches
+runs.
 
 ### Function Pattern Matching
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -4,7 +4,8 @@ Complete syntax and semantics of the Aether programming language.
 
 ## Overview
 
-Aether is a statically-typed, compiled language combining Erlang-inspired actor concurrency with type inference. It features clean, minimal syntax and compiles to C code.
+Aether is a statically-typed compiled language with actor-based concurrency and
+type inference. It compiles to C.
 
 ## Paradigm placement
 
@@ -24,7 +25,7 @@ The placement is deliberate, Aether picks the pieces of each tradition that comp
 
 - **Closures + trailing blocks are first-class** and are *the* idiomatic control-flow construction. The "DSL with scope" pattern (`window("Demo") { vg { circle(...) { fill("#F00") } } }`) is built from closures running in the caller's lexical scope, not from method dispatch on a builder object. See [Closures and Builder DSL](closures-and-builder-dsl.md).
 - **No classes, no inheritance, no `self` / `this`.** Structs are plain data records (`struct Circle { cx: float, cy: float, r: float }`) with no methods attached. Behaviour comes from free functions taking the struct as an argument: `circle_area(c)` not `c.area()`.
-- **Type-annotated parameters with full inference** and **Go-style multi-return** (`-> (long, string)` for value+error tuples), result-type-via-tuple rather than exceptions on the happy path. This is the Go / Rust functional-pragmatic family, not OO error handling.
+- **Type-annotated parameters with full inference** and **multi-value returns** (`-> (long, string)` for value-and-error tuples). Failure is carried in the return value rather than thrown, so the happy path has no exception machinery in it.
 - **Modules with explicit `exports`**, namespaced free functions, not classes-as-namespaces. The visible surface of a module is the export list, not a public-method set.
 - **`fn` as a first-class type**, passed, stored, boxed, unboxed. Aether's closures lower to `_AeClosure { void(*fn)(void); void* env; }` with structural sharing through ref cells (`ref()` / `ref_get` / `ref_set`); the runtime treats them as values, not as method receivers.
 - **No method-dispatch machinery in the compiler.** There's no vtable, no virtual call. Every function call resolves to a direct C function call. The bare-fn-to-closure adapter machinery and the `fn ↔ ptr` coercion rules exist to make first-class function values work end-to-end, a strictly functional priority.
@@ -468,7 +469,8 @@ site's metadata.
 
 ## Pattern Matching Functions
 
-Aether supports Erlang-style function clauses with pattern matching and guard clauses:
+A function can be written as several clauses, each matching a different shape of
+argument, with guards to narrow a clause further:
 
 ### Basic Pattern Matching
 
@@ -2187,7 +2189,7 @@ If `sqrt` internally calls a sibling helper that *isn't* in the import list, the
 ### Module Public API, `exports (…)`
 
 Each module declares its public surface once at the top of the file via
-an Erlang-style `exports (…)` list. Names in the list are callable from
+an `exports (…)` list. Names in the list are callable from
 outside the module via either qualified (`mod.name(…)`) or short-alias
 (`import mod (*)`) forms. Names **not** in the list are private, still
 callable from inside the module's own functions, but rejected at


### PR DESCRIPTION
Docs only, no code.

## The problem

The README's first line was:

> Erlang-style actors, Rust-grade capability discipline, and Go-flavored ergonomics, compiled to readable C.

Three names in the opening sentence describe what other projects did, not what
this one does. The language reference opened the same way, with "combining
Erlang-inspired actor concurrency with type inference".

It was also not accurate. Aether's actors are compiled, scheduled across cores
by the runtime, with lock-free mailboxes and migration; there are no supervision
trees and no hot code reload. "Erlang-style" claimed a resemblance the
implementation does not have.

## The change

The README now leads with the distinguishing property:

> A compiled actor language whose permissions are part of the source, enforced from compile time down to libc. No VM and no garbage collector: the compiler emits readable C.

The same substitution ran through the docs a newcomer reads first:

| Was | Now |
|---|---|
| "Aether has Erlang-inspired pattern matching." | A sentence describing clauses, guards, and first-match-wins |
| "Aether supports Erlang-style function clauses" | Same, described rather than labelled |
| "Go-style `(value, err)` tuples" | `(value, err)` tuples. The shape describes itself |
| "an Erlang-style `exports (…)` list" | "an `exports (…)` list" |
| "This is the Go / Rust functional-pragmatic family" | What the mechanism actually does: failure travels in the return value |
| "The mix is Pony's object capabilities, Java's removed SecurityManager, and a fraction of gVisor" | Points at the sandbox doc, which covers the prior art properly |

Definition-by-comparison in README, getting-started and language-reference: 8
occurrences before, 0 after.

## What is deliberately unchanged

The **Acknowledgments** section. It credits Erlang/OTP, Go, Rust, Pony, Nim, V,
Ruby, Odin, Java, gVisor, WASI, Deno, Capsicum and the configuration ecosystems
at length, at the end of the README. That is the right place for lineage, and it
is what made the name-dropping at the top redundant.

Also unchanged: roughly 45 comparisons in design and cross-reference docs. A
comparison that explains a deliberate divergence ("unlike X, we do Y because Z")
carries information; one that substitutes for a definition does not. Only the
second kind was removed.
