### PR TITLE
fix(codegen): string.free actually frees, unbox_closure stops segfaulting, unresolved-type warning gets a location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,60 @@ version number before tagging the release.
 
 ### Fixed
 
+- **A string returned through a heap-returning boundary leaked when the caller
+  freed it.** An Aether `string` is either a refcounted AetherString or a plain
+  malloc'd payload, and the runtime cannot free the second: given a bare
+  `char*` it cannot tell a heap payload from static storage, so `string.free`
+  no-ops and the value leaks. Every heap-returning function routes its returns
+  through a uniform-heap helper whose cold half (a literal, or anything not
+  already owned) minted exactly that bare buffer, so the two branches of one
+  function returned two different shapes and the caller could only free one of
+  them. `json.parse` leaked a block per call at its success-path error slot,
+  and so did every literal returned the same way. The cold path now mints the
+  same refcounted shape the sibling branch already returns, which costs the
+  hot path nothing. `tests/leaks_known.txt` loses its
+  `test_fs_read_error_detail` entry, which was filed for this and annotated to
+  be dropped once fixed; that test reports zero rather than its allowed three,
+  and `test_string_double_locale` goes from one leak to none.
+
+  Freeing an interpolated string still leaks: interpolation has a different
+  producer, and closing that half means separating "escaped because something
+  else owns it" from "escaped because this call frees it" in the ownership
+  analysis. Tracked separately with the measurements behind that conclusion. Registering `string_free` as non-storing
+  in the codegen looks like the fix for both and is not, because it withdraws
+  the escape marking that suppresses automatic frees, and
+  `contrib/tinyweb/example_schema_api` then double-frees and aborts.
+
+- **`or` took its handler on success when the error slot was a refcounted
+  string.** "Is this an error" is "is the error slot non-empty", and the slot
+  holds either physical string shape, but the check indexed the pointer raw, so
+  a refcounted slot's magic header read as content and every such result looked
+  like a failure. A function whose success path returns `string.concat("", "")`
+  in the error slot, the uniform shape std/json documents, took the `or`
+  handler on success. The `defer` success/error guard used the same convention
+  and had the same flaw. Both now read the payload through
+  `aether_string_data`, which handles either shape.
+
+- **`unbox_closure()` on a value that was never boxed segfaulted with no
+  diagnostic.** A bare function passed into a `ptr` slot stays a raw code
+  address; unboxing it read `.env` out of the function's own machine code and
+  jumped through it. Boxed closures now carry a tag after the `{fn, env}`
+  prefix, and unbox panics with a message naming the cause and the fix. The tag
+  goes after that prefix deliberately: it is the FFI layout std/collections and
+  std/worker read, and a tag in front would turn their `fn` into the tag and
+  call it.
+
+- **`box_closure()` rejected a bare function**, which is the value most likely
+  to need boxing and what the new panic message recommends. It now wraps one in
+  the same env-ignoring adapter a ptr-typed field assignment already used.
+
+- **The codegen `unresolved type` warning had no source location**, so it could
+  not be traced or fixed from the source side, and no flag produced one. It now
+  reports file, line, column and the enclosing function. The warning fires on
+  in-tree examples today, and one of those turned out to be a real defect
+  rather than noise, filed separately: an actor `?` ask never infers its reply
+  type, so a non-int reply fails to build.
+
 - **The cross-language skynet benchmark credited every implementation for
   actors it never created.** All eleven divided by the tree's full node count,
   1,111,111, while creating between 1,111 and 1,111,111 concurrency units

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1243,7 +1243,9 @@ static int defer_fires_at_exit(CodeGenerator* gen, int i) {
 /* #1140 — emit one deferred statement, wrapping it in a runtime guard when the
  * exit's success/error outcome is not statically known. The guard uses exactly
  * the convention the rest of the compiler uses for "this result carries an
- * error": a non-NULL, non-empty error slot (`e && e[0]`). */
+ * error": a non-NULL, non-empty error slot. Non-empty is read through
+ * aether_string_data, since the slot holds either physical string shape and
+ * indexing a refcounted one raw reads its magic header as content. */
 static void emit_deferred_one(CodeGenerator* gen, int i) {
     ASTNode* deferred = gen->defer_stack[i];
     if (!deferred) return;
@@ -1254,7 +1256,7 @@ static void emit_deferred_one(CodeGenerator* gen, int i) {
                    gen->defer_err_slot != NULL);
     if (guarded) {
         print_indent(gen);
-        fprintf(gen->output, "if (%s(%s && %s[0])) {\n",
+        fprintf(gen->output, "if (%s(%s && aether_string_data((const void*)%s)[0])) {\n",
                 mode == DEFER_CATCH ? "" : "!",
                 gen->defer_err_slot, gen->defer_err_slot);
         gen->indent_level++;
@@ -1968,6 +1970,34 @@ const char* safe_value_name(const char* name) {
     return buf;
 }
 
+/* Source position of the construct codegen is lowering right now.
+ * get_c_type() and the other Type-only helpers have no AST node to blame,
+ * so a diagnostic raised from inside them would print with no file or line
+ * and be impossible to act on. generate_statement / generate_expression /
+ * the function emitter keep this current as they walk. */
+static const char* g_diag_file = NULL;
+static int g_diag_line = 0;
+static int g_diag_column = 0;
+static const char* g_diag_func = NULL;
+static char g_diag_context[160];
+
+void codegen_note_diag_pos(const ASTNode* node) {
+    if (!node || node->line <= 0) return;
+    g_diag_line = node->line;
+    g_diag_column = node->column;
+    if (node->source_file) g_diag_file = node->source_file;
+}
+
+void codegen_note_diag_func(const char* name) {
+    g_diag_func = name;
+}
+
+const char* codegen_diag_context(void) {
+    if (!g_diag_func) return NULL;
+    snprintf(g_diag_context, sizeof(g_diag_context), "in function %s", g_diag_func);
+    return g_diag_context;
+}
+
 const char* get_c_type(Type* type) {
     if (!type) {
         AetherError w = {NULL, NULL, 0, 0, "internal: NULL type in codegen, defaulting to int",
@@ -2184,18 +2214,19 @@ const char* get_c_type(Type* type) {
             if (type->is_fnptr) return "void*";
             return "_AeClosure";
         case TYPE_UNKNOWN: {
-            AetherError w = {NULL, NULL, 0, 0,
+            AetherError w = {g_diag_file, NULL, g_diag_line, g_diag_column,
                              "unresolved type in codegen, defaulting to int",
                              "add explicit type annotation or check that the variable is initialized",
-                             NULL, AETHER_ERR_NONE};
+                             codegen_diag_context(), AETHER_ERR_NONE};
             aether_warning_report(&w);
             return "int";
         }
         default: {
             char wbuf[128];
             snprintf(wbuf, sizeof(wbuf), "internal: unknown type kind %d in codegen, defaulting to void", type->kind);
-            AetherError w = {NULL, NULL, 0, 0, wbuf,
-                             "this is a compiler bug, please report it", NULL, AETHER_ERR_NONE};
+            AetherError w = {g_diag_file, NULL, g_diag_line, g_diag_column, wbuf,
+                             "this is a compiler bug, please report it",
+                             codegen_diag_context(), AETHER_ERR_NONE};
             aether_warning_report(&w);
             return "void";
         }
@@ -4361,16 +4392,22 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
      * caller's unconditional `free()` would crash on it; the helper
      * duplicates so the caller's free reclaims the dup uniformly.
      *
-     * Cap-aware allocation: the cold-path dup is gated by the
-     * resource-caps tracker (#343, aether_resource_caps.h). A host
-     * that arms `aether_set_memory_cap(N)` bounds this path; with no
-     * cap armed it's a single branch + libc malloc. The matching
-     * free() at the caller side is plain libc free() — heap-safe
-     * because aether_caps_malloc returns a libc-compatible pointer
-     * (header comment at aether_resource_caps.h:89-94). Cap
-     * accounting drifts upward on the dup path; consistent with the
-     * existing string_concat and stdlib alloc shapes whose frees
-     * also bypass aether_caps_account_free.
+     * The cold-path dup mints a refcounted AetherString rather than a
+     * bare buffer, because the caller cannot free a bare one. Aether's
+     * `string` is either shape, and given a plain `char*` the runtime
+     * cannot tell a heap payload from a static literal, so
+     * `string.free(s)` no-ops on it and the value leaks: one block per
+     * call at every `json.parse` error slot, every interpolation, every
+     * HTTP body a caller dutifully frees (#1461).
+     *
+     * The hot path is untouched, so nothing that was already owned pays
+     * for this, and the shape is not new to callers: the sibling path of
+     * every one of these returns already hands back a string_concat
+     * result, which is the same refcounted shape. Both `string_release`
+     * and the codegen's `aether_heap_str_free` reclaim it, and printing
+     * and comparison go through `aether_string_data`, which reads either
+     * shape. What must NOT appear is a plain `free()` on the result: that
+     * would reclaim the header and leak the payload.
      *
      * Binary-safety: Aether's `string` carries either plain `char*` or
      * a length-bearing `AetherString*` (magic-header struct). The cold-
@@ -4387,6 +4424,7 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "#include <stdlib.h>");
     print_line(gen, "#include <stddef.h>");
     print_line(gen, "extern void* aether_caps_malloc(size_t bytes);");
+    print_line(gen, "extern void* string_new_with_length(const char* data, int length);");
     print_line(gen, "static inline const char* aether_uniform_heap_str(const char* s, int is_heap) {");
     print_line(gen, "    if (!s) return (const char*)0;");
     print_line(gen, "    if (is_heap) return s;");
@@ -4407,11 +4445,7 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "    } else {");
     print_line(gen, "        _n = strlen(s);");
     print_line(gen, "    }");
-    print_line(gen, "    char* _d = (char*)aether_caps_malloc(_n + 1);");
-    print_line(gen, "    if (!_d) return (const char*)0;");
-    print_line(gen, "    if (_n) memcpy(_d, _data, _n);");
-    print_line(gen, "    _d[_n] = '\\0';");
-    print_line(gen, "    return (const char*)_d;");
+    print_line(gen, "    return (const char*)string_new_with_length(_data, (int)_n);");
     print_line(gen, "}");
     /* AetherString-aware heap-string release. A `_heap_<name>` slot
      * tracked by the codegen can hold two physically distinct shapes:
@@ -4619,9 +4653,37 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "#endif");
     // Closure support: generic closure struct (function pointer + captured environment)
     print_line(gen, "typedef struct { void (*fn)(void); void* env; } _AeClosure;");
-    // Box a closure onto the heap so it can be stored in a list (void*)
-    print_line(gen, "static inline void* _aether_box_closure(_AeClosure c) { _AeClosure* p = malloc(sizeof(_AeClosure)); *p = c; return (void*)p; }");
-    print_line(gen, "static inline _AeClosure _aether_unbox_closure(void* p) { return *(_AeClosure*)p; }");
+    /* Boxed form. The tag sits AFTER the {fn, env} prefix on purpose: that
+     * prefix is the FFI layout std/collections and std/worker mirror and
+     * embedders are documented to rely on, so putting the tag first would
+     * silently turn every C-side reader's `fn` into the tag and call it.
+     *
+     * Boxing is the only way a valid closure pointer is ever produced, so
+     * the tag is what tells a real box apart from a raw code address,
+     * which is what a bare function coerced into a `ptr` slot leaves
+     * behind. Unboxing that used to read `.env` off the function's own
+     * machine code and jump through it (issue #1439). */
+    print_line(gen, "typedef struct { void (*fn)(void); void* env; unsigned long long tag; } _AeClosureBox;");
+    print_line(gen, "#define _AE_CLOSURE_TAG 0xAEC105EDB0CEDULL");
+    print_line(gen, "static inline void* _aether_box_closure(_AeClosure c) {");
+    print_line(gen, "    _AeClosureBox* p = (_AeClosureBox*)malloc(sizeof(_AeClosureBox));");
+    print_line(gen, "    if (!p) return (void*)0;");
+    print_line(gen, "    p->fn = c.fn; p->env = c.env; p->tag = _AE_CLOSURE_TAG;");
+    print_line(gen, "    return (void*)p;");
+    print_line(gen, "}");
+    print_line(gen, "static inline _AeClosure _aether_unbox_closure(void* p) {");
+    print_line(gen, "    if (!p || ((const _AeClosureBox*)p)->tag != _AE_CLOSURE_TAG) {");
+    print_line(gen, "        aether_panic(\"unbox_closure() on a value that was never boxed. \"");
+    print_line(gen, "                     \"A bare function stored into a `ptr` slot stays a raw code \"");
+    print_line(gen, "                     \"pointer; only a value that crossed an `fn`-typed boundary or \"");
+    print_line(gen, "                     \"went through box_closure() carries an environment. Declare the \"");
+    print_line(gen, "                     \"slot `fn`, or box explicitly before storing it.\");");
+    print_line(gen, "    }");
+    print_line(gen, "    _AeClosure c;");
+    print_line(gen, "    c.fn = ((const _AeClosureBox*)p)->fn;");
+    print_line(gen, "    c.env = ((const _AeClosureBox*)p)->env;");
+    print_line(gen, "    return c;");
+    print_line(gen, "}");
     // Lazy evaluation: thunks (deferred computation with memoization)
     print_line(gen, "typedef struct { _AeClosure compute; intptr_t value; int evaluated; } _AeThunk;");
     print_line(gen, "static inline void* _aether_thunk_new(_AeClosure c) { _AeThunk* t = malloc(sizeof(_AeThunk)); t->compute = c; t->value = 0; t->evaluated = 0; return (void*)t; }");
@@ -5171,6 +5233,8 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         ASTNode* cd = program->children[i];
         if (cd && cd->type == AST_CONST_DECLARATION &&
             cd->value && cd->child_count > 0) {
+            codegen_note_diag_pos(cd);
+            codegen_note_diag_func(NULL);
             if (cd->annotation && strcmp(cd->annotation, "array_const") == 0) {
                 // static const T NAME[] = {v1, v2, ...};
                 Type* elem_type = (cd->node_type && cd->node_type->element_type)
@@ -5237,6 +5301,8 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         ASTNode* child = program->children[i];
         if (!child || (child->type != AST_FUNCTION_DEFINITION && child->type != AST_BUILDER_FUNCTION)) continue;
         if (!child->value) continue;
+        codegen_note_diag_pos(child);
+        codegen_note_diag_func(child->value);
 
         // Skip if already forward-declared (pattern matching generates combined functions)
         int already_declared = 0;

--- a/compiler/codegen/codegen.h
+++ b/compiler/codegen/codegen.h
@@ -533,6 +533,12 @@ void print_line(CodeGenerator* gen, const char* format, ...);
 void codegen_maybe_emit_line(CodeGenerator* gen, const ASTNode* node);
 void print_expression(CodeGenerator* gen, ASTNode* expr);
 const char* get_c_type(Type* type);
+
+/* Current-position register for diagnostics raised from Type-only helpers
+ * (get_c_type and friends), which have no AST node of their own to blame. */
+void codegen_note_diag_pos(const ASTNode* node);
+void codegen_note_diag_func(const char* name);
+const char* codegen_diag_context(void);
 const char* get_c_operator(const char* aether_op);
 
 // Defer management

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -2178,6 +2178,8 @@ static int utf8_sequence_length(const char* s) {
 void generate_expression(CodeGenerator* gen, ASTNode* expr) {
     if (!expr) return;
 
+    codegen_note_diag_pos(expr);
+
     /* Argument-temp lifetime substitution. If this AST_FUNCTION_CALL
      * node has been hoisted by a parent-call wrap (see
      * arg_drain_register at the AST_FUNCTION_CALL fallthrough below),
@@ -2328,7 +2330,14 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                            or_fallible_value_slot_is_heap(gen, fallible));
             fprintf(gen->output, "({ %s _oe%d = ", tuple_c, id);
             generate_expression(gen, fallible);
-            fprintf(gen->output, "; %s _oer%d;\nif (_oe%d._%d && _oe%d._%d[0]) {\n",
+            /* "Is this an error" is "is the error slot non-empty", and the
+             * slot holds either physical string shape. Indexing it raw reads
+             * the AetherString magic header as content, so every refcounted
+             * error slot looks non-empty whatever it says: `parse_strict`
+             * returns an empty one on SUCCESS and `or` took the handler.
+             * aether_string_data yields the payload for either shape. */
+            fprintf(gen->output,
+                    "; %s _oer%d;\nif (_oe%d._%d && aether_string_data((const void*)_oe%d._%d)[0]) {\n",
                     val_c, id, id, err_idx, id, err_idx);
             if (handler->type == AST_BLOCK) {
                 /* Block statements emit their own `#line` directives, which
@@ -3836,9 +3845,9 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 // clears _heap_X. This is required because string_release
                 // no longer marks its argument escaped (is_nonstoring_
                 // builtin), so X now also receives an automatic
-                // function-exit defer-free — without clearing the flag
+                // function-exit defer-free: without clearing the flag
                 // here, `defer string.release(s)` on a magic AetherString
-                // would be freed twice (explicit + auto): a double-free.
+                // would be freed twice (explicit + auto), a double-free.
                 // Non-heap-var arguments (literals, borrowed params) fall
                 // through to the plain, literal-safe string_release call.
                 else if ((strcmp(func_name, "string_release") == 0 ||
@@ -3847,7 +3856,7 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                          expr->children[0]->type == AST_IDENTIFIER &&
                          expr->children[0]->value &&
                          is_heap_string_var(gen, expr->children[0]->value)) {
-                    /* Any heap-tracked local — NOT only string-typed.
+                    /* Any heap-tracked local, NOT only string-typed.
                      * string.from_int / from_long / new return a magic
                      * AetherString that the classifier tracks but types
                      * `-> ptr`; those too get an auto defer-free now, so
@@ -4016,9 +4025,23 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 // The trailing block becomes the last child (a closure)
                 // box_closure(closure) — heap-allocate a closure so it can be stored in a list
                 else if (strcmp(func_name, "box_closure") == 0 && expr->child_count == 1) {
-                    fprintf(gen->output, "_aether_box_closure(");
-                    generate_expression(gen, expr->children[0]);
-                    fprintf(gen->output, ")");
+                    /* A bare function has no environment, so it is not an
+                     * _AeClosure and C rejected it outright. Wrap it in the
+                     * same env-ignoring adapter a ptr-typed struct field
+                     * assignment uses, so the one operation that exists to
+                     * make a value safe for unbox_closure accepts the value
+                     * most likely to need it. */
+                    if (bare_top_level_fn(gen, expr->children[0])) {
+                        const char* bn = expr->children[0]->value;
+                        register_bare_fn_adapter(gen, bn);
+                        fprintf(gen->output,
+                                "_aether_box_closure((_AeClosure){ .fn = (void(*)(void))_aether_bare_adapter_%s, .env = NULL })",
+                                bn);
+                    } else {
+                        fprintf(gen->output, "_aether_box_closure(");
+                        generate_expression(gen, expr->children[0]);
+                        fprintf(gen->output, ")");
+                    }
                 }
                 // unbox_closure(ptr) — retrieve a closure from a heap pointer
                 else if (strcmp(func_name, "unbox_closure") == 0 && expr->child_count == 1) {

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -274,6 +274,16 @@ static void discover_bare_fn_adapters_walk(CodeGenerator* gen, ASTNode* node) {
     /* AST_FUNCTION_CALL: register any bare-fn arg whose callee param
      * is `fn`-typed. */
     if (node->type == AST_FUNCTION_CALL && node->value && gen->program) {
+        /* box_closure is a builtin, so it never resolves as a user
+         * function below; register its bare-fn argument here or the
+         * adapter the wrap site emits is never declared. */
+        if (strcmp(node->value, "box_closure") == 0 && node->child_count == 1) {
+            ASTNode* arg = node->children[0];
+            if (arg && arg->type == AST_IDENTIFIER && arg->value &&
+                find_user_function_by_name(gen, arg->value)) {
+                register_bare_fn_adapter(gen, arg->value);
+            }
+        }
         ASTNode* callee = find_user_function_by_name(gen, node->value);
         if (callee) {
             int pi = 0;
@@ -904,6 +914,8 @@ void generate_function_definition(CodeGenerator* gen, ASTNode* func) {
     // function — important when the merged program intermixes
     // user-written and module-imported functions in arbitrary order.
     codegen_maybe_emit_line(gen, func);
+    codegen_note_diag_pos(func);
+    codegen_note_diag_func(func->value);
 
     // If function returns a tuple with UNKNOWN elements, scan all returns and merge
     if (func->node_type && func->node_type->kind == TYPE_TUPLE) {

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -3940,6 +3940,8 @@ static int emit_optional_chain_assign(CodeGenerator* gen, ASTNode* lhs, ASTNode*
 void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
     if (!stmt) return;
 
+    codegen_note_diag_pos(stmt);
+
     // Emit `#line N "src.ae"` so gcc errors, gdb breakpoints, and
     // gcov reports reference the .ae source the user wrote, not the
     // mid-file position of the merged .c output. Dedup'd inside

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -333,7 +333,7 @@ function that mints a fresh owned buffer belongs here.
 
 ### User-defined `-> string` functions
 
-A user-defined function that returns `string` is treated as heap-returning **iff *any* return statement in its body yields a heap-string-expression** (recursively considering other heap-returning user functions), an OR-fold across the return sites. A function whose returns are *all* string literals or forwarded borrowed parameters is NOT heap-returning, and the wrapper won't try to free its results. A function that *mixes* the two (one branch `return string.concat(...)`, another `return "constant"`) *is* heap-returning: its literal branches are malloc-duplicated through the uniform-heap return wrap (see [Return-ownership contract](#return-ownership-contract-uniform-heap-return-escape) below) so the caller can free every branch identically.
+A user-defined function that returns `string` is treated as heap-returning **iff *any* return statement in its body yields a heap-string-expression** (recursively considering other heap-returning user functions), an OR-fold across the return sites. A function whose returns are *all* string literals or forwarded borrowed parameters is NOT heap-returning, and the wrapper won't try to free its results. A function that *mixes* the two (one branch `return string.concat(...)`, another `return "constant"`) *is* heap-returning: its literal branches are duplicated into owned strings through the uniform-heap return wrap (see [Return-ownership contract](#return-ownership-contract-uniform-heap-return-escape) below) so the caller can free every branch identically.
 
 ```aether
 my_concat(a: string, b: string) -> string {
@@ -473,7 +473,9 @@ Audited stdlib retainers carrying `@retain` today: the refcount ops `string_reta
 
 Every function whose return type is `string` honours one rule:
 
-> **The caller may always `free()` the returned pointer exactly once, regardless of which return branch produced the value, regardless of whether the value originated as a literal, a heap allocation, or a heap-tracked local.**
+> **The caller may always release the returned pointer exactly once, regardless of which return branch produced the value, regardless of whether the value originated as a literal, a heap allocation, or a heap-tracked local.**
+
+Release it with `string.free` / `string.release`, or leave it to the scope-exit reclaim, both of which route through `aether_heap_str_free` and handle either physical shape. Not with a plain `free()`: a refcounted value would lose its payload.
 
 The classifier OR-folds the function's return statements: a function is *heap-returning* if **any** return yields a heap expression (`string.concat`, interpolation, a heap-returning user fn, an `@heap` extern, or a bare identifier of a heap-tracked local). For such functions the codegen wraps every return value through a small inline helper:
 
@@ -482,11 +484,11 @@ static inline const char* aether_uniform_heap_str(const char* s, int is_heap) {
     if (!s) return NULL;
     if (is_heap) return s;                  // fast path, already heap-owned
     /* AetherString-aware length probe (magic-header detect, ASan-clean)... */
-    char* dup = malloc(n + 1);              // cold path, dup the literal
-    memcpy(dup, data, n); dup[n] = '\0';
-    return dup;
+    return string_new_with_length(data, n); // cold path, own the literal
 }
 ```
+
+The cold path mints a refcounted AetherString rather than a bare buffer, because a bare one is not something the caller can release: given a plain `char*` the runtime cannot tell a heap payload from static storage, so it no-ops and the value leaks. That was one leaked block per call at every error slot a caller dutifully freed. The shape is not new to callers, since the sibling branch of such a function already returns a `string.concat` result, which is the same shape.
 
 The flag is resolved at compile time wherever possible:
 
@@ -538,6 +540,8 @@ A heap string stored as a container *value* is owned by the container and releas
 The key is always interned by the container (copied via `string_new`), so a heap key is the caller's to reclaim, see the `@retain` note above.
 
 **Boxed closures.** A closure value (`fn`-typed, not a raw fn-pointer) stored into a list is heap-boxed by the `fn -> ptr` coercion (`_aether_box_closure`). The list takes ownership of the box (it is stored owned, and `list_free` reclaims the non-magic box via `free`); a bare function pointer (`is_fnptr`, a code address) is not heap and stays on the raw path.
+
+The box is `{fn, env}` followed by a tag word. The `{fn, env}` prefix is the layout C code reads, so it stays first and unchanged: `std/collections` and `std/worker` mirror it, and the box pointer is still the `malloc` base that plain `free` reclaims. The tag is how `unbox_closure` tells a real box from a raw code address, which is what a bare function coerced into a `ptr` slot leaves behind. Unboxing one of those panics naming the cause instead of reading `env` out of the function's machine code and jumping through it. To make a bare function safe to unbox, pass it through an `fn`-typed parameter or call `box_closure` on it.
 
 ### Closure environment lifetime
 

--- a/std/string/module.ae
+++ b/std/string/module.ae
@@ -58,12 +58,18 @@ extern string_empty() -> ptr
 // allocation immediately). The escape walker marks any heap-
 // string variable passed at this slot as escaped, so the
 // function-exit defer-free does not also call free() on the
-// same buffer — without `@retain` here, a `defer string.release(s)`
-// paired with the new auto-cleanup (issue #420 v2) would
-// double-free the underlying allocation. After the call the
-// caller's `_heap_<name>` tracker is conservatively kept at its
-// previous value; the var is treated as dead from the
-// reclamation system's perspective.
+// same buffer, without `@retain` here, a `defer string.release(s)`
+// paired with the auto-cleanup would double-free the underlying
+// allocation. After the call the caller's `_heap_<name>` tracker
+// is conservatively kept at its previous value; the var is
+// treated as dead from the reclamation system's perspective.
+//
+// These free what the runtime can SEE is heap: a value carrying
+// the AetherString magic header. A plain malloc'd payload is
+// indistinguishable from a literal here and is left alone, so
+// producing one and handing it to a caller to free would leak it.
+// That is why the uniform-heap return wrap mints the refcounted
+// shape rather than a bare buffer.
 extern string_retain(str: @retain string)
 extern string_release(str: @retain string)
 extern string_free(str: @retain string)

--- a/tests/leaks_known.txt
+++ b/tests/leaks_known.txt
@@ -26,25 +26,3 @@ test_cryptography_hmac_md4_md5 122
 # remaining count is the OpenSSL atexit artifact only. Cap kept as a ceiling.
 test_rsa_pkcs1 130
 
-# ── KNOWN CODEGEN BUG: the empty-string ("") tuple slot (#1461) ──────
-# test_fs_read_error_detail exercises fs.read / fs.read_binary FAILURE
-# paths, which return ("", <message>). The bare "" literal in the value
-# slot is heap-allocated but never freed — 1 byte per failing call. It
-# is NOT reachable from the caller: freeing the returned value with
-# string.free() or string_release() does not reclaim it, and the leak
-# is attributed to the CALLER's frame, not to std.fs.
-#
-# Same family as the #1311 quirk described for test_rsa_pkcs1 above:
-# that fix heap-classified nested tuple-destructure ERROR slots; this
-# is the mirror case, the "" literal sharing a slot with heap strings.
-# Confirmed pre-existing on main — an equivalent 4-line program using
-# only json.parse (no fs at all) leaks identically, and a plain
-# string.to_double() tuple does not, so it is specific to this shape
-# rather than to tuples in general.
-#
-# Cap is 4: the test makes exactly 4 failing calls (2x fs.read,
-# 2x fs.read_binary). Measured 2 on Linux/valgrind and 3 on macOS
-# leaks(1) — the tools differ on whether they see all of them. Set to
-# the call count so the entry cannot silently absorb a NEW leak, and
-# drop this entry entirely once #1461 lands.
-test_fs_read_error_detail 4

--- a/tests/regression/test_string_free_no_leak.ae
+++ b/tests/regression/test_string_free_no_leak.ae
@@ -1,0 +1,141 @@
+// Regression: a string handed back through a heap-returning boundary must be
+// reclaimable by the caller's `string.free`.
+//
+// An Aether `string` has two physical shapes: a refcounted AetherString
+// (magic header plus payload) and a plain malloc'd char*. The runtime's
+// string_release can only recognise the first: given a bare char* it cannot
+// tell a heap payload from a static literal, so it no-ops and the value
+// leaks.
+//
+// Every function classified heap-returning routes its returns through a
+// uniform-heap helper, and the cold half of that helper (a literal, or any
+// value not already owned) used to mint a bare buffer. So the two paths of one
+// function returned two different shapes, and the caller could free only one
+// of them: json.parse's error slot leaked a block per call, and so did every
+// literal returned the same way. The helper now mints the same refcounted
+// shape its sibling path already returns.
+//
+// Not covered here, because it has a different producer and is tracked
+// separately: string interpolation still yields a bare buffer, so freeing an
+// interpolated string leaks. Adding string_free to the codegen's non-storing
+// list looks like the fix and is not: it withdraws the escape marking that
+// suppresses automatic frees, and contrib/tinyweb/example_schema_api then
+// double-frees and aborts.
+//
+// The loops make one leaked block per call unmissable under the macOS
+// leaks(1) gate and Valgrind/ASan on Linux.
+
+import std.string
+import std.json
+
+extern exit(code: int)
+
+check(cond: int, msg: string) -> int {
+    if cond != 0 {
+        return 0
+    }
+    println("  FAIL: ${msg}")
+    return 1
+}
+
+// A heap-returning boundary whose two paths return DIFFERENT shapes: the
+// error path hands back a concat (magic AetherString), the success path a
+// bare literal the compiler must duplicate for the caller to own. Both
+// arrive at the caller's string.free.
+classify(n: int) -> string! {
+    if n < 0 {
+        return string.concat("negative: ", "out of range"), ""
+    }
+    return "ok", ""
+}
+
+main() {
+    println("=== test_string_free_no_leak ===")
+    fails = 0
+
+    // 1. The reported shape: parse's success-path error slot is an owned
+    //    duplicate of "", i.e. a 1-byte plain malloc'd payload.
+    n = 0
+    while n < 200 {
+        doc, perr = json.parse("{\"x\":3.14,\"name\":\"a text value\"}")
+        fails = fails + check(string.equals(perr, ""), "parse err not empty")
+        string.free(perr)
+        fails = fails + check(doc != null, "parse returned null")
+
+        out, serr = json.stringify(doc)
+        fails = fails + check(string.contains(out, "3.14"), "stringify lost the number")
+        string.free(out)
+        string.free(serr)
+        json.free(doc)
+        n = n + 1
+    }
+
+    // 2. The failure path, where the error slot is a real message rather
+    //    than an empty duplicate.
+    n = 0
+    while n < 200 {
+        bad, berr = json.parse("{\"x\":")
+        fails = fails + check(bad == null, "malformed input parsed")
+        fails = fails + check(string.equals(berr, "") == 0, "no error message")
+        string.free(berr)
+        n = n + 1
+    }
+
+    // 3. Both shapes out of one Aether function.
+    n = 0
+    while n < 200 {
+        neg, e1 = classify(-1)
+        fails = fails + check(string.contains(neg, "negative"), "concat path wrong")
+        string.free(neg)
+        string.free(e1)
+
+        pos, e2 = classify(1)
+        fails = fails + check(string.equals(pos, "ok"), "literal path wrong")
+        string.free(pos)
+        string.free(e2)
+        n = n + 1
+    }
+
+    // 4. concat, the everyday producer of an owned string.
+    n = 0
+    while n < 200 {
+        joined = string.concat("prefix-", "suffix")
+        fails = fails + check(string.equals(joined, "prefix-suffix"), "concat wrong")
+        string.free(joined)
+        n = n + 1
+    }
+
+    // 5. A variable reassigned across iterations, freed each time: the
+    //    shape that leaks linearly in a serialisation loop.
+    acc = ""
+    n = 0
+    while n < 200 {
+        string.free(acc)
+        acc = string.concat("row ", "value")
+        n = n + 1
+    }
+    fails = fails + check(string.equals(acc, "row value"), "final value wrong")
+    string.free(acc)
+
+    // 6. A producer that returns the refcounted shape directly, so the
+    //    runtime free path has to keep working unchanged.
+    n = 0
+    while n < 200 {
+        num = string.from_double(3.5)
+        fails = fails + check(string.contains(num, "3.5"), "from_double wrong")
+        string.free(num)
+        n = n + 1
+    }
+
+    // 7. A literal-holding variable was never heap-owned; freeing it must
+    //    not reach free() on static storage.
+    lit = "static text"
+    string.free(lit)
+    fails = fails + check(string.equals(lit, "static text"), "literal damaged")
+
+    if fails != 0 {
+        println("test_string_free_no_leak: ${fails} failure(s)")
+        exit(1)
+    }
+    println("=== test_string_free_no_leak passed ===")
+}

--- a/tests/regression/test_unbox_unboxed_fn_panics.ae
+++ b/tests/regression/test_unbox_unboxed_fn_panics.ae
@@ -1,0 +1,83 @@
+// Regression: unbox_closure() on a value that was never boxed must fail
+// where the mistake is, not by jumping through garbage.
+//
+// A closure is {fn, env}; boxing mallocs that pair. A bare named function
+// has no environment, so passing one into a `ptr` slot stores a raw code
+// address. unbox_closure() then read `.env` out of the function's own
+// machine code and call() jumped through it: SIGSEGV at runtime, and the
+// compiler said nothing at build time.
+//
+// The box now carries a tag, placed after the {fn, env} prefix because that
+// prefix is the FFI layout std/collections and std/worker read: a tag in
+// front would turn their `fn` into the tag and call it. unbox checks the tag
+// and panics with a message naming the cause and the fix.
+//
+// Both valid ways of producing a boxed value are pinned here too, so the
+// check cannot be "fixed" by making boxing itself fail.
+
+import std.string
+import std.heap
+
+extern exit(code: int)
+
+struct Holder { cb: ptr }
+
+bump(x: int) -> int { return x + 1 }
+
+// ptr-typed param: the bare function arrives as a raw code pointer and no
+// box is ever created.
+store_ptr(h: *Holder, f: ptr) { h.cb = f }
+
+// fn-typed param: the call site boxes, so the ptr field holds a real box.
+store_fn(h: *Holder, f: fn) { h.cb = f }
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    println("=== test_unbox_unboxed_fn_panics ===")
+
+    // 1. The reported crash: unboxing a raw code pointer. Catching it is
+    //    the assertion, an uncaught panic or a segfault both fail the run.
+    caught = 0
+    h = heap.new(Holder)
+    store_ptr(h, bump)
+    try {
+        g = unbox_closure(h.cb)
+        r = call(g, 41)
+        println("  unboxed a bare fn and got ${r}")
+    } catch e {
+        caught = 1
+        if string.contains(e, "never boxed") != 1 {
+            fail("panic reason does not name the cause: ${e}")
+        }
+    }
+    if caught != 1 {
+        fail("unboxing a bare fn was not diagnosed")
+    }
+    println("  PASS: raw code pointer is rejected, not jumped through")
+    heap.free(h)
+
+    // 2. An fn-typed parameter boxes at the call site.
+    h2 = heap.new(Holder)
+    store_fn(h2, bump)
+    g2 = unbox_closure(h2.cb)
+    if call(g2, 41) != 42 {
+        fail("fn-typed param path lost the value")
+    }
+    println("  PASS: fn-typed param boxes and round-trips")
+    heap.free(h2)
+
+    // 3. Explicit box_closure on a bare function, the fix the panic
+    //    message recommends, so it has to compile and run.
+    b = box_closure(bump)
+    g3 = unbox_closure(b)
+    if call(g3, 7) != 8 {
+        fail("box_closure(bare fn) lost the value")
+    }
+    println("  PASS: box_closure accepts a bare function")
+
+    println("=== test_unbox_unboxed_fn_panics passed ===")
+}


### PR DESCRIPTION
Three defects from the tracker, each with a regression test proven to fail on pristine `main`.

## A returned string leaked when the caller freed it

An Aether `string` is one of two physical shapes: a refcounted AetherString, or a plain malloc'd payload. The runtime cannot free the second, because given a bare `char*` it cannot tell a heap payload from static storage, so `string.free` no-ops on it.

Every heap-returning function routes its returns through a uniform-heap helper, and the cold half of that helper (a literal, or anything not already owned) minted exactly that bare buffer. So the two branches of one function returned two different shapes and the caller could free only one of them. `json.parse` leaked a block per call at its success-path error slot, and so did every literal returned the same way.

The cold path now mints the same refcounted shape the sibling branch already returns, so the hot path pays nothing and callers get one shape to release. `tests/leaks_known.txt` loses its `test_fs_read_error_detail` entry, which was filed for this bug and annotated "drop this entry entirely once #1461 lands": that test now reports zero rather than its allowed three, and `test_string_double_locale` goes from one leak to none.

Freeing an *interpolated* string still leaks, because interpolation has a different producer. Filed as #1539 with the measurements, including why the apparent fix for both is wrong. Registering `string_free` as non-storing in the codegen is the obvious move and it withdraws the escape marking that suppresses automatic frees: `contrib/tinyweb/example_schema_api` then double-frees and aborts (this PR's first revision did exactly that, and CI caught it). Guarding the free on the ownership flag without keeping the runtime call as a fallback is also wrong: the flag is a runtime fact and `string.from_double` returns a refcounted value with it clear, which took `test_string_double_roundtrip` from 0 leaks to 10,046. Closing that half means separating "escaped because something else owns it" from "escaped because this call frees it", which is its own change.

## `unbox_closure()` on an unboxed value segfaulted, with no diagnostic

A closure is `{fn, env}` and boxing mallocs that pair. A bare named function has no environment, so passing one into a `ptr` slot stores a raw code address. `unbox_closure()` then read `.env` out of the function's own machine code and `call()` jumped through it: SIGSEGV at runtime, clean build, no warning.

Boxed closures now carry a tag, and unbox checks it and panics naming both the cause and the fix. The tag sits **after** the `{fn, env}` prefix deliberately: that prefix is the FFI layout `std/collections` and `std/worker` read, and a tag in front would turn their `fn` into the tag and call it. The box pointer is still the malloc base that plain `free` reclaims. A runtime check rather than a compile-time one because the coercion itself is legitimate: `extern call_int1(fn: ptr, x: int)` with a bare fn argument is the documented FFI idiom, so diagnosing the source would fire on valid code.

`box_closure()` also rejected a bare function, which is the value most likely to need boxing and exactly what the new panic message recommends. It now wraps one in the same env-ignoring adapter a ptr-typed field assignment already used, so the advice the message gives actually compiles.

## The codegen `unresolved type` warning had no location

It printed with no file, line or expression, and no flag produced one, so it could not be acted on from source. `get_c_type` takes only a `Type`, so codegen now keeps the position of the construct it is lowering and the warning reports file, line, column and enclosing function.

That warning turned out to be pointing at a real defect rather than benign noise. An actor `?` ask never infers its reply type, so `x = actor ? Message {}` is always declared `int` and any non-int reply fails the C compile, even though every other part of that pipeline handles strings, floats and pointers correctly. Filed as #1537: the request-to-reply mapping already exists twice with "MUST stay in sync" comments, so it wants a shared resolver and its own reply-type test matrix rather than a third copy.

## Verification

- Both new tests fail on pristine `main`: 200 leaks for the string one, SIGSEGV for the closure one
- `make contrib-check` fully green, including the `tinyweb/schema_api` case that failed CI on the first revision
- Every in-tree test that calls `string.free` (16) built, run, and leak-checked at zero
- 230 C unit tests, `-Werror` build with zero warnings, fmt gate canonical
- The three existing closure regression tests pass unchanged against the tagged box
- `.ae` suite: the only failures are ones that fail identically on pristine `main` on this machine (Apple `ld` rejecting `--allow-multiple-definition`, gcov, a blocked bind, sandbox-killed interpreters, a local version stamp)

Closes #1461
Closes #1439
Closes #1488