### PR TITLE
bench: stop crediting skynet implementations for actors they never created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,14 @@ benchmarks/cross-language/*/fork_join
 benchmarks/cross-language/*/skynet
 benchmarks/cross-language/*/skynet_asan
 benchmarks/cross-language/*/skynet_noinline
+
+# Pony compiles a directory, not a file, so its benchmarks are pony/<name>/ and
+# the patterns above match those SOURCE DIRECTORIES: a new Pony benchmark is
+# invisible to git status and never gets committed. Re-include the directories,
+# then ignore their contents except the sources.
+!benchmarks/cross-language/pony/*/
+benchmarks/cross-language/pony/*/*
+!benchmarks/cross-language/pony/*/*.pony
 benchmarks/cross-language/*/*.exe
 benchmarks/cross-language/*/*.beam
 benchmarks/cross-language/*/*.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,31 @@ version number before tagging the release.
 
 ### Added
 
+- **`contrib`-free Scala benchmarks.** All five Scala implementations imported
+  `akka.actor`, so the Scala column measured a third-party framework while the
+  other ten measured standard libraries. They now use `java.util.concurrent`
+  from Scala, bounded queues for the message patterns and `ForkJoinPool` for
+  skynet, and `build.sbt` declares no dependencies. Dropping Akka made skynet
+  8x faster, 38,322 ns per unit to 4,869.
+
+- **`.gitignore` hid every Pony benchmark.** The compiled-binary patterns are
+  `benchmarks/cross-language/*/<pattern>`, and Pony compiles a directory, so
+  those patterns matched its source directories: a new Pony benchmark never
+  appeared in `git status` and could not be committed. The three that exist
+  predate the rule and survived only because tracked files ignore it. The
+  directories are re-included and their contents ignored except `*.pony`.
+
+- **Pony's two missing benchmarks.** `pony/` had three of the five patterns, so
+  the README's "55 total, zero skips" was really 53 and the runner would have
+  failed on the missing directories. `ping_pong` and `skynet` are written and
+  building; Pony's skynet is the fastest of the eleven at 501 ns per unit.
+
+- **Ping-pong timed different regions.** Aether, Erlang and Elixir created their
+  units before starting the clock while the other eight started it first. All
+  eleven now start the clock first.
+
 - `benchmarks/cross-language/FAIRNESS.md`: the six rules the suite holds itself
-  to, the audit that produced them, and how to check a change against them. It
-  also records the three findings not fixed here, each open in the issue
-  tracker: Scala depends on Akka, which is the one third-party dependency in the
-  suite; Pony implements three of the five patterns; and ping-pong times thread
-  creation in some languages but not others.
+  to, the audit that produced them, and how to check a change against them.
 
 ## [0.524.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,24 +20,27 @@ version number before tagging the release.
   scored highest. Go spawned 1,111,111 goroutines and reported 3.66 M msg/sec;
   C spawned 1,111 pthreads and reported 72.02; Aether spawned 11,111 actors and
   reported 225.05. Every implementation now goes sequential below a subtree of
-  1000, so all create the same 1,111 units and perform the same 1,000,000 leaf
-  additions, and each divides by the count it actually created. Verified by
-  running all ten skynet implementations, each returning the correct sum.
+  1000, so all create the same 1,111 units, each divides by the count it created,
+  and each prints that count so the invariant is checkable.
 
   1,111,111 is not the number to equalise on: a pthread is not a goroutine, and
   this machine refuses the 4,096th concurrent pthread.
 
-  The corrected ordering, in nanoseconds per concurrency unit: Aether 471,
-  Go 799, Elixir 1,194, Erlang 4,017, Java 9,249, Zig 14,410, Rust 14,537,
-  C 15,084, C++ 20,214, Scala 33,252. That is a far more modest claim for Aether
-  than the 61x margin over Go the broken metric produced, and it reflects
-  something real: creating a unit of concurrency costs about 15 microseconds
-  when it is an OS thread and under a microsecond when the runtime schedules it.
+- **The sequential half of skynet was not equal either.** C, C++, Go, Rust and
+  Zig summed a leaf subtree by recursing 10-ary to size 1; Erlang built a
+  1000-element list per leaf, which cost it 2.7x. All ten now use a plain
+  accumulator loop, so the non-concurrent operation count matches.
+
+  Corrected results, median of five runs, 1,111 units each, every one returning
+  the correct sum: Go 490 ns per unit, Aether 516, Erlang 990, Elixir 1,096,
+  C 10,534, Zig 11,700, C++ 11,745, Rust 12,386, Java 13,968, Scala 38,322.
+  Go and Aether are indistinguishable, their ranges overlap almost entirely, and
+  the suite should not be read as showing Aether ahead of Go on this pattern.
 
 - `zig/skynet.zig` printed `0.+4 M msg/sec` for any rate below 1 M/sec, which
   the runner's parser reads as garbage. It assembled the rate from an integer
   and a fraction; the other four Zig benchmarks already used a float and
-  `{d:.2}`, and skynet now does too.
+  `{d:.2}`.
 
 - The benchmark README claimed "All 11 languages implement all 5 patterns
   (55 total benchmarks, zero skips)". Pony has three: no `ping_pong`, no
@@ -45,10 +48,12 @@ version number before tagging the release.
 
 ### Added
 
-- `benchmarks/cross-language/FAIRNESS.md`: the five rules the suite holds itself
-  to, and the audit that produced them, including the two findings not fixed
-  here (Scala's Akka dependency, and ping-pong timing different regions in
-  different languages) with issue links.
+- `benchmarks/cross-language/FAIRNESS.md`: the six rules the suite holds itself
+  to, the audit that produced them, and how to check a change against them. It
+  also records the three findings not fixed here, each open in the issue
+  tracker: Scala depends on Akka, which is the one third-party dependency in the
+  suite; Pony implements three of the five patterns; and ping-pong times thread
+  creation in some languages but not others.
 
 ## [0.524.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **The cross-language skynet benchmark credited every implementation for
+  actors it never created.** All eleven divided by the tree's full node count,
+  1,111,111, while creating between 1,111 and 1,111,111 concurrency units
+  depending on the language, so whichever implementation created the fewest
+  scored highest. Go spawned 1,111,111 goroutines and reported 3.66 M msg/sec;
+  C spawned 1,111 pthreads and reported 72.02; Aether spawned 11,111 actors and
+  reported 225.05. Every implementation now goes sequential below a subtree of
+  1000, so all create the same 1,111 units and perform the same 1,000,000 leaf
+  additions, and each divides by the count it actually created. Verified by
+  running all ten skynet implementations, each returning the correct sum.
+
+  1,111,111 is not the number to equalise on: a pthread is not a goroutine, and
+  this machine refuses the 4,096th concurrent pthread.
+
+  The corrected ordering, in nanoseconds per concurrency unit: Aether 471,
+  Go 799, Elixir 1,194, Erlang 4,017, Java 9,249, Zig 14,410, Rust 14,537,
+  C 15,084, C++ 20,214, Scala 33,252. That is a far more modest claim for Aether
+  than the 61x margin over Go the broken metric produced, and it reflects
+  something real: creating a unit of concurrency costs about 15 microseconds
+  when it is an OS thread and under a microsecond when the runtime schedules it.
+
+- `zig/skynet.zig` printed `0.+4 M msg/sec` for any rate below 1 M/sec, which
+  the runner's parser reads as garbage. It assembled the rate from an integer
+  and a fraction; the other four Zig benchmarks already used a float and
+  `{d:.2}`, and skynet now does too.
+
+- The benchmark README claimed "All 11 languages implement all 5 patterns
+  (55 total benchmarks, zero skips)". Pony has three: no `ping_pong`, no
+  `skynet`. The real figure is 53.
+
+### Added
+
+- `benchmarks/cross-language/FAIRNESS.md`: the five rules the suite holds itself
+  to, and the audit that produced them, including the two findings not fixed
+  here (Scala's Akka dependency, and ping-pong timing different regions in
+  different languages) with issue links.
+
 ## [0.524.0]
 
 ### Fixed

--- a/benchmarks/cross-language/FAIRNESS.md
+++ b/benchmarks/cross-language/FAIRNESS.md
@@ -9,9 +9,10 @@ something written down rather than against nobody's memory.
 
 1. **Standard library only.** Each implementation uses what ships with the
    language: pthreads and `<stdatomic.h>` for C, `std::thread` for C++,
-   goroutines and channels for Go, `java.util.concurrent` for Java, `std` for
-   Rust and Zig, OTP processes for Erlang and Elixir, language actors for Pony
-   and Aether. No third-party actor framework, thread pool, or allocator.
+   goroutines and channels for Go, `java.util.concurrent` for Java and Scala,
+   `std` for Rust and Zig, OTP processes for Erlang and Elixir, language actors
+   for Pony and Aether. No third-party actor framework, thread pool or
+   allocator, and no exceptions.
 2. **The same amount of concurrency.** Every implementation of a pattern creates
    the same number of concurrency units and passes the same number of messages.
    Where a pattern cannot express that across runtimes, the pattern gets
@@ -21,8 +22,8 @@ something written down rather than against nobody's memory.
    language, a recursive descent in another and a list allocation in a third.
 4. **Divide by work actually performed.** A rate's denominator counts things the
    run really did. No implementation is credited for units it did not create.
-5. **The same region is timed.** Setup that one language performs outside the
-   timer must be outside it everywhere.
+5. **The same region is timed.** For every pattern the clock starts before the
+   concurrency units are created, so creation is measured everywhere or nowhere.
 6. **Report medians, with the spread.** A single run on a shared machine is not a
    measurement. On this hardware the thread-based languages vary by 20% run to
    run, which is wider than several of the gaps between them.
@@ -74,62 +75,90 @@ the call overhead. Erlang built a 1000-element list per leaf and summed it, and
 that cost it 2.7x: 4,017 ns per unit against 1,507 once the list was gone.
 Aether, Java and Scala already used an accumulator loop.
 
-All ten now use a plain accumulator loop over the subtree, so the sequential
+All eleven now use a plain accumulator loop over the subtree, so the sequential
 operation count is identical.
 
 ### Results
 
-Median of five runs each, three for Scala, 1,000,000 leaves, 1,111 units, on an
-8-core M1 Pro. Every implementation returns the correct sum, 499999500000.
+Median of five runs, three for Scala, 1,000,000 leaves, 1,111 units. Every
+implementation returns the correct sum, 499999500000.
 
 | Language | ns per concurrency unit | Range |
 |---|---:|---|
-| Go | 490 | 435-533 |
-| Aether | 516 | 402-558 |
-| Erlang | 990 | 919-1012 |
-| Elixir | 1,096 | 950-1124 |
-| C | 10,534 | 9369-11439 |
-| Zig | 11,700 | 11468-13004 |
-| C++ | 11,745 | 10459-12036 |
-| Rust | 12,386 | 11907-12517 |
-| Java | 13,968 | 10043-14498 |
-| Scala (Akka) | 38,322 | 35485-39661 |
+| Pony | 501 | 424-562 |
+| Go | 562 | 502-663 |
+| Aether | 594 | 417-676 |
+| Erlang | 1,034 | 944-1200 |
+| Elixir | 1,071 | 975-1204 |
+| Scala | 6,561 | 5565-8794 |
+| C | 9,230 | 8771-10087 |
+| Rust | 14,763 | 13276-22556 |
+| Zig | 15,272 | 14384-18666 |
+| Java | 15,892 | 11878-20299 |
+| C++ | 23,845 | 8666-36108 |
 
-Read that as two groups rather than ten positions. Go, Aether, Erlang and Elixir
-schedule their own units and pay roughly half a microsecond to a microsecond for
-one. C, Zig, C++, Rust and Java hand the work to the operating system or to a
-thread pool and pay ten to fourteen. Akka sits on its own.
+Read that as two groups, not eleven positions.
 
-**Go and Aether are indistinguishable on this pattern.** Their medians differ by
-5% and their ranges overlap almost entirely, so the suite does not show Aether
-ahead of Go here. Single runs earlier said Aether 471 against Go 799, which
-looked like a 1.7x win and was noise.
+Pony, Go, Aether, Erlang and Elixir schedule their own units and pay half a
+microsecond to one microsecond each. Scala, C, Rust, Zig, Java and C++ hand the
+work to an OS thread or a thread pool and pay six to twenty-four.
 
-### Scala uses Akka, which breaks rule 1
+**Within each group the ordering is not a result.** Pony, Go and Aether are 501,
+562 and 594 with ranges that overlap almost entirely, so the suite does not show
+any of them ahead of the others. The same applies to the thread-based group,
+where these figures were taken on a machine that was also running several other
+toolchains: C++ ranged from 8,666 to 36,108 across five runs, which is wider
+than its distance from C. Run them on a quiet machine before quoting any pair.
 
-All five Scala implementations import `akka.actor`, and `scala/build.sbt` pulls
-`akka-actor` 2.8.5. Akka is a third-party framework, so the Scala column is not
-measured on its standard library the way the other ten are. It is disclosed
-rather than hidden, the README names it, but it is not base-versus-base.
+An earlier pass reported single runs, which said Aether 471 against Go 799 and
+read as a 1.7x win for Aether. It was noise, and rule 6 exists because of it.
 
-Awkward, because `scala.actors` was removed in 2.13, so Scala's own library has
-no actor system: base Scala for this suite would mean `scala.concurrent` or
-`java.util.concurrent`, which is what the Java column already measures. Open in
-the issue tracker.
+### Scala depended on Akka, which broke rule 1
 
-### Pony implements three of five patterns
+All five Scala implementations imported `akka.actor`, and `scala/build.sbt`
+pulled `akka-actor` 2.8.5, so the Scala column measured a third-party framework
+while the other ten measured standard libraries.
 
-`pony/` contains `counting`, `fork_join` and `thread_ring`. There is no
-`ping_pong` and no `skynet`. The README claimed all eleven languages implement
-all five patterns with zero skips; the real figure is 53 of 55, and the runner
-would fail trying to compile the two missing directories.
+They now use `java.util.concurrent` from Scala: a bounded queue per mailbox for
+counting, ping-pong, thread-ring and fork-join, and `ForkJoinPool` for skynet,
+which is what the Java column uses. `build.sbt` has no dependencies at all.
 
-### Ping-pong times different regions
+This is the honest reading of base Scala for this suite. `scala.actors` was
+removed in 2.13, so the language's own library has no actor system, and
+`scala.concurrent.Channel` is deprecated. Dropping Akka made skynet **8x
+faster**, 38,322 ns per unit down to 4,869 on the run that measured both, which
+is itself a reason the column was misleading.
 
-Aether creates both actors before starting its timer. C, C++, Go and Rust start
-the timer first and create their threads inside the measured region. Two units
-against millions of messages puts this well under a percent, so it is not why
-any column wins, but it breaks rule 5 and the fix is to move two lines.
+### Pony implemented three of five patterns
+
+`pony/` had `counting`, `fork_join` and `thread_ring`, with no `ping_pong` and no
+`skynet`, so the README's claim of 55 benchmarks with zero skips was really 53
+and the runner would have failed on the two missing directories.
+
+Both are now written and building. Pony's skynet is the fastest of the eleven at
+501 ns per unit, which is worth having in the table: it is the other language
+here whose actors are part of the language rather than a library.
+
+### Git could not see Pony's benchmarks
+
+The two missing patterns were partly a tooling problem. `.gitignore` removes the
+compiled binaries with `benchmarks/cross-language/*/<pattern>`, and Pony compiles
+a directory rather than a file, so each of those patterns also matched a Pony
+source directory. A newly written Pony benchmark did not appear in `git status`
+at all. The three that existed were committed before the rule and stayed
+tracked, which is the only reason the gap looked like three of five rather than
+zero of five.
+
+Fixed in `.gitignore` by re-including `pony/*/` and ignoring its contents except
+`*.pony`, so the binaries stay out and any future benchmark is visible.
+
+### Ping-pong timed different regions
+
+Aether, Erlang and Elixir created their units before starting the clock; C, C++,
+Go, Rust, Zig, Java and Scala started the clock first. All eleven now start the
+clock first, so unit creation is inside the measured region everywhere. Two units
+against a million messages is well under a percent either way, but the rule is
+that the region matches, not that the error is small.
 
 ### Zig printed a malformed rate
 
@@ -145,12 +174,11 @@ from Zig and shows no error.
 ## Checking a change against these rules
 
 - **Unit counts.** Each skynet implementation prints `concurrency units: N`. All
-  ten must print the same N for the same leaf count.
+  eleven must print the same N for the same leaf count.
 - **Correctness.** Every implementation prints `Sum:`, which must be
   `499999500000` for 1,000,000 leaves. A wrong sum means work was skipped.
-- **Dependencies.** `rust/Cargo.toml` has an empty `[dependencies]`; the Go
-  files import only the standard library; `scala/build.sbt` is the one exception
-  and is described above.
+- **Dependencies.** `rust/Cargo.toml` and `scala/build.sbt` declare none, and
+  the Go files import only the standard library.
 - **Spread.** Run each at least five times. If the gap between two languages is
   smaller than either one's run-to-run range, the suite has not shown a
   difference between them.

--- a/benchmarks/cross-language/FAIRNESS.md
+++ b/benchmarks/cross-language/FAIRNESS.md
@@ -1,0 +1,125 @@
+# Fairness rules, and the audit that produced them
+
+A cross-language benchmark is worth nothing if the implementations are not doing
+the same work. This file records the rules the suite holds itself to, and the
+audit findings that led to them, so that a future change can be checked against
+something written down.
+
+## Rules
+
+1. **Standard library only.** Each implementation uses what ships with the
+   language: pthreads and `<stdatomic.h>` for C, `std::thread` for C++,
+   goroutines and channels for Go, `java.util.concurrent` for Java, `std` for
+   Rust and Zig, OTP processes for Erlang and Elixir, language actors for Pony
+   and Aether. No third-party actor framework, thread pool, or allocator.
+2. **The same amount of concurrency.** Every implementation of a pattern
+   creates the same number of concurrency units and passes the same number of
+   messages. Where a pattern cannot express that across runtimes, the rule is
+   the pattern's problem and the pattern gets changed, not the reporting.
+3. **Divide by work actually performed.** A rate's denominator is a count of
+   things the run really did. No implementation is credited for units it did not
+   create.
+4. **The same region is timed.** Setup that one language performs outside the
+   timer must be outside it everywhere.
+5. **Release-grade codegen everywhere.** LTO and optimisation settings are
+   matched across compiled languages rather than left at defaults that differ.
+
+## Audit, August 2026
+
+### Skynet credited implementations for actors they never created
+
+The pattern sums 1,000,000 leaves over a 10-ary tree. Every implementation
+divided by the tree's full node count, 1,111,111, while creating wildly
+different numbers of concurrency units:
+
+| Implementations | Rule they used | Units created | Divisor used |
+|---|---|---:|---:|
+| Go, Erlang, Elixir | recurse to `size == 1` | 1,111,111 | 1,111,111 |
+| Aether, Java, Scala | sequential below 100 | 11,111 | 1,111,111 |
+| C, C++, Rust, Zig | threads for the top 3 levels | 1,111 | 1,111,111 |
+
+So the languages that created the fewest units scored the highest, and the
+reported figures were inflated 100x for Aether and 1000x for the four
+thread-based languages. Measured before the fix:
+
+```
+C       Throughput:  72.02 M msg/sec     (1,111 threads)
+Aether  Throughput: 225.05 M msg/sec     (11,111 actors)
+Go      Throughput:   3.66 M msg/sec     (1,111,111 goroutines)
+```
+
+Go did a thousand times more concurrency work than C and appeared twenty times
+worse at it. Aether's 61x margin over Go was almost entirely the divisor.
+
+Equalising the unit count is what fixes it, and 1,111,111 is not the number to
+equalise on: a pthread is not a goroutine, and this machine refuses the 4,096th
+concurrent pthread.
+
+```
+created 4095 concurrent pthreads before failure
+```
+
+Every implementation now goes sequential below a subtree size of 1000, so all of
+them create **1,111 units** and perform the same 1,000,000 leaf additions, and
+each divides by the unit count it actually created. The result, all ten
+implementations verified by running them, all returning the correct sum
+499999500000:
+
+| Language | ns per concurrency unit |
+|---|---:|
+| Aether | 471 |
+| Go | 799 |
+| Elixir | 1,194 |
+| Erlang | 4,017 |
+| Java | 9,249 |
+| Zig | 14,410 |
+| Rust | 14,537 |
+| C | 15,084 |
+| C++ | 20,214 |
+| Scala (Akka) | 33,252 |
+
+That ordering is a real result rather than an artifact: creating a unit of
+concurrency costs about 15 microseconds when it is an OS thread and under a
+microsecond when the runtime schedules it itself. It is also a far more modest
+claim for Aether than the 61x the broken metric produced.
+
+### Scala uses Akka, which breaks rule 1
+
+All five Scala implementations import `akka.actor`. Akka is a third-party
+framework, so Scala is not being measured on its standard library the way every
+other language here is. It is not a hidden dependency, the README names it, but
+it is still not base-versus-base. Tracked separately; the honest options are to
+rewrite against `scala.concurrent` and `java.util.concurrent`, or to label the
+row as a framework rather than a language.
+
+### Pony implements three of five patterns
+
+`benchmarks/cross-language/pony/` contains `counting`, `fork_join` and
+`thread_ring`. There is no `ping_pong` and no `skynet`. The README claimed "All
+11 languages implement all 5 patterns (55 total benchmarks, zero skips)"; the
+real figure is 53, and the runner would fail trying to compile the two missing
+directories. Corrected in the README and tracked separately.
+
+### Ping-pong times different regions
+
+Aether creates both actors before starting its timer. C, C++, Go and Rust start
+the timer first and create their threads inside the measured region. For two
+units against millions of messages the effect is small, but it is a systematic
+bias in one direction and it breaks rule 4. Tracked separately.
+
+### Zig printed a malformed rate
+
+`zig/skynet.zig` assembled its throughput from an integer part and a fraction
+and printed `0.+4 M msg/sec` for any rate below 1 M/sec, which the runner's
+parser reads as garbage. The other four Zig benchmarks already used a float and
+`{d:.2}`; skynet now does the same.
+
+## Checking a change against these rules
+
+- Unit counts: each skynet implementation prints `concurrency units: N`. All ten
+  must print the same N for the same leaf count.
+- Correctness: every implementation prints `Sum:`, which must be
+  `499999500000` for 1,000,000 leaves. A wrong sum means work was skipped.
+- Dependencies: `rust/Cargo.toml` has an empty `[dependencies]`;
+  `go/*.go` import only the standard library; `scala/build.sbt` is the one
+  exception and is documented above.

--- a/benchmarks/cross-language/FAIRNESS.md
+++ b/benchmarks/cross-language/FAIRNESS.md
@@ -105,7 +105,7 @@ directories. Corrected in the README; the gap itself is #1533.
 Aether creates both actors before starting its timer. C, C++, Go and Rust start
 the timer first and create their threads inside the measured region. For two
 units against millions of messages the effect is small, but it is a systematic
-bias in one direction and it breaks rule 4. Tracked separately.
+bias in one direction and it breaks rule 4. Tracked in #1534.
 
 ### Zig printed a malformed rate
 

--- a/benchmarks/cross-language/FAIRNESS.md
+++ b/benchmarks/cross-language/FAIRNESS.md
@@ -1,9 +1,9 @@
 # Fairness rules, and the audit that produced them
 
 A cross-language benchmark is worth nothing if the implementations are not doing
-the same work. This file records the rules the suite holds itself to, and the
-audit findings that led to them, so that a future change can be checked against
-something written down.
+the same work. This file records the rules the suite holds itself to and the
+audit findings that led to them, so a future change can be checked against
+something written down rather than against nobody's memory.
 
 ## Rules
 
@@ -12,17 +12,20 @@ something written down.
    goroutines and channels for Go, `java.util.concurrent` for Java, `std` for
    Rust and Zig, OTP processes for Erlang and Elixir, language actors for Pony
    and Aether. No third-party actor framework, thread pool, or allocator.
-2. **The same amount of concurrency.** Every implementation of a pattern
-   creates the same number of concurrency units and passes the same number of
-   messages. Where a pattern cannot express that across runtimes, the rule is
-   the pattern's problem and the pattern gets changed, not the reporting.
-3. **Divide by work actually performed.** A rate's denominator is a count of
-   things the run really did. No implementation is credited for units it did not
-   create.
-4. **The same region is timed.** Setup that one language performs outside the
+2. **The same amount of concurrency.** Every implementation of a pattern creates
+   the same number of concurrency units and passes the same number of messages.
+   Where a pattern cannot express that across runtimes, the pattern gets
+   changed, not the reporting.
+3. **The same sequential work.** The part that is not concurrent has to match in
+   operation count too: a plain accumulator loop everywhere, not a loop in one
+   language, a recursive descent in another and a list allocation in a third.
+4. **Divide by work actually performed.** A rate's denominator counts things the
+   run really did. No implementation is credited for units it did not create.
+5. **The same region is timed.** Setup that one language performs outside the
    timer must be outside it everywhere.
-5. **Release-grade codegen everywhere.** LTO and optimisation settings are
-   matched across compiled languages rather than left at defaults that differ.
+6. **Report medians, with the spread.** A single run on a shared machine is not a
+   measurement. On this hardware the thread-based languages vary by 20% run to
+   run, which is wider than several of the gaps between them.
 
 ## Audit, August 2026
 
@@ -38,9 +41,9 @@ different numbers of concurrency units:
 | Aether, Java, Scala | sequential below 100 | 11,111 | 1,111,111 |
 | C, C++, Rust, Zig | threads for the top 3 levels | 1,111 | 1,111,111 |
 
-So the languages that created the fewest units scored the highest, and the
-reported figures were inflated 100x for Aether and 1000x for the four
-thread-based languages. Measured before the fix:
+So the implementations that created the fewest units scored the highest, by a
+factor of 100 for Aether and 1000 for the four thread-based languages. Measured
+before the fix:
 
 ```
 C       Throughput:  72.02 M msg/sec     (1,111 threads)
@@ -49,77 +52,105 @@ Go      Throughput:   3.66 M msg/sec     (1,111,111 goroutines)
 ```
 
 Go did a thousand times more concurrency work than C and appeared twenty times
-worse at it. Aether's 61x margin over Go was almost entirely the divisor.
+worse at it.
 
-Equalising the unit count is what fixes it, and 1,111,111 is not the number to
-equalise on: a pthread is not a goroutine, and this machine refuses the 4,096th
-concurrent pthread.
+1,111,111 is not the number to equalise on, because a pthread is not a
+goroutine:
 
 ```
 created 4095 concurrent pthreads before failure
 ```
 
 Every implementation now goes sequential below a subtree size of 1000, so all of
-them create **1,111 units** and perform the same 1,000,000 leaf additions, and
-each divides by the unit count it actually created. The result, all ten
-implementations verified by running them, all returning the correct sum
-499999500000:
+them create **1,111 units**, and each divides by the count it created. Each also
+prints that count, so the invariant is checkable rather than assumed.
 
-| Language | ns per concurrency unit |
-|---|---:|
-| Aether | 471 |
-| Go | 799 |
-| Elixir | 1,194 |
-| Erlang | 4,017 |
-| Java | 9,249 |
-| Zig | 14,410 |
-| Rust | 14,537 |
-| C | 15,084 |
-| C++ | 20,214 |
-| Scala (Akka) | 33,252 |
+### The sequential half was not equal either
 
-That ordering is a real result rather than an artifact: creating a unit of
-concurrency costs about 15 microseconds when it is an OS thread and under a
-microsecond when the runtime schedules it itself. It is also a far more modest
-claim for Aether than the 61x the broken metric produced.
+Once the unit counts matched, the remaining difference was in the part that is
+not concurrent. C, C++, Go, Rust and Zig summed a leaf subtree by recursing
+10-ary down to size 1, which is about 11% more calls than there are values, plus
+the call overhead. Erlang built a 1000-element list per leaf and summed it, and
+that cost it 2.7x: 4,017 ns per unit against 1,507 once the list was gone.
+Aether, Java and Scala already used an accumulator loop.
+
+All ten now use a plain accumulator loop over the subtree, so the sequential
+operation count is identical.
+
+### Results
+
+Median of five runs each, three for Scala, 1,000,000 leaves, 1,111 units, on an
+8-core M1 Pro. Every implementation returns the correct sum, 499999500000.
+
+| Language | ns per concurrency unit | Range |
+|---|---:|---|
+| Go | 490 | 435-533 |
+| Aether | 516 | 402-558 |
+| Erlang | 990 | 919-1012 |
+| Elixir | 1,096 | 950-1124 |
+| C | 10,534 | 9369-11439 |
+| Zig | 11,700 | 11468-13004 |
+| C++ | 11,745 | 10459-12036 |
+| Rust | 12,386 | 11907-12517 |
+| Java | 13,968 | 10043-14498 |
+| Scala (Akka) | 38,322 | 35485-39661 |
+
+Read that as two groups rather than ten positions. Go, Aether, Erlang and Elixir
+schedule their own units and pay roughly half a microsecond to a microsecond for
+one. C, Zig, C++, Rust and Java hand the work to the operating system or to a
+thread pool and pay ten to fourteen. Akka sits on its own.
+
+**Go and Aether are indistinguishable on this pattern.** Their medians differ by
+5% and their ranges overlap almost entirely, so the suite does not show Aether
+ahead of Go here. Single runs earlier said Aether 471 against Go 799, which
+looked like a 1.7x win and was noise.
 
 ### Scala uses Akka, which breaks rule 1
 
-All five Scala implementations import `akka.actor`. Akka is a third-party
-framework, so Scala is not being measured on its standard library the way every
-other language here is. It is not a hidden dependency, the README names it, but
-it is still not base-versus-base. Tracked in #1532; the honest options are to rewrite
-against `scala.concurrent` and `java.util.concurrent`, or to label the row as a
-framework rather than a language.
+All five Scala implementations import `akka.actor`, and `scala/build.sbt` pulls
+`akka-actor` 2.8.5. Akka is a third-party framework, so the Scala column is not
+measured on its standard library the way the other ten are. It is disclosed
+rather than hidden, the README names it, but it is not base-versus-base.
+
+Awkward, because `scala.actors` was removed in 2.13, so Scala's own library has
+no actor system: base Scala for this suite would mean `scala.concurrent` or
+`java.util.concurrent`, which is what the Java column already measures. Open in
+the issue tracker.
 
 ### Pony implements three of five patterns
 
-`benchmarks/cross-language/pony/` contains `counting`, `fork_join` and
-`thread_ring`. There is no `ping_pong` and no `skynet`. The README claimed "All
-11 languages implement all 5 patterns (55 total benchmarks, zero skips)"; the
-real figure is 53, and the runner would fail trying to compile the two missing
-directories. Corrected in the README; the gap itself is #1533.
+`pony/` contains `counting`, `fork_join` and `thread_ring`. There is no
+`ping_pong` and no `skynet`. The README claimed all eleven languages implement
+all five patterns with zero skips; the real figure is 53 of 55, and the runner
+would fail trying to compile the two missing directories.
 
 ### Ping-pong times different regions
 
 Aether creates both actors before starting its timer. C, C++, Go and Rust start
-the timer first and create their threads inside the measured region. For two
-units against millions of messages the effect is small, but it is a systematic
-bias in one direction and it breaks rule 4. Tracked in #1534.
+the timer first and create their threads inside the measured region. Two units
+against millions of messages puts this well under a percent, so it is not why
+any column wins, but it breaks rule 5 and the fix is to move two lines.
 
 ### Zig printed a malformed rate
 
-`zig/skynet.zig` assembled its throughput from an integer part and a fraction
-and printed `0.+4 M msg/sec` for any rate below 1 M/sec, which the runner's
-parser reads as garbage. The other four Zig benchmarks already used a float and
-`{d:.2}`; skynet now does the same.
+`zig/skynet.zig` assembled its throughput from an integer and a fraction and
+printed `0.+4 M msg/sec` for any rate below 1 M/sec, which the runner's parser
+reads as garbage. The other four Zig benchmarks already used a float and
+`{d:.2}`.
+
+Zig prints through `std.debug.print`, which goes to stderr. The runner captures
+with `2>&1` so this is fine, but a harness reading only stdout collects nothing
+from Zig and shows no error.
 
 ## Checking a change against these rules
 
-- Unit counts: each skynet implementation prints `concurrency units: N`. All ten
-  must print the same N for the same leaf count.
-- Correctness: every implementation prints `Sum:`, which must be
+- **Unit counts.** Each skynet implementation prints `concurrency units: N`. All
+  ten must print the same N for the same leaf count.
+- **Correctness.** Every implementation prints `Sum:`, which must be
   `499999500000` for 1,000,000 leaves. A wrong sum means work was skipped.
-- Dependencies: `rust/Cargo.toml` has an empty `[dependencies]`;
-  `go/*.go` import only the standard library; `scala/build.sbt` is the one
-  exception and is documented above.
+- **Dependencies.** `rust/Cargo.toml` has an empty `[dependencies]`; the Go
+  files import only the standard library; `scala/build.sbt` is the one exception
+  and is described above.
+- **Spread.** Run each at least five times. If the gap between two languages is
+  smaller than either one's run-to-run range, the suite has not shown a
+  difference between them.

--- a/benchmarks/cross-language/FAIRNESS.md
+++ b/benchmarks/cross-language/FAIRNESS.md
@@ -88,9 +88,9 @@ claim for Aether than the 61x the broken metric produced.
 All five Scala implementations import `akka.actor`. Akka is a third-party
 framework, so Scala is not being measured on its standard library the way every
 other language here is. It is not a hidden dependency, the README names it, but
-it is still not base-versus-base. Tracked separately; the honest options are to
-rewrite against `scala.concurrent` and `java.util.concurrent`, or to label the
-row as a framework rather than a language.
+it is still not base-versus-base. Tracked in #1532; the honest options are to rewrite
+against `scala.concurrent` and `java.util.concurrent`, or to label the row as a
+framework rather than a language.
 
 ### Pony implements three of five patterns
 
@@ -98,7 +98,7 @@ row as a framework rather than a language.
 `thread_ring`. There is no `ping_pong` and no `skynet`. The README claimed "All
 11 languages implement all 5 patterns (55 total benchmarks, zero skips)"; the
 real figure is 53, and the runner would fail trying to compile the two missing
-directories. Corrected in the README and tracked separately.
+directories. Corrected in the README; the gap itself is #1533.
 
 ### Ping-pong times different regions
 

--- a/benchmarks/cross-language/README.md
+++ b/benchmarks/cross-language/README.md
@@ -18,7 +18,7 @@ Both the benchmark runner (`run_benchmarks.ae`) and the visualization server (`v
 | **Counting** | Single-actor unidirectional throughput |
 | **Thread Ring** | Scheduling overhead with 100 actors in a ring |
 | **Fork-Join** | Parallel fan-out throughput to 8 workers |
-| **Skynet** | Recursive 10-ary tree summing 1M leaves — actor creation + aggregation |
+| **Skynet** | Recursive 10-ary tree summing 1M leaves, actor creation + aggregation. Every language goes sequential below a subtree of 1000, so all create the same 1,111 concurrency units |
 
 ## Languages (11)
 
@@ -34,9 +34,14 @@ Both the benchmark runner (`run_benchmarks.ae`) and the visualization server (`v
 | **Elixir** | BEAM VM | Lightweight processes + mailboxes |
 | **Erlang** | BEAM VM | Lightweight processes + mailboxes |
 | **Pony** | Native (Pony runtime) | GC-free actors, ref capabilities |
-| **Scala** | JVM (Akka) | Akka actor system |
+| **Scala** | JVM (Akka) | Akka actor system, the one third-party dependency here; see [FAIRNESS.md](FAIRNESS.md) |
 
-All 11 languages implement all 5 patterns (55 total benchmarks, zero skips).
+53 of the 55 combinations exist. Pony implements `counting`, `fork_join` and
+`thread_ring` only; it has no `ping_pong` and no `skynet` directory.
+
+See [FAIRNESS.md](FAIRNESS.md) for the rules the suite holds itself to, and for
+the August 2026 audit that found the skynet metric crediting every
+implementation for actors it never created.
 
 ## Methodology
 

--- a/benchmarks/cross-language/README.md
+++ b/benchmarks/cross-language/README.md
@@ -34,14 +34,15 @@ Both the benchmark runner (`run_benchmarks.ae`) and the visualization server (`v
 | **Elixir** | BEAM VM | Lightweight processes + mailboxes |
 | **Erlang** | BEAM VM | Lightweight processes + mailboxes |
 | **Pony** | Native (Pony runtime) | GC-free actors, ref capabilities |
-| **Scala** | JVM (Akka) | Akka actor system, the one third-party dependency here; see [FAIRNESS.md](FAIRNESS.md) |
+| **Scala** | JVM | `java.util.concurrent` queues and ForkJoinPool |
 
-53 of the 55 combinations exist. Pony implements `counting`, `fork_join` and
-`thread_ring` only; it has no `ping_pong` and no `skynet` directory.
+All 11 languages implement all 5 patterns, 55 in total.
 
-See [FAIRNESS.md](FAIRNESS.md) for the rules the suite holds itself to, and for
-the August 2026 audit that found the skynet metric crediting every
-implementation for actors it never created.
+See [FAIRNESS.md](FAIRNESS.md) for the rules the suite holds itself to and the
+audit that produced them. In short: standard library only, the same number of
+concurrency units and the same sequential work in every implementation, rates
+divided by work actually performed, the same region timed, and medians rather
+than single runs.
 
 ## Methodology
 

--- a/benchmarks/cross-language/aether/ping_pong.ae
+++ b/benchmarks/cross-language/aether/ping_pong.ae
@@ -47,6 +47,8 @@ main() {
         total_messages = atoi(env_val);
     }
 
+    start_time = clock_ns();
+
     ping = spawn(PingActor());
     pong = spawn(PongActor());
 
@@ -54,7 +56,6 @@ main() {
     ping.target = total_messages;
     pong.ping_ref = ping;
 
-    start_time = clock_ns();
     pong ! Ping { count: 0 };
     wait_for_idle();
     end_time = clock_ns();

--- a/benchmarks/cross-language/aether/skynet.ae
+++ b/benchmarks/cross-language/aether/skynet.ae
@@ -7,13 +7,7 @@
 // This matches the approach used by C, Go, Rust, and other
 // high-performance implementations.
 //
-// Default: 1,000,000 leaves, threshold 1000 -> 1,111 actors.
-//
-// The threshold is the same in every language in this suite, so every
-// implementation creates the same 1,111 concurrency units and performs the
-// same 1,000,000 leaf additions. 1.1M units is only reachable by runtimes with
-// green threads; this machine caps pthreads at 4,095, so equalising at 1,111 is
-// what makes the comparison mean anything.
+// Default: 1,000,000 leaves, threshold 1000 -> 1,111 actors. See FAIRNESS.md.
 
 // Setup tells a node its own actor ref so it can pass itself as parent to children.
 message Setup { self_ref: ptr }
@@ -93,17 +87,7 @@ main() {
         num_leaves = atoi(env_val);
     }
 
-    // Divide by the concurrency units created, not by the tree's node count.
-    //
-    // Every language in this suite now uses the same threshold, so every one
-    // creates the same 1,111 units and performs the same num_leaves leaf
-    // additions. A per-unit cost is therefore directly comparable, and it is
-    // what skynet is for: the price of creating a unit, passing its result up
-    // and aggregating.
-    //
-    // It used to divide by the full 1,111,111-node tree while creating between
-    // 1,111 and 1,111,111 units depending on the language, so whichever
-    // implementation created the fewest scored highest.
+    // Divide by units created, not the tree's node count. See FAIRNESS.md.
     long actor_count = 1;
     long n = num_leaves;
     while (n > 1000) {

--- a/benchmarks/cross-language/aether/skynet.ae
+++ b/benchmarks/cross-language/aether/skynet.ae
@@ -7,7 +7,13 @@
 // This matches the approach used by C, Go, Rust, and other
 // high-performance implementations.
 //
-// Default: 1,000,000 leaves, threshold 100 -> ~11,111 actors (not 1.1M)
+// Default: 1,000,000 leaves, threshold 1000 -> 1,111 actors.
+//
+// The threshold is the same in every language in this suite, so every
+// implementation creates the same 1,111 concurrency units and performs the
+// same 1,000,000 leaf additions. 1.1M units is only reachable by runtimes with
+// green threads; this machine caps pthreads at 4,095, so equalising at 1,111 is
+// what makes the comparison mean anything.
 
 // Setup tells a node its own actor ref so it can pass itself as parent to children.
 message Setup { self_ref: ptr }
@@ -32,7 +38,7 @@ actor SkynetNode {
         }
         Spawn(offset, size, parent) -> {
             parent_ref = parent;
-            if (size <= 100) {
+            if (size <= 1000) {
                 // Sequential threshold: compute subtree sum without spawning actors.
                 long sum = 0;
                 long i = 0;
@@ -87,15 +93,24 @@ main() {
         num_leaves = atoi(env_val);
     }
 
-    // Total tree nodes = sum of nodes at each level of the 10-ary tree
-    // For 1M leaves: 1 + 10 + 100 + 1000 + 10000 + 100000 + 1000000 = 1111111
-    // All languages use this same count for fair throughput comparison
-    long total_nodes = 0;
+    // Divide by the concurrency units created, not by the tree's node count.
+    //
+    // Every language in this suite now uses the same threshold, so every one
+    // creates the same 1,111 units and performs the same num_leaves leaf
+    // additions. A per-unit cost is therefore directly comparable, and it is
+    // what skynet is for: the price of creating a unit, passing its result up
+    // and aggregating.
+    //
+    // It used to divide by the full 1,111,111-node tree while creating between
+    // 1,111 and 1,111,111 units depending on the language, so whichever
+    // implementation created the fewest scored highest.
+    long actor_count = 1;
     long n = num_leaves;
-    while (n >= 1) {
-        total_nodes = total_nodes + n;
+    while (n > 1000) {
+        actor_count = actor_count + n / 1000;
         n = n / 10;
     }
+    long total_nodes = actor_count;
 
     start_time = clock_ns();
 
@@ -107,6 +122,11 @@ main() {
     wait_for_idle();
     end_time = clock_ns();
 
+    print("Leaves: ");
+    print(num_leaves);
+    print(", concurrency units: ");
+    print(actor_count);
+    print(" (sequential below 1000)\n");
     print("Sum: ");
     print(root.total);
     print("\n");

--- a/benchmarks/cross-language/c/skynet.c
+++ b/benchmarks/cross-language/c/skynet.c
@@ -1,7 +1,7 @@
 /**
  * C Skynet Benchmark
  * Based on https://github.com/atemerev/skynet
- * Uses pthreads for top THREAD_DEPTH levels, sequential below.
+ * Uses pthreads while the subtree is larger than SEQ_THRESHOLD, sequential below.
  * Spawning 1M OS threads is not feasible; limits concurrent threads to ~1000.
  *
  * Compile with: gcc -O3 -march=native skynet.c -o skynet -pthread
@@ -13,8 +13,10 @@
 #include <string.h>
 #include <time.h>
 
-/* Below THREAD_DEPTH, compute the sub-tree sum sequentially. */
-#define THREAD_DEPTH 3
+/* Sequential below SEQ_THRESHOLD. Same threshold in every language in this
+ * suite, so all of them create the same 1,111 concurrency units and perform the
+ * same 1,000,000 leaf additions. */
+#define SEQ_THRESHOLD 1000
 
 static long long skynet_seq(long long offset, long long size) {
     if (size == 1) return offset;
@@ -39,7 +41,7 @@ static void* skynet_thread(void* arg) {
     long long size   = a->size;
     int       depth  = a->depth;
 
-    if (size == 1 || depth >= THREAD_DEPTH) {
+    if (size <= SEQ_THRESHOLD) {
         a->result = skynet_seq(offset, size);
         return NULL;
     }
@@ -76,15 +78,26 @@ static long long get_leaves(void) {
 int main(void) {
     long long num_leaves = get_leaves();
 
-    /* Total actors = sum of nodes at each level */
-    long long total_actors = 0;
-    for (long long n = num_leaves; n >= 1; n /= 10) {
-        total_actors += n;
+    /* Divide by the concurrency units created, not by the tree's node count.
+     *
+     * Every language in this suite now uses the same SEQ_THRESHOLD, so every
+     * one creates the same 1,111 units and performs the same num_leaves leaf
+     * additions. A per-unit cost is therefore directly comparable, and it is
+     * what skynet is for: the price of creating a unit, passing its result up
+     * and aggregating.
+     *
+     * It used to divide by the full 1,111,111-node tree while creating between
+     * 1,111 and 1,111,111 units depending on the language, so whichever
+     * implementation created the fewest scored highest. */
+    long long total_actors = 1;
+    for (long long n = num_leaves; n > SEQ_THRESHOLD; n /= 10) {
+        total_actors += n / SEQ_THRESHOLD;
     }
+    const long long rate_base = total_actors;
 
     printf("=== C Skynet Benchmark ===\n");
-    printf("Leaves: %lld (pthreads, top %d levels parallel)\n\n",
-           num_leaves, THREAD_DEPTH);
+    printf("Leaves: %lld, concurrency units: %lld (sequential below %d)\n\n",
+           num_leaves, total_actors, SEQ_THRESHOLD);
 
     SkynetArg root = { .offset = 0, .size = num_leaves, .depth = 0, .result = 0 };
 
@@ -103,9 +116,9 @@ int main(void) {
 
     printf("Sum: %lld\n", root.result);
     if (elapsed_us > 0) {
-        long long ns_per_msg   = elapsed_ns / total_actors;
-        long long throughput_m = total_actors / elapsed_us;
-        long long leftover     = total_actors - (throughput_m * elapsed_us);
+        long long ns_per_msg   = elapsed_ns / rate_base;
+        long long throughput_m = rate_base / elapsed_us;
+        long long leftover     = rate_base - (throughput_m * elapsed_us);
         long long frac         = (leftover * 100) / elapsed_us;
         printf("ns/msg:         %lld\n", ns_per_msg);
         printf("Throughput:     %lld.%02lld M msg/sec\n", throughput_m, frac);

--- a/benchmarks/cross-language/c/skynet.c
+++ b/benchmarks/cross-language/c/skynet.c
@@ -13,17 +13,14 @@
 #include <string.h>
 #include <time.h>
 
-/* Sequential below SEQ_THRESHOLD. Same threshold in every language in this
- * suite, so all of them create the same 1,111 concurrency units and perform the
- * same 1,000,000 leaf additions. */
+/* Same threshold in every language here, so all create 1,111 units for a
+ * million leaves. See FAIRNESS.md. */
 #define SEQ_THRESHOLD 1000
 
 static long long skynet_seq(long long offset, long long size) {
-    if (size == 1) return offset;
-    long long child_size = size / 10;
     long long sum = 0;
-    for (int i = 0; i < 10; i++) {
-        sum += skynet_seq(offset + (long long)i * child_size, child_size);
+    for (long long i = 0; i < size; i++) {
+        sum += offset + i;
     }
     return sum;
 }
@@ -78,17 +75,7 @@ static long long get_leaves(void) {
 int main(void) {
     long long num_leaves = get_leaves();
 
-    /* Divide by the concurrency units created, not by the tree's node count.
-     *
-     * Every language in this suite now uses the same SEQ_THRESHOLD, so every
-     * one creates the same 1,111 units and performs the same num_leaves leaf
-     * additions. A per-unit cost is therefore directly comparable, and it is
-     * what skynet is for: the price of creating a unit, passing its result up
-     * and aggregating.
-     *
-     * It used to divide by the full 1,111,111-node tree while creating between
-     * 1,111 and 1,111,111 units depending on the language, so whichever
-     * implementation created the fewest scored highest. */
+    /* Divide by units created, not the tree's node count. See FAIRNESS.md. */
     long long total_actors = 1;
     for (long long n = num_leaves; n > SEQ_THRESHOLD; n /= 10) {
         total_actors += n / SEQ_THRESHOLD;

--- a/benchmarks/cross-language/cpp/skynet.cpp
+++ b/benchmarks/cross-language/cpp/skynet.cpp
@@ -1,7 +1,7 @@
 /**
  * C++ Skynet Benchmark
  * Based on https://github.com/atemerev/skynet
- * Uses std::thread for top THREAD_DEPTH levels, sequential below.
+ * Uses std::thread while the subtree is larger than SEQ_THRESHOLD.
  * Spawning 1M OS threads is not feasible; limits concurrent threads to ~1000.
  *
  * Compile with: g++ -O3 -std=c++17 -march=native skynet.cpp -o skynet -pthread
@@ -16,8 +16,12 @@
 #include <cstring>
 #include <array>
 
-// Below THREAD_DEPTH, compute the sub-tree sum sequentially on the current thread.
-static const int THREAD_DEPTH = 3;
+// Sequential below SEQ_THRESHOLD. The same threshold in every language in this
+// suite, so all of them create the same 1,111 concurrency units and perform the
+// same leaf additions. The divisor is that unit count, not the tree's 1,111,111
+// nodes: dividing by nodes nobody created scored the implementations that
+// created fewest the highest.
+static const long long SEQ_THRESHOLD = 1000;
 
 static long long skynet_seq(long long offset, long long size) {
     if (size == 1) return offset;
@@ -38,7 +42,7 @@ struct ResultSlot {
 };
 
 static void skynet(ResultSlot* out, long long offset, long long size, int depth) {
-    if (size == 1 || depth >= THREAD_DEPTH) {
+    if (size <= SEQ_THRESHOLD) {
         std::lock_guard<std::mutex> lock(out->mtx);
         out->value = skynet_seq(offset, size);
         out->ready = true;
@@ -81,14 +85,15 @@ static long long get_leaves() {
 int main() {
     long long num_leaves = get_leaves();
 
-    // Total actors = sum of nodes at each level
-    long long total_actors = 0;
-    for (long long n = num_leaves; n >= 1; n /= 10) {
-        total_actors += n;
+    // Concurrency units actually created; also the divisor, since every language
+    // in this suite creates the same count.
+    long long total_actors = 1;
+    for (long long n = num_leaves; n > SEQ_THRESHOLD; n /= 10) {
+        total_actors += n / SEQ_THRESHOLD;
     }
 
     std::cout << "=== C++ Skynet Benchmark ===" << std::endl;
-    std::cout << "Leaves: " << num_leaves << " (std::thread, top " << THREAD_DEPTH << " levels parallel)" << std::endl;
+    std::cout << "Leaves: " << num_leaves << ", concurrency units: " << total_actors << " (sequential below " << SEQ_THRESHOLD << ")" << std::endl;
     std::cout << std::endl;
 
     ResultSlot root;

--- a/benchmarks/cross-language/cpp/skynet.cpp
+++ b/benchmarks/cross-language/cpp/skynet.cpp
@@ -16,19 +16,14 @@
 #include <cstring>
 #include <array>
 
-// Sequential below SEQ_THRESHOLD. The same threshold in every language in this
-// suite, so all of them create the same 1,111 concurrency units and perform the
-// same leaf additions. The divisor is that unit count, not the tree's 1,111,111
-// nodes: dividing by nodes nobody created scored the implementations that
-// created fewest the highest.
+// Same threshold in every language here; divisor is the unit count, not the
+// tree's nodes. See FAIRNESS.md.
 static const long long SEQ_THRESHOLD = 1000;
 
 static long long skynet_seq(long long offset, long long size) {
-    if (size == 1) return offset;
-    long long child_size = size / 10;
     long long sum = 0;
-    for (int i = 0; i < 10; i++) {
-        sum += skynet_seq(offset + (long long)i * child_size, child_size);
+    for (long long i = 0; i < size; i++) {
+        sum += offset + i;
     }
     return sum;
 }
@@ -85,8 +80,7 @@ static long long get_leaves() {
 int main() {
     long long num_leaves = get_leaves();
 
-    // Concurrency units actually created; also the divisor, since every language
-    // in this suite creates the same count.
+    // Units created; also the divisor. See FAIRNESS.md.
     long long total_actors = 1;
     for (long long n = num_leaves; n > SEQ_THRESHOLD; n /= 10) {
         total_actors += n / SEQ_THRESHOLD;

--- a/benchmarks/cross-language/elixir/ping_pong.exs
+++ b/benchmarks/cross-language/elixir/ping_pong.exs
@@ -44,9 +44,9 @@ defmodule PingPong do
     IO.puts("Using Erlang/OTP processes\n")
 
     ping_pid = self()
-    pong_pid = spawn(fn -> pong(0) end)
 
     start = :erlang.monotonic_time(:nanosecond)
+    pong_pid = spawn(fn -> pong(0) end)
     ping(pong_pid, @messages, 0)
     finish = :erlang.monotonic_time(:nanosecond)
 

--- a/benchmarks/cross-language/elixir/skynet.exs
+++ b/benchmarks/cross-language/elixir/skynet.exs
@@ -20,12 +20,19 @@ defmodule Skynet do
   end
 
   # Total actors = sum of nodes at each level
-  defp total_actors(n) when n < 1, do: 0
-  defp total_actors(n), do: n + total_actors(div(n, 10))
+  # Concurrency units actually created; also the divisor, since every language
+  # in this suite creates the same count. It used to sum every level of the
+  # tree, 1,111,111 for a million leaves, which is what BEAM really spawned
+  # while the thread-based languages spawned 1,111 and were scored the same way.
+  @seq_threshold 1000
+  defp total_actors(n) when n <= @seq_threshold, do: 1
+  defp total_actors(n), do: div(n, @seq_threshold) + total_actors(div(n, 10))
 
   # Leaf: send offset to parent. Internal: spawn 10 children, collect, sum, report up.
-  def skynet_node(offset, 1, parent) do
-    send(parent, offset)
+  # Same threshold as every other language in this suite: below it the subtree
+  # is summed in this process rather than spawning more.
+  def skynet_node(offset, size, parent) when size <= @seq_threshold do
+    send(parent, Enum.reduce(0..(size - 1), 0, fn i, acc -> acc + offset + i end))
   end
 
   def skynet_node(offset, size, parent) do
@@ -50,7 +57,7 @@ defmodule Skynet do
     total = total_actors(num_leaves)
 
     IO.puts("=== Elixir Skynet Benchmark ===")
-    IO.puts("Leaves: #{num_leaves}")
+    IO.puts("Leaves: #{num_leaves}, concurrency units: #{total} (sequential below #{@seq_threshold})")
     IO.puts("Using Erlang/OTP processes\n")
 
     caller = self()

--- a/benchmarks/cross-language/elixir/skynet.exs
+++ b/benchmarks/cross-language/elixir/skynet.exs
@@ -20,19 +20,15 @@ defmodule Skynet do
   end
 
   # Total actors = sum of nodes at each level
-  # Concurrency units actually created; also the divisor, since every language
-  # in this suite creates the same count. It used to sum every level of the
-  # tree, 1,111,111 for a million leaves, which is what BEAM really spawned
-  # while the thread-based languages spawned 1,111 and were scored the same way.
+  # Units created; also the divisor. See FAIRNESS.md.
   @seq_threshold 1000
   defp total_actors(n) when n <= @seq_threshold, do: 1
   defp total_actors(n), do: div(n, @seq_threshold) + total_actors(div(n, 10))
 
   # Leaf: send offset to parent. Internal: spawn 10 children, collect, sum, report up.
-  # Same threshold as every other language in this suite: below it the subtree
-  # is summed in this process rather than spawning more.
+  # Same threshold as every other language here.
   def skynet_node(offset, size, parent) when size <= @seq_threshold do
-    send(parent, Enum.reduce(0..(size - 1), 0, fn i, acc -> acc + offset + i end))
+    send(parent, seq_sum(offset, size, 0))
   end
 
   def skynet_node(offset, size, parent) do
@@ -44,6 +40,9 @@ defmodule Skynet do
     sum = collect(10, 0)
     send(parent, sum)
   end
+
+  defp seq_sum(_offset, 0, acc), do: acc
+  defp seq_sum(offset, n, acc), do: seq_sum(offset, n - 1, acc + offset + n - 1)
 
   defp collect(0, acc), do: acc
   defp collect(n, acc) do

--- a/benchmarks/cross-language/erlang/ping_pong.erl
+++ b/benchmarks/cross-language/erlang/ping_pong.erl
@@ -46,12 +46,13 @@ start() ->
     io:format("=== Erlang Ping-Pong Benchmark ===~n"),
     io:format("Messages: ~p~n~n", [Messages]),
 
-    % Spawn processes
     Parent = self(),
-    Pong = spawn(fun() -> pong(0, Messages) end),
 
-    % Start timer (monotonic_time is correct for benchmarks per Erlang docs)
+    % monotonic_time is the correct clock for benchmarks per the Erlang docs.
+    % Process creation is inside the timed region, as in every other language here.
     Start = erlang:monotonic_time(nanosecond),
+
+    Pong = spawn(fun() -> pong(0, Messages) end),
 
     % Run ping-pong - spawn returns the PID, we need to link it to receive done
     spawn_link(fun() ->

--- a/benchmarks/cross-language/erlang/skynet.erl
+++ b/benchmarks/cross-language/erlang/skynet.erl
@@ -15,20 +15,16 @@ get_leaves() ->
         Val -> list_to_integer(Val)
     end.
 
-%% Concurrency units actually created; also the divisor, since every language in
-%% this suite creates the same count. It used to sum every level of the tree,
-%% 1,111,111 for a million leaves, which is what BEAM really spawned while the
-%% thread-based languages spawned 1,111 and were scored on the same divisor.
+%% Units created; also the divisor. See FAIRNESS.md.
 -define(SEQ_THRESHOLD, 1000).
 total_actors(N) when N =< ?SEQ_THRESHOLD -> 1;
 total_actors(N) -> (N div ?SEQ_THRESHOLD) + total_actors(N div 10).
 
 %% Each node spawns 10 children or reports its offset (leaf).
 %% Results bubble up via message passing.
-%% Same threshold as every other language in this suite: below it the subtree is
-%% summed in this process rather than spawning more.
+%% Same threshold as every other language here.
 skynet_node(Offset, Size, Parent) when Size =< ?SEQ_THRESHOLD ->
-    Parent ! lists:sum([Offset + I || I <- lists:seq(0, Size - 1)]);
+    Parent ! seq_sum(Offset, Size, 0);
 skynet_node(Offset, Size, Parent) ->
     ChildSize = Size div 10,
     Self = self(),
@@ -39,6 +35,9 @@ skynet_node(Offset, Size, Parent) ->
     end, lists:seq(0, 9)),
     Sum = collect(10, 0),
     Parent ! Sum.
+
+seq_sum(_Offset, 0, Acc) -> Acc;
+seq_sum(Offset, N, Acc) -> seq_sum(Offset, N - 1, Acc + Offset + N - 1).
 
 collect(0, Acc) -> Acc;
 collect(N, Acc) ->

--- a/benchmarks/cross-language/erlang/skynet.erl
+++ b/benchmarks/cross-language/erlang/skynet.erl
@@ -15,14 +15,20 @@ get_leaves() ->
         Val -> list_to_integer(Val)
     end.
 
-%% Compute total actors: sum of nodes at each level
-total_actors(N) when N < 1 -> 0;
-total_actors(N) -> N + total_actors(N div 10).
+%% Concurrency units actually created; also the divisor, since every language in
+%% this suite creates the same count. It used to sum every level of the tree,
+%% 1,111,111 for a million leaves, which is what BEAM really spawned while the
+%% thread-based languages spawned 1,111 and were scored on the same divisor.
+-define(SEQ_THRESHOLD, 1000).
+total_actors(N) when N =< ?SEQ_THRESHOLD -> 1;
+total_actors(N) -> (N div ?SEQ_THRESHOLD) + total_actors(N div 10).
 
 %% Each node spawns 10 children or reports its offset (leaf).
 %% Results bubble up via message passing.
-skynet_node(Offset, 1, Parent) ->
-    Parent ! Offset;
+%% Same threshold as every other language in this suite: below it the subtree is
+%% summed in this process rather than spawning more.
+skynet_node(Offset, Size, Parent) when Size =< ?SEQ_THRESHOLD ->
+    Parent ! lists:sum([Offset + I || I <- lists:seq(0, Size - 1)]);
 skynet_node(Offset, Size, Parent) ->
     ChildSize = Size div 10,
     Self = self(),
@@ -46,7 +52,8 @@ start() ->
     TotalActors = total_actors(NumLeaves),
 
     io:format("=== Erlang Skynet Benchmark ===~n"),
-    io:format("Leaves: ~p~n~n", [NumLeaves]),
+    io:format("Leaves: ~p, concurrency units: ~p (sequential below ~p)~n~n",
+              [NumLeaves, TotalActors, ?SEQ_THRESHOLD]),
 
     Self = self(),
     Start = erlang:monotonic_time(nanosecond),

--- a/benchmarks/cross-language/go/skynet.go
+++ b/benchmarks/cross-language/go/skynet.go
@@ -27,26 +27,19 @@ func getLeaves() int64 {
 
 // skynetNode sends its subtree sum to the result channel.
 // Leaves send their offset directly; internal nodes spawn 10 children and sum.
-// seqSum sums a subtree on the current goroutine, no further spawning.
+// seqSum sums a subtree on the current goroutine.
 const seqThreshold int64 = 1000
 
 func seqSum(offset, size int64) int64 {
-	if size == 1 {
-		return offset
-	}
-	childSize := size / 10
 	var sum int64
-	for i := int64(0); i < 10; i++ {
-		sum += seqSum(offset+i*childSize, childSize)
+	for i := int64(0); i < size; i++ {
+		sum += offset + i
 	}
 	return sum
 }
 
 func skynetNode(result chan<- int64, offset, size int64) {
-	// Same threshold as every other language in this suite. Go could spawn all
-	// 1,111,111 goroutines and used to, but then it did a thousand times the
-	// concurrency work of the pthread implementations while being scored on the
-	// same divisor, which is why it came last on a benchmark it should win.
+	// Same threshold as every other language here. See FAIRNESS.md.
 	if size <= seqThreshold {
 		result <- seqSum(offset, size)
 		return
@@ -66,14 +59,11 @@ func skynetNode(result chan<- int64, offset, size int64) {
 func main() {
 	numLeaves := getLeaves()
 
-	// Concurrency units actually created; reported, never used as a divisor.
+	// Units created; also the divisor. See FAIRNESS.md.
 	totalActors := int64(1)
 	for n := numLeaves; n > seqThreshold; n /= 10 {
 		totalActors += n / seqThreshold
 	}
-	// Divide by the units created, not the tree's node count. Every language in
-	// this suite now uses the same threshold, so the counts are equal and a
-	// per-unit cost is directly comparable.
 	rateBase := totalActors
 
 	fmt.Println("=== Go Skynet Benchmark ===")

--- a/benchmarks/cross-language/go/skynet.go
+++ b/benchmarks/cross-language/go/skynet.go
@@ -27,9 +27,28 @@ func getLeaves() int64 {
 
 // skynetNode sends its subtree sum to the result channel.
 // Leaves send their offset directly; internal nodes spawn 10 children and sum.
-func skynetNode(result chan<- int64, offset, size int64) {
+// seqSum sums a subtree on the current goroutine, no further spawning.
+const seqThreshold int64 = 1000
+
+func seqSum(offset, size int64) int64 {
 	if size == 1 {
-		result <- offset
+		return offset
+	}
+	childSize := size / 10
+	var sum int64
+	for i := int64(0); i < 10; i++ {
+		sum += seqSum(offset+i*childSize, childSize)
+	}
+	return sum
+}
+
+func skynetNode(result chan<- int64, offset, size int64) {
+	// Same threshold as every other language in this suite. Go could spawn all
+	// 1,111,111 goroutines and used to, but then it did a thousand times the
+	// concurrency work of the pthread implementations while being scored on the
+	// same divisor, which is why it came last on a benchmark it should win.
+	if size <= seqThreshold {
+		result <- seqSum(offset, size)
 		return
 	}
 	children := make(chan int64, 10)
@@ -47,16 +66,19 @@ func skynetNode(result chan<- int64, offset, size int64) {
 func main() {
 	numLeaves := getLeaves()
 
-	// Total actors = sum of nodes at each level
-	totalActors := int64(0)
-	n := numLeaves
-	for n >= 1 {
-		totalActors += n
-		n /= 10
+	// Concurrency units actually created; reported, never used as a divisor.
+	totalActors := int64(1)
+	for n := numLeaves; n > seqThreshold; n /= 10 {
+		totalActors += n / seqThreshold
 	}
+	// Divide by the units created, not the tree's node count. Every language in
+	// this suite now uses the same threshold, so the counts are equal and a
+	// per-unit cost is directly comparable.
+	rateBase := totalActors
 
 	fmt.Println("=== Go Skynet Benchmark ===")
-	fmt.Printf("Leaves: %d\n\n", numLeaves)
+	fmt.Printf("Leaves: %d, concurrency units: %d (sequential below %d)\n\n",
+		numLeaves, totalActors, seqThreshold)
 
 	root := make(chan int64, 1)
 	start := time.Now()
@@ -69,9 +91,9 @@ func main() {
 
 	fmt.Printf("Sum: %d\n", sum)
 	if elapsedUs > 0 {
-		nsPerMsg := elapsedNs / totalActors
-		throughputM := totalActors / elapsedUs
-		leftover := totalActors - (throughputM * elapsedUs)
+		nsPerMsg := elapsedNs / rateBase
+		throughputM := rateBase / elapsedUs
+		leftover := rateBase - (throughputM * elapsedUs)
 		throughputFrac := (leftover * 100) / elapsedUs
 		fmt.Printf("ns/msg:         %d\n", nsPerMsg)
 		fmt.Printf("Throughput:     %d.", throughputM)

--- a/benchmarks/cross-language/java/Skynet.java
+++ b/benchmarks/cross-language/java/Skynet.java
@@ -55,9 +55,7 @@ public class Skynet {
         String env = System.getenv("BENCHMARK_MESSAGES");
         long numLeaves = env != null ? Long.parseLong(env) : 1000000;
 
-        // Concurrency units actually created; also the divisor, since every
-        // language in this suite creates the same count. It used to divide by
-        // the whole 1,111,111-node tree while creating 11,111 tasks.
+        // Units created; also the divisor. See FAIRNESS.md.
         long totalNodes = 1;
         for (long n = numLeaves; n > SEQ_THRESHOLD; n /= 10) totalNodes += n / SEQ_THRESHOLD;
 

--- a/benchmarks/cross-language/java/Skynet.java
+++ b/benchmarks/cross-language/java/Skynet.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveTask;
 
 public class Skynet {
-    private static final int SEQ_THRESHOLD = 100;
+    private static final int SEQ_THRESHOLD = 1000;
 
     static class SkynetTask extends RecursiveTask<Long> {
         private final long offset;
@@ -55,9 +55,11 @@ public class Skynet {
         String env = System.getenv("BENCHMARK_MESSAGES");
         long numLeaves = env != null ? Long.parseLong(env) : 1000000;
 
-        // Total tree nodes (same formula as all languages for fair comparison)
-        long totalNodes = 0;
-        for (long n = numLeaves; n >= 1; n /= 10) totalNodes += n;
+        // Concurrency units actually created; also the divisor, since every
+        // language in this suite creates the same count. It used to divide by
+        // the whole 1,111,111-node tree while creating 11,111 tasks.
+        long totalNodes = 1;
+        for (long n = numLeaves; n > SEQ_THRESHOLD; n /= 10) totalNodes += n / SEQ_THRESHOLD;
 
         ForkJoinPool pool = new ForkJoinPool();
 
@@ -65,6 +67,8 @@ public class Skynet {
         long result = pool.invoke(new SkynetTask(0, numLeaves));
         long elapsed = System.nanoTime() - start;
 
+        System.out.println("Leaves: " + numLeaves + ", concurrency units: " + totalNodes
+                + " (sequential below " + SEQ_THRESHOLD + ")");
         System.out.println("Sum: " + result);
 
         if (elapsed > 0) {

--- a/benchmarks/cross-language/pony/ping_pong/ping_pong.pony
+++ b/benchmarks/cross-language/pony/ping_pong/ping_pong.pony
@@ -1,0 +1,80 @@
+// Pony Ping-Pong Benchmark (Savina-style)
+// Two actors exchange messages back and forth.
+
+use "time"
+
+actor PongActor
+  var _ping: (PingActor | None) = None
+
+  be set_ping(p: PingActor) =>
+    _ping = p
+
+  be ping(value: U64) =>
+    match _ping
+    | let p: PingActor => p.pong(value)
+    end
+
+actor PingActor
+  let _main: Main
+  let _pong: PongActor
+  let _target: U64
+  var _received: U64 = 0
+  var _errors: U64 = 0
+
+  new create(main: Main, pong_actor: PongActor, target: U64) =>
+    _main = main
+    _pong = pong_actor
+    _target = target
+
+  be start() =>
+    _pong.ping(0)
+
+  be pong(value: U64) =>
+    if value != _received then
+      _errors = _errors + 1
+    end
+    _received = _received + 1
+    if _received < _target then
+      _pong.ping(_received)
+    else
+      _main.done(_received, _errors)
+    end
+
+actor Main
+  let _env: Env
+  var _start: U64 = 0
+  var _messages: U64 = 100_000
+
+  new create(env: Env) =>
+    _env = env
+
+    for v in env.vars.values() do
+      if v.contains("BENCHMARK_MESSAGES=") then
+        try
+          let parts = v.split("=")
+          let val_str = parts(1)?
+          _messages = val_str.u64()?
+        end
+      end
+    end
+
+    _env.out.print("=== Pony Ping-Pong Benchmark ===")
+    _env.out.print("Messages: " + _messages.string() + "\n")
+    _start = Time.nanos()
+
+    let pong = PongActor
+    let ping = PingActor(this, pong, _messages)
+    pong.set_ping(ping)
+    ping.start()
+
+  be done(received: U64, errors: U64) =>
+    let finish = Time.nanos()
+    if errors > 0 then
+      _env.out.print("VALIDATION FAILED: " + errors.string() + " errors")
+    end
+    let elapsed_ns = finish - _start
+    let ns_per_msg = elapsed_ns.f64() / received.f64()
+    let throughput = 1_000_000_000.0 / ns_per_msg
+
+    _env.out.print("ns/msg:         " + ns_per_msg.string())
+    _env.out.print("Throughput:     " + (throughput / 1_000_000.0).string() + " M msg/sec")

--- a/benchmarks/cross-language/pony/skynet/skynet.pony
+++ b/benchmarks/cross-language/pony/skynet/skynet.pony
@@ -1,0 +1,102 @@
+// Pony Skynet Benchmark
+// Based on https://github.com/atemerev/skynet
+// Same threshold as every other language here; see FAIRNESS.md.
+
+use "time"
+
+primitive Leaf
+  fun threshold(): I64 => 1000
+
+  fun sum(offset: I64, size: I64): I64 =>
+    var acc: I64 = 0
+    var i: I64 = 0
+    while i < size do
+      acc = acc + offset + i
+      i = i + 1
+    end
+    acc
+
+actor SkynetNode
+  let _parent: (SkynetNode | Main)
+  var _pending: I64 = 0
+  var _total: I64 = 0
+
+  new create(parent: (SkynetNode | Main)) =>
+    _parent = parent
+
+  be compute(offset: I64, size: I64) =>
+    if size <= Leaf.threshold() then
+      _report(Leaf.sum(offset, size))
+    else
+      let child_size = size / 10
+      _pending = 10
+      var i: I64 = 0
+      while i < 10 do
+        let child = SkynetNode(this)
+        child.compute(offset + (i * child_size), child_size)
+        i = i + 1
+      end
+    end
+
+  be result(value: I64) =>
+    _total = _total + value
+    _pending = _pending - 1
+    if _pending == 0 then
+      _report(_total)
+    end
+
+  fun ref _report(value: I64) =>
+    match _parent
+    | let p: SkynetNode => p.result(value)
+    | let m: Main => m.done(value)
+    end
+
+actor Main
+  let _env: Env
+  var _start: U64 = 0
+  var _leaves: I64 = 1_000_000
+
+  new create(env: Env) =>
+    _env = env
+
+    for v in env.vars.values() do
+      if v.contains("BENCHMARK_MESSAGES=") then
+        try
+          let parts = v.split("=")
+          let val_str = parts(1)?
+          _leaves = val_str.i64()?
+        end
+      end
+    end
+
+    var units: I64 = 1
+    var n = _leaves
+    while n > Leaf.threshold() do
+      units = units + (n / Leaf.threshold())
+      n = n / 10
+    end
+
+    _env.out.print("=== Pony Skynet Benchmark ===")
+    _env.out.print("Leaves: " + _leaves.string() + ", concurrency units: " + units.string()
+      + " (sequential below " + Leaf.threshold().string() + ")\n")
+
+    _start = Time.nanos()
+    let root = SkynetNode(this)
+    root.compute(0, _leaves)
+
+  be done(total: I64) =>
+    let finish = Time.nanos()
+    var units: I64 = 1
+    var n = _leaves
+    while n > Leaf.threshold() do
+      units = units + (n / Leaf.threshold())
+      n = n / 10
+    end
+
+    _env.out.print("Sum: " + total.string())
+    let elapsed_ns = finish - _start
+    let ns_per_msg = elapsed_ns.f64() / units.f64()
+    let throughput = (units.f64() / (elapsed_ns.f64() / 1_000_000_000.0)) / 1_000_000.0
+
+    _env.out.print("ns/msg:         " + ns_per_msg.string())
+    _env.out.print("Throughput:     " + throughput.string() + " M msg/sec")

--- a/benchmarks/cross-language/rust/src/skynet.rs
+++ b/benchmarks/cross-language/rust/src/skynet.rs
@@ -21,21 +21,14 @@ fn get_leaves() -> i64 {
     1_000_000
 }
 
-// Sequential below SEQ_THRESHOLD. The same threshold in every language in this
-// suite, so all of them create the same 1,111 concurrency units and perform the
-// same leaf additions. The divisor is that unit count, not the tree's 1,111,111
-// nodes: dividing by nodes nobody created scored the implementations that
-// created fewest the highest.
+// Same threshold in every language here; divisor is the unit count, not the
+// tree's nodes. See FAIRNESS.md.
 const SEQ_THRESHOLD: i64 = 1000;
 
 fn skynet_seq(offset: i64, size: i64) -> i64 {
-    if size == 1 {
-        return offset;
-    }
-    let child_size = size / 10;
     let mut sum = 0i64;
-    for i in 0..10i64 {
-        sum += skynet_seq(offset + i * child_size, child_size);
+    for i in 0..size {
+        sum += offset + i;
     }
     sum
 }
@@ -64,8 +57,7 @@ fn skynet(tx: Sender<i64>, offset: i64, size: i64, depth: usize) {
 fn main() {
     let num_leaves = get_leaves();
 
-    // Concurrency units actually created; also the divisor, since every language
-    // in this suite creates the same count.
+    // Units created; also the divisor. See FAIRNESS.md.
     let mut total_actors = 1i64;
     let mut n = num_leaves;
     while n > SEQ_THRESHOLD {

--- a/benchmarks/cross-language/rust/src/skynet.rs
+++ b/benchmarks/cross-language/rust/src/skynet.rs
@@ -1,6 +1,6 @@
 // Rust Skynet Benchmark
 // Based on https://github.com/atemerev/skynet
-// Uses std::thread for top levels (THREAD_DEPTH levels), sequential below.
+// Uses std::thread while the subtree is larger than SEQ_THRESHOLD.
 // Spawning 1M OS threads is not feasible; this limits concurrent threads to ~1000.
 
 use std::sync::mpsc::{channel, Sender};
@@ -21,8 +21,12 @@ fn get_leaves() -> i64 {
     1_000_000
 }
 
-// Below THREAD_DEPTH, compute the sub-tree sum sequentially on the current thread.
-const THREAD_DEPTH: usize = 3;
+// Sequential below SEQ_THRESHOLD. The same threshold in every language in this
+// suite, so all of them create the same 1,111 concurrency units and perform the
+// same leaf additions. The divisor is that unit count, not the tree's 1,111,111
+// nodes: dividing by nodes nobody created scored the implementations that
+// created fewest the highest.
+const SEQ_THRESHOLD: i64 = 1000;
 
 fn skynet_seq(offset: i64, size: i64) -> i64 {
     if size == 1 {
@@ -37,7 +41,7 @@ fn skynet_seq(offset: i64, size: i64) -> i64 {
 }
 
 fn skynet(tx: Sender<i64>, offset: i64, size: i64, depth: usize) {
-    if size == 1 || depth >= THREAD_DEPTH {
+    if size <= SEQ_THRESHOLD {
         tx.send(skynet_seq(offset, size)).unwrap();
         return;
     }
@@ -60,16 +64,17 @@ fn skynet(tx: Sender<i64>, offset: i64, size: i64, depth: usize) {
 fn main() {
     let num_leaves = get_leaves();
 
-    // Total actors = sum of nodes at each level
-    let mut total_actors = 0i64;
+    // Concurrency units actually created; also the divisor, since every language
+    // in this suite creates the same count.
+    let mut total_actors = 1i64;
     let mut n = num_leaves;
-    while n >= 1 {
-        total_actors += n;
+    while n > SEQ_THRESHOLD {
+        total_actors += n / SEQ_THRESHOLD;
         n /= 10;
     }
 
     println!("=== Rust Skynet Benchmark ===");
-    println!("Leaves: {} (std::thread, top {} levels parallel)\n", num_leaves, THREAD_DEPTH);
+    println!("Leaves: {}, concurrency units: {} (sequential below {})\n", num_leaves, total_actors, SEQ_THRESHOLD);
 
     let (tx, rx) = channel::<i64>();
     let start = Instant::now();

--- a/benchmarks/cross-language/scala/build.sbt
+++ b/benchmarks/cross-language/scala/build.sbt
@@ -1,7 +1,5 @@
-name := "akka-benchmark"
+name := "scala-benchmark"
 version := "1.0"
 scalaVersion := "2.13.12"
 
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.8.5"
-)
+// No third-party dependencies: the suite compares standard libraries.

--- a/benchmarks/cross-language/scala/counting.scala
+++ b/benchmarks/cross-language/scala/counting.scala
@@ -1,68 +1,44 @@
 package bench.counting
 
-// Scala Akka Counting Actor Benchmark (Savina-style)
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import java.util.concurrent.ArrayBlockingQueue
 
-case object Increment
-case class GetCount(replyTo: ActorRef)
-case class Count(value: Long)
+// Single consumer draining a bounded queue: the standard-library equivalent of
+// one actor with a mailbox.
+object CountingBenchmark {
+  def main(args: Array[String]): Unit = {
+    val messages = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000").toLong
 
-class CounterActor extends Actor {
-  var count = 0L
+    println("=== Scala Counting Benchmark ===")
+    println(s"Messages: $messages")
+    println("Using java.util.concurrent.ArrayBlockingQueue\n")
 
-  def receive = {
-    case Increment =>
-      count += 1
-    case GetCount(replyTo) =>
-      replyTo ! Count(count)
+    val queue = new ArrayBlockingQueue[java.lang.Long](1024)
+    var received = 0L
+
+    val start = System.nanoTime()
+
+    val consumer = new Thread(() => {
+      var seen = 0L
+      while (seen < messages) {
+        queue.take()
+        seen += 1
+      }
+    })
+    consumer.start()
+
+    var i = 0L
+    while (i < messages) {
+      queue.put(java.lang.Long.valueOf(i))
+      i += 1
+    }
+    consumer.join()
+    received = messages
+
+    val elapsed = System.nanoTime() - start
+    val nsPerMsg = elapsed / received
+    val throughput = received.toDouble / elapsed * 1e9
+
+    println(s"ns/msg:         $nsPerMsg")
+    println(f"Throughput:     ${throughput / 1e6}%.2f M msg/sec")
   }
-}
-
-class CollectorActor(promise: Promise[Long]) extends Actor {
-  def receive = {
-    case Count(value) =>
-      promise.success(value)
-      context.system.terminate()
-  }
-}
-
-object CountingBenchmark extends App {
-  val messages = sys.env.get("BENCHMARK_MESSAGES").flatMap(s => scala.util.Try(s.toLong).toOption).getOrElse(100000L)
-  println("=== Scala Akka Counting Actor Benchmark ===")
-  println(s"Messages: $messages\n")
-
-  val system = ActorSystem("Counting")
-  val promise = Promise[Long]()
-
-  val counter = system.actorOf(Props[CounterActor]())
-  val collector = system.actorOf(Props(classOf[CollectorActor], promise))
-
-  val startTime = System.nanoTime()
-
-  // Send all messages
-  for (_ <- 0L until messages) {
-    counter ! Increment
-  }
-
-  // Get count
-  counter ! GetCount(collector)
-
-  val count = Await.result(promise.future, 120.seconds)
-  val endTime = System.nanoTime()
-
-  val elapsed = (endTime - startTime).toDouble / 1e9
-
-  if (count != messages) {
-    println(s"VALIDATION FAILED: expected $messages, got $count")
-  }
-
-  val throughput = messages / elapsed / 1e6
-  val nsPerMsg = elapsed * 1e9 / messages
-
-  println(f"ns/msg:         $nsPerMsg%.2f")
-  println(f"Throughput:     $throughput%.2f M msg/sec")
-
-  Await.result(system.whenTerminated, 10.seconds)
 }

--- a/benchmarks/cross-language/scala/fork_join.scala
+++ b/benchmarks/cross-language/scala/fork_join.scala
@@ -1,89 +1,54 @@
 package bench.fork_join
 
-// Scala Akka Fork-Join Benchmark (Savina-style)
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import java.util.concurrent.{ArrayBlockingQueue, CountDownLatch}
 
-case class Work(value: Int)
-case object Done
-case class Result(processed: Int)
+// Fan-out to 8 workers, each draining its own bounded queue.
+object ForkJoinBenchmark {
+  def main(args: Array[String]): Unit = {
+    val messages = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000").toLong
+    val workers = 8
+    val perWorker = messages / workers
+    val total = perWorker * workers
 
-class WorkerActor(parent: ActorRef) extends Actor {
-  var processed = 0
+    println("=== Scala Fork-Join Benchmark ===")
+    println(s"Workers: $workers, messages: $total")
+    println("Using java.util.concurrent.ArrayBlockingQueue\n")
 
-  def receive = {
-    case Work(_) =>
-      processed += 1
-    case Done =>
-      parent ! Result(processed)
-  }
-}
+    val queues = Array.fill(workers)(new ArrayBlockingQueue[java.lang.Long](1024))
+    val done = new CountDownLatch(workers)
 
-class CoordinatorActor(promise: Promise[Int], numWorkers: Int, messagesPerWorker: Int) extends Actor {
-  var workers: Array[ActorRef] = null
-  var resultsReceived = 0
-  var totalProcessed = 0
-  var startTime = 0L
+    val start = System.nanoTime()
 
-  override def preStart(): Unit = {
-    // Create workers
-    workers = Array.tabulate(numWorkers)(i =>
-      context.actorOf(Props(classOf[WorkerActor], self), s"worker$i")
-    )
-
-    startTime = System.nanoTime()
-
-    // Send messages round-robin
-    val total = numWorkers * messagesPerWorker
-    for (i <- 0 until total) {
-      workers(i % numWorkers) ! Work(i)
+    var w = 0
+    while (w < workers) {
+      val me = w
+      new Thread(() => {
+        var seen = 0L
+        while (seen < perWorker) {
+          queues(me).take()
+          seen += 1
+        }
+        done.countDown()
+      }).start()
+      w += 1
     }
 
-    // Signal workers to report
-    workers.foreach(_ ! Done)
-  }
-
-  def receive = {
-    case Result(processed) =>
-      totalProcessed += processed
-      resultsReceived += 1
-      if (resultsReceived == numWorkers) {
-        promise.success(totalProcessed)
-        context.system.terminate()
+    var i = 0L
+    while (i < perWorker) {
+      var k = 0
+      while (k < workers) {
+        queues(k).put(java.lang.Long.valueOf(i))
+        k += 1
       }
+      i += 1
+    }
+    done.await()
+
+    val elapsed = System.nanoTime() - start
+    val nsPerMsg = elapsed / total
+    val throughput = total.toDouble / elapsed * 1e9
+
+    println(s"ns/msg:         $nsPerMsg")
+    println(f"Throughput:     ${throughput / 1e6}%.2f M msg/sec")
   }
-}
-
-object ForkJoinBenchmark extends App {
-  val numWorkers = 8
-  val totalMessages = sys.env.get("BENCHMARK_MESSAGES").flatMap(s => scala.util.Try(s.toInt).toOption).getOrElse(100000)
-  val messagesPerWorker = totalMessages / numWorkers
-  val total = numWorkers * messagesPerWorker
-
-  println("=== Scala Akka Fork-Join Throughput Benchmark ===")
-  println(s"Workers: $numWorkers, Messages: $total\n")
-
-  val system = ActorSystem("ForkJoin")
-  val promise = Promise[Int]()
-
-  val startTime = System.nanoTime()
-  val coordinator = system.actorOf(Props(classOf[CoordinatorActor], promise, numWorkers, messagesPerWorker))
-
-  val totalProcessed = Await.result(promise.future, 120.seconds)
-  val endTime = System.nanoTime()
-
-  val elapsed = (endTime - startTime).toDouble / 1e9
-
-  if (totalProcessed != total) {
-    println(s"VALIDATION FAILED: expected $total, got $totalProcessed")
-  }
-
-  val throughput = total / elapsed / 1e6
-  val nsPerMsg = elapsed * 1e9 / total
-
-  println(f"ns/msg:         $nsPerMsg%.2f")
-  println(f"Throughput:     $throughput%.2f M msg/sec")
-
-  Await.result(system.whenTerminated, 10.seconds)
 }

--- a/benchmarks/cross-language/scala/ping_pong.scala
+++ b/benchmarks/cross-language/scala/ping_pong.scala
@@ -1,84 +1,49 @@
 package bench.ping_pong
 
-// Scala Akka Ping-Pong Benchmark
-// Classic actor framework comparison
+import java.util.concurrent.ArrayBlockingQueue
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+// Two threads exchanging one value at a time in each direction: a strict
+// request-response round trip, as in the other implementations.
+object PingPongBenchmark {
+  def main(args: Array[String]): Unit = {
+    val messages = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000").toLong
 
-case class Ping(value: Long)
-case class Pong(value: Long)
-case class Start(pong: ActorRef)
-case class Done(count: Long)
+    println("=== Scala Ping-Pong Benchmark ===")
+    println(s"Messages: $messages")
+    println("Using java.util.concurrent.ArrayBlockingQueue\n")
 
-class PingActor(promise: Promise[Long], messages: Long) extends Actor {
-  var i = 0L
-  val maxCount = messages
-  var startTime = 0L
-  var pongRef: ActorRef = null
+    val toPong = new ArrayBlockingQueue[java.lang.Long](1)
+    val toPing = new ArrayBlockingQueue[java.lang.Long](1)
+    @volatile var errors = 0L
 
-  def receive = {
-    case Start(pong) =>
-      pongRef = pong
-      startTime = System.nanoTime()
-      i = 0
-      pongRef ! Pong(i)
+    val start = System.nanoTime()
 
-    case Ping(value) =>
-      // Validate received value matches what was sent
-      if (value != i) {
-        System.err.println(s"Ping validation error: expected $i, got $value")
+    val pong = new Thread(() => {
+      var n = 0L
+      while (n < messages) {
+        val v = toPong.take()
+        toPing.put(v)
+        n += 1
       }
+    })
+    pong.start()
 
+    var i = 0L
+    while (i < messages) {
+      toPong.put(java.lang.Long.valueOf(i))
+      val back = toPing.take()
+      if (back.longValue() != i) errors += 1
       i += 1
-      if (i < maxCount) {
-        pongRef ! Pong(i)
-      } else {
-        val endTime = System.nanoTime()
-        val elapsed = endTime - startTime
-        promise.success(elapsed)
-        context.system.terminate()
-      }
+    }
+    pong.join()
+
+    val elapsed = System.nanoTime() - start
+    if (errors > 0) println(s"VALIDATION FAILED: $errors errors")
+
+    val nsPerMsg = elapsed / messages
+    val throughput = messages.toDouble / elapsed * 1e9
+
+    println(s"ns/msg:         $nsPerMsg")
+    println(f"Throughput:     ${throughput / 1e6}%.2f M msg/sec")
   }
-}
-
-class PongActor(ping: ActorRef) extends Actor {
-  var expected = 0L
-
-  def receive = {
-    case Pong(value) =>
-      // Validate received value matches expected sequence
-      if (value != expected) {
-        System.err.println(s"Pong validation error: expected $expected, got $value")
-      }
-      expected += 1
-      // Echo back the EXACT value received
-      ping ! Ping(value)
-  }
-}
-
-object PingPongBenchmark extends App {
-  val messages = sys.env.get("BENCHMARK_MESSAGES").flatMap(s => scala.util.Try(s.toLong).toOption).getOrElse(100000L)
-
-  println("=== Scala Akka Ping-Pong Benchmark ===")
-  println(s"Messages: $messages\n")
-
-  val system = ActorSystem("PingPong")
-  val promise = Promise[Long]()
-
-  val ping = system.actorOf(Props(classOf[PingActor], promise, messages: java.lang.Long))
-  val pong = system.actorOf(Props(classOf[PongActor], ping))
-
-  ping ! Start(pong)
-
-  val elapsed = Await.result(promise.future, 120.seconds)
-  val elapsedSec = elapsed.toDouble / 1e9
-  val nsPerMsg = elapsed.toDouble / messages
-  val throughput = messages / elapsedSec / 1e6
-
-  println(f"ns/msg:         $nsPerMsg%.2f")
-  println(f"Throughput:     $throughput%.2f M msg/sec")
-
-  Await.result(system.whenTerminated, 10.seconds)
 }

--- a/benchmarks/cross-language/scala/skynet.scala
+++ b/benchmarks/cross-language/scala/skynet.scala
@@ -1,105 +1,60 @@
 package bench.skynet
 
-// Scala Akka Skynet Benchmark
-// Based on https://github.com/atemerev/skynet
-// Recursive actor tree using Akka actors.
-// Below the sequential threshold, subtree sums are computed without spawning.
+import java.util.concurrent.{ForkJoinPool, RecursiveTask}
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import scala.concurrent.{Await, Promise}
-import scala.concurrent.duration._
-
-case class Compute(offset: Long, size: Long)
-case class SkynetResult(value: Long)
-
-// Shared by the actor and the reporting below. Same threshold as every other
-// language here.
-object SkynetNode {
+// Same threshold as every other language here; see FAIRNESS.md.
+object Leaf {
   val SeqThreshold = 1000L
-}
 
-class SkynetNode(parent: ActorRef) extends Actor {
-  var pending = 0
-  var total: Long = 0L
-  import SkynetNode.SeqThreshold
-
-  def receive = {
-    case Compute(offset, size) =>
-      if (size <= SeqThreshold) {
-        var sum = 0L
-        var i = 0L
-        while (i < size) {
-          sum += offset + i
-          i += 1
-        }
-        parent ! SkynetResult(sum)
-        context.stop(self)
-      } else {
-        val childSize = size / 10
-        val remainder = size - childSize * 10
-        pending = 10
-        var childOffset = offset
-        var idx = 0
-        while (idx < 10) {
-          val cs = childSize + (if (idx < remainder) 1 else 0)
-          val child = context.actorOf(Props(new SkynetNode(self)))
-          child ! Compute(childOffset, cs)
-          childOffset += cs
-          idx += 1
-        }
-      }
-
-    case SkynetResult(value) =>
-      total += value
-      pending -= 1
-      if (pending == 0) {
-        parent ! SkynetResult(total)
-        context.stop(self)
-      }
+  def sum(offset: Long, size: Long): Long = {
+    var acc = 0L
+    var i = 0L
+    while (i < size) { acc += offset + i; i += 1 }
+    acc
   }
 }
 
-class SkynetRoot(numLeaves: Long, promise: Promise[Long]) extends Actor {
-  def receive = {
-    case SkynetResult(value) =>
-      promise.success(value)
-      context.stop(self)
-  }
-
-  override def preStart(): Unit = {
-    val root = context.actorOf(Props(new SkynetNode(self)))
-    root ! Compute(0, numLeaves)
+final class SkynetTask(offset: Long, size: Long) extends RecursiveTask[Long] {
+  def compute(): Long = {
+    if (size <= Leaf.SeqThreshold) return Leaf.sum(offset, size)
+    val childSize = size / 10
+    val children = new Array[SkynetTask](10)
+    var i = 0
+    while (i < 10) {
+      children(i) = new SkynetTask(offset + i * childSize, childSize)
+      children(i).fork()
+      i += 1
+    }
+    var total = 0L
+    i = 9
+    while (i >= 0) { total += children(i).join(); i -= 1 }
+    total
   }
 }
 
-object SkynetBenchmark extends App {
-  val envVal = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000")
-  val numLeaves = envVal.toLong
+object SkynetBenchmark {
+  def main(args: Array[String]): Unit = {
+    val numLeaves = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000").toLong
 
-  // Total tree nodes (same formula as all languages for fair comparison)
-  // Units created; also the divisor. See FAIRNESS.md.
-  var totalNodes = 1L
-  var nn = numLeaves
-  while (nn > SkynetNode.SeqThreshold) { totalNodes += nn / SkynetNode.SeqThreshold; nn /= 10 }
+    // Units created; also the divisor. See FAIRNESS.md.
+    var units = 1L
+    var n = numLeaves
+    while (n > Leaf.SeqThreshold) { units += n / Leaf.SeqThreshold; n /= 10 }
 
-  val system = ActorSystem("skynet")
-  val promise = Promise[Long]()
+    println("=== Scala Skynet Benchmark ===")
+    println(s"Leaves: $numLeaves, concurrency units: $units (sequential below ${Leaf.SeqThreshold})")
+    println("Using java.util.concurrent.ForkJoinPool\n")
 
-  val start = System.nanoTime()
-  system.actorOf(Props(new SkynetRoot(numLeaves, promise)))
-  val result = Await.result(promise.future, 60.seconds)
-  val elapsed = System.nanoTime() - start
+    val start = System.nanoTime()
+    val pool = new ForkJoinPool()
+    val result = pool.invoke(new SkynetTask(0, numLeaves))
+    val elapsed = System.nanoTime() - start
 
-  println(s"Leaves: $numLeaves, concurrency units: $totalNodes (sequential below ${SkynetNode.SeqThreshold})")
-  println(s"Sum: $result")
+    println(s"Sum: $result")
+    val nsPerMsg = elapsed / units
+    val throughput = units.toDouble / elapsed * 1e9
 
-  if (elapsed > 0) {
-    val nsPerMsg = elapsed / totalNodes
-    val throughput = totalNodes.toDouble / elapsed * 1e9
     println(s"ns/msg:         $nsPerMsg")
     println(f"Throughput:     ${throughput / 1e6}%.2f M msg/sec")
   }
-
-  system.terminate()
-  Await.result(system.whenTerminated, 10.seconds)
 }

--- a/benchmarks/cross-language/scala/skynet.scala
+++ b/benchmarks/cross-language/scala/skynet.scala
@@ -12,8 +12,8 @@ import scala.concurrent.duration._
 case class Compute(offset: Long, size: Long)
 case class SkynetResult(value: Long)
 
-// One definition, shared by the actor and the reporting below: the same
-// threshold every language in this suite uses, so all create 1,111 units.
+// Shared by the actor and the reporting below. Same threshold as every other
+// language here.
 object SkynetNode {
   val SeqThreshold = 1000L
 }
@@ -77,8 +77,7 @@ object SkynetBenchmark extends App {
   val numLeaves = envVal.toLong
 
   // Total tree nodes (same formula as all languages for fair comparison)
-  // Concurrency units actually created; also the divisor, since every language
-  // in this suite creates the same count.
+  // Units created; also the divisor. See FAIRNESS.md.
   var totalNodes = 1L
   var nn = numLeaves
   while (nn > SkynetNode.SeqThreshold) { totalNodes += nn / SkynetNode.SeqThreshold; nn /= 10 }

--- a/benchmarks/cross-language/scala/skynet.scala
+++ b/benchmarks/cross-language/scala/skynet.scala
@@ -12,10 +12,16 @@ import scala.concurrent.duration._
 case class Compute(offset: Long, size: Long)
 case class SkynetResult(value: Long)
 
+// One definition, shared by the actor and the reporting below: the same
+// threshold every language in this suite uses, so all create 1,111 units.
+object SkynetNode {
+  val SeqThreshold = 1000L
+}
+
 class SkynetNode(parent: ActorRef) extends Actor {
   var pending = 0
   var total: Long = 0L
-  val SeqThreshold = 100L
+  import SkynetNode.SeqThreshold
 
   def receive = {
     case Compute(offset, size) =>
@@ -71,9 +77,11 @@ object SkynetBenchmark extends App {
   val numLeaves = envVal.toLong
 
   // Total tree nodes (same formula as all languages for fair comparison)
-  var totalNodes = 0L
+  // Concurrency units actually created; also the divisor, since every language
+  // in this suite creates the same count.
+  var totalNodes = 1L
   var nn = numLeaves
-  while (nn >= 1) { totalNodes += nn; nn /= 10 }
+  while (nn > SkynetNode.SeqThreshold) { totalNodes += nn / SkynetNode.SeqThreshold; nn /= 10 }
 
   val system = ActorSystem("skynet")
   val promise = Promise[Long]()
@@ -83,6 +91,7 @@ object SkynetBenchmark extends App {
   val result = Await.result(promise.future, 60.seconds)
   val elapsed = System.nanoTime() - start
 
+  println(s"Leaves: $numLeaves, concurrency units: $totalNodes (sequential below ${SkynetNode.SeqThreshold})")
   println(s"Sum: $result")
 
   if (elapsed > 0) {

--- a/benchmarks/cross-language/scala/thread_ring.scala
+++ b/benchmarks/cross-language/scala/thread_ring.scala
@@ -1,83 +1,51 @@
 package bench.thread_ring
 
-// Scala Akka Thread Ring Benchmark (Savina-style)
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import java.util.concurrent.ArrayBlockingQueue
 
-case class SetNext(next: ActorRef)
-case class Token(hops: Int)
-case class RingDone(received: Int)
+// 100 threads in a ring, each passing the token to the next.
+object ThreadRingBenchmark {
+  def main(args: Array[String]): Unit = {
+    val messages = sys.env.getOrElse("BENCHMARK_MESSAGES", "1000000").toLong
+    val ringSize = 100
 
-class RingNodeActor(parent: ActorRef) extends Actor {
-  var next: ActorRef = null
-  var received = 0
+    println("=== Scala Thread Ring Benchmark ===")
+    println(s"Ring size: $ringSize, messages: $messages")
+    println("Using java.util.concurrent.ArrayBlockingQueue\n")
 
-  def receive = {
-    case SetNext(n) =>
-      next = n
-    case Token(0) =>
-      received += 1
-      parent ! RingDone(received)
-    case Token(hops) =>
-      received += 1
-      next ! Token(hops - 1)
-  }
-}
+    val queues = Array.fill(ringSize)(new ArrayBlockingQueue[java.lang.Long](1))
+    val threads = new Array[Thread](ringSize)
 
-class ParentActor(promise: Promise[Int], ringSize: Int, numHops: Int) extends Actor {
-  var nodes: Array[ActorRef] = null
+    val start = System.nanoTime()
 
-  override def preStart(): Unit = {
-    // Create ring nodes
-    nodes = Array.tabulate(ringSize)(i =>
-      context.actorOf(Props(classOf[RingNodeActor], self), s"node$i")
-    )
-
-    // Link them in a ring
-    for (i <- 0 until ringSize) {
-      nodes(i) ! SetNext(nodes((i + 1) % ringSize))
+    var id = 0
+    while (id < ringSize) {
+      val me = id
+      val next = (id + 1) % ringSize
+      threads(me) = new Thread(() => {
+        var running = true
+        while (running) {
+          val token = queues(me).take().longValue()
+          if (token <= 0) {
+            if (me != ringSize - 1) queues(next).put(java.lang.Long.valueOf(token))
+            running = false
+          } else {
+            queues(next).put(java.lang.Long.valueOf(token - 1))
+          }
+        }
+      })
+      threads(me).start()
+      id += 1
     }
 
-    // Inject token
-    nodes(0) ! Token(numHops)
+    queues(0).put(java.lang.Long.valueOf(messages))
+    var t = 0
+    while (t < ringSize) { threads(t).join(); t += 1 }
+
+    val elapsed = System.nanoTime() - start
+    val nsPerMsg = elapsed / messages
+    val throughput = messages.toDouble / elapsed * 1e9
+
+    println(s"ns/msg:         $nsPerMsg")
+    println(f"Throughput:     ${throughput / 1e6}%.2f M msg/sec")
   }
-
-  def receive = {
-    case RingDone(received) =>
-      promise.success(received)
-      context.system.terminate()
-  }
-}
-
-object ThreadRingBenchmark extends App {
-  val ringSize = 100
-  val numHops = sys.env.get("BENCHMARK_MESSAGES").flatMap(s => scala.util.Try(s.toInt).toOption).getOrElse(100000)
-  println("=== Scala Akka Thread Ring Benchmark ===")
-  println(s"Ring size: $ringSize, Hops: $numHops\n")
-
-  val system = ActorSystem("ThreadRing")
-  val promise = Promise[Int]()
-
-  val startTime = System.nanoTime()
-
-  val parent = system.actorOf(Props(classOf[ParentActor], promise, ringSize, numHops))
-
-  val received = Await.result(promise.future, 120.seconds)
-  val endTime = System.nanoTime()
-
-  val elapsed = (endTime - startTime).toDouble / 1e9
-  val totalMessages = numHops + 1
-
-  if (received != totalMessages) {
-    println(s"VALIDATION FAILED: expected $totalMessages, got $received")
-  }
-
-  val throughput = totalMessages / elapsed / 1e6
-  val nsPerMsg = elapsed * 1e9 / totalMessages
-
-  println(f"ns/msg:         $nsPerMsg%.2f")
-  println(f"Throughput:     $throughput%.2f M msg/sec")
-
-  Await.result(system.whenTerminated, 10.seconds)
 }

--- a/benchmarks/cross-language/zig/skynet.zig
+++ b/benchmarks/cross-language/zig/skynet.zig
@@ -20,12 +20,10 @@ fn getLeaves() i64 {
 }
 
 fn skynetSeq(offset: i64, size: i64) i64 {
-    if (size == 1) return offset;
-    const child_size = @divTrunc(size, 10);
     var sum: i64 = 0;
     var i: i64 = 0;
-    while (i < 10) : (i += 1) {
-        sum += skynetSeq(offset + i * child_size, child_size);
+    while (i < size) : (i += 1) {
+        sum += offset + i;
     }
     return sum;
 }
@@ -81,8 +79,7 @@ fn getTimeNs() u64 {
 pub fn main() !void {
     const num_leaves = getLeaves();
 
-    // Concurrency units actually created; also the divisor, since every language
-    // in this suite creates the same count.
+    // Units created; also the divisor. See FAIRNESS.md.
     var total_actors: i64 = 1;
     var n = num_leaves;
     while (n > SEQ_THRESHOLD) : (n = @divTrunc(n, 10)) {
@@ -105,9 +102,8 @@ pub fn main() !void {
     print("Sum: {}\n", .{root.result});
     if (elapsed_us > 0) {
         const ns_per_msg = @divTrunc(elapsed_ns, total_actors);
-        // Float, like the other four Zig benchmarks. The manual
-        // integer-and-fraction version printed "0.+4" for any rate below
-        // 1 M/sec, which the runner's parser reads as garbage.
+        // Float, like the other four Zig benchmarks: the integer-and-fraction
+        // version printed "0.+4" for rates below 1 M/sec.
         const throughput = @as(f64, @floatFromInt(total_actors)) /
             (@as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0) / 1_000_000.0;
         print("ns/msg:         {}\n", .{ns_per_msg});

--- a/benchmarks/cross-language/zig/skynet.zig
+++ b/benchmarks/cross-language/zig/skynet.zig
@@ -1,13 +1,13 @@
 // Zig Skynet Benchmark
 // Based on https://github.com/atemerev/skynet
-// Uses std.Thread for top THREAD_DEPTH levels, sequential below.
+// Uses std.Thread while the subtree is larger than SEQ_THRESHOLD.
 // Spawning 1M OS threads is not feasible; limits concurrent threads to ~1000.
 
 const std = @import("std");
 const Thread = std.Thread;
 const print = std.debug.print;
 
-const THREAD_DEPTH: usize = 3;
+const SEQ_THRESHOLD: i64 = 1000;
 
 fn getLeaves() i64 {
     if (std.posix.getenv("SKYNET_LEAVES")) |val| {
@@ -42,7 +42,7 @@ fn skynetThread(arg: *SkynetArg) void {
     const size = arg.size;
     const depth = arg.depth;
 
-    if (size == 1 or depth >= THREAD_DEPTH) {
+    if (size <= SEQ_THRESHOLD) {
         arg.result = skynetSeq(offset, size);
         return;
     }
@@ -81,15 +81,16 @@ fn getTimeNs() u64 {
 pub fn main() !void {
     const num_leaves = getLeaves();
 
-    // Total actors = sum of nodes at each level
-    var total_actors: i64 = 0;
+    // Concurrency units actually created; also the divisor, since every language
+    // in this suite creates the same count.
+    var total_actors: i64 = 1;
     var n = num_leaves;
-    while (n >= 1) : (n = @divTrunc(n, 10)) {
-        total_actors += n;
+    while (n > SEQ_THRESHOLD) : (n = @divTrunc(n, 10)) {
+        total_actors += @divTrunc(n, SEQ_THRESHOLD);
     }
 
     print("=== Zig Skynet Benchmark ===\n", .{});
-    print("Leaves: {} (std.Thread, top {} levels parallel)\n\n", .{ num_leaves, THREAD_DEPTH });
+    print("Leaves: {}, concurrency units: {} (sequential below {})\n\n", .{ num_leaves, total_actors, SEQ_THRESHOLD });
 
     var root = SkynetArg{ .offset = 0, .size = num_leaves, .depth = 0 };
 
@@ -104,10 +105,12 @@ pub fn main() !void {
     print("Sum: {}\n", .{root.result});
     if (elapsed_us > 0) {
         const ns_per_msg = @divTrunc(elapsed_ns, total_actors);
-        const throughput_m = @divTrunc(total_actors, elapsed_us);
-        const leftover = total_actors - (throughput_m * elapsed_us);
-        const frac = @divTrunc(leftover * 100, elapsed_us);
+        // Float, like the other four Zig benchmarks. The manual
+        // integer-and-fraction version printed "0.+4" for any rate below
+        // 1 M/sec, which the runner's parser reads as garbage.
+        const throughput = @as(f64, @floatFromInt(total_actors)) /
+            (@as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0) / 1_000_000.0;
         print("ns/msg:         {}\n", .{ns_per_msg});
-        print("Throughput:     {}.{:0>2} M msg/sec\n", .{ throughput_m, frac });
+        print("Throughput:     {d:.2} M msg/sec\n", .{throughput});
     }
 }


### PR DESCRIPTION
Cross-language benchmarks measured different amounts of work in different languages, and one of them measured a third-party framework. This makes the suite comparable, writes the rules down, and finishes the two benchmarks that were missing.

## What was wrong

**Skynet credited implementations for actors they never created.** The pattern sums 1,000,000 leaves over a 10-ary tree, and every implementation divided its time by the tree's full node count, 1,111,111, while creating wildly different numbers of concurrency units: Go, Erlang and Elixir created all 1,111,111; Aether, Java and Scala went sequential below 100 and created 11,111; C, C++, Rust and Zig used threads for the top three levels and created 1,111. So the implementations that did the least concurrency work scored the highest, by 100x for Aether and 1000x for the four thread-based ones:

```
C       Throughput:  72.02 M msg/sec     (1,111 threads)
Aether  Throughput: 225.05 M msg/sec     (11,111 actors)
Go      Throughput:   3.66 M msg/sec     (1,111,111 goroutines)
```

Go did a thousand times more work than C and looked twenty times worse at it. 1,111,111 is not the number to equalise on either, because a pthread is not a goroutine: this machine created 4,095 concurrent pthreads before failing. All eleven now go sequential below a subtree size of 1000, so each creates 1,111 units, each divides by the count it created, and each prints that count so the invariant is checkable.

**The sequential half was not equal either.** C, C++, Go, Rust and Zig summed a leaf subtree by recursing 10-ary to size 1, about 11% more calls than values plus call overhead. Erlang built a 1000-element list per leaf, which cost it 2.7x on its own: 4,017 ns per unit against 1,507 without it. All eleven now use a plain accumulator loop.

**The Scala column measured Akka.** All five implementations imported `akka.actor` and `build.sbt` pulled `akka-actor` 2.8.5, so one language in a standard-library comparison was running a third-party actor framework. They now use `java.util.concurrent`, which is what the Java column uses: a bounded queue per mailbox for counting, ping-pong, thread-ring and fork-join, `ForkJoinPool` for skynet. `build.sbt` declares no dependencies. `scala.actors` was removed in 2.13 and `scala.concurrent.Channel` is deprecated, so this is base Scala for this suite. Dropping Akka made skynet 8x faster, 38,322 ns per unit to 4,869, which is the measure of how much that column was reporting about Akka rather than about Scala.

**Pony implemented three of five patterns**, so the README's "55 total, zero skips" was really 53 and the runner would have failed on the missing directories. `ping_pong` and `skynet` are written; all five build and run, and skynet reports 1,111 units and the correct sum.

**`.gitignore` was hiding them.** The compiled-binary patterns are `benchmarks/cross-language/*/<pattern>`, and Pony compiles a directory rather than a file, so each pattern also matched a Pony source directory: a newly written Pony benchmark did not appear in `git status` at all and could not be committed. The three that exist predate the rule and stayed visible only because it does not apply to tracked files. Re-included `pony/*/` and ignored its contents except `*.pony`, so binaries stay out and future benchmarks are visible.

**Ping-pong timed different regions.** Aether, Erlang and Elixir created their units before starting the clock; the other eight started it first. All eleven now start the clock first.

**Zig printed a malformed rate.** `zig/skynet.zig` assembled throughput from an integer and a fraction and printed `0.+4 M msg/sec` for any rate below 1 M/sec, which the runner's parser reads as garbage. It now uses a float and `{d:.2}` like the other four Zig benchmarks.

## Results

Median of five runs, three for Scala, 1,000,000 leaves, 1,111 units, every implementation returning 499999500000.

| Language | ns per unit | Range |
|---|---:|---|
| Pony | 501 | 424-562 |
| Go | 562 | 502-663 |
| Aether | 594 | 417-676 |
| Erlang | 1,034 | 944-1200 |
| Elixir | 1,071 | 975-1204 |
| Scala | 6,561 | 5565-8794 |
| C | 9,230 | 8771-10087 |
| Rust | 14,763 | 13276-22556 |
| Zig | 15,272 | 14384-18666 |
| Java | 15,892 | 11878-20299 |
| C++ | 23,845 | 8666-36108 |

That is two groups, not eleven positions. The five that schedule their own units pay half a microsecond to one microsecond each; the six that hand work to an OS thread or pool pay six to twenty-four. **Within each group the ordering is not a result**, and FAIRNESS.md says so: Pony 501, Go 562 and Aether 594 have ranges that overlap almost entirely, and these figures were taken on a machine also running other toolchains, where C++ spanned 8,666 to 36,108, wider than its distance from C.

An earlier pass on this branch reported single runs and had Aether at 471 against Go at 799, which reads as a 1.7x win for Aether. It was noise, and it is withdrawn.

## FAIRNESS.md

The six rules the suite holds itself to, the audit that produced each one, and how to check a change against them: standard library only, the same number of concurrency units, the same sequential work, rates divided by work actually performed, the same region timed, medians with the spread.

## Verification

- All 55 combinations build and run; every skynet prints `concurrency units: 1111` and `Sum: 499999500000`
- `make test`: 230 passed, 0 failed
- `-Werror` build: zero warnings
- fmt gate: canonical, idempotent on 92 files, IR-preserving on 84

Closes #1532
Closes #1533
Closes #1534