### PR TITLE
fix(string): interpolation produces the refcounted shape, so a helper can free it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Freeing an interpolated string leaked it once it crossed a boundary.** An
+  Aether `string` is either a refcounted AetherString or a plain malloc'd
+  payload, and the runtime cannot free the second: given a bare `char*` it
+  cannot tell a heap payload from a static literal, so `string.free` no-ops.
+  The compiler's per-variable ownership flag covered the direct case, but a
+  parameter carries no flag, so handing an interpolation to a helper that frees
+  what it is given leaked one block per call.
+
+  Interpolation now produces the refcounted shape, which the runtime can free
+  wherever the value ends up. The payload lives in the same allocation as the
+  header, recognised on release by position rather than by a flag, so it costs
+  a larger `malloc` rather than a second one: measured at +1.6% on a loop that
+  does nothing but interpolate two million strings, inside that benchmark's own
+  run-to-run spread. An earlier version that allocated the header separately
+  cost 16%, which is why it does not.
+
+## [current]
+
 ### Added
 
 - **contrib/vulkan: depth attachments and multisampling.** The offscreen target

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -4496,16 +4496,28 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "int list_add_closure_owned(void*, void*);");
     /* String interpolation helper — portable, always available */
     print_line(gen, "#include <stdarg.h>");
+    /* Returns the REFCOUNTED shape, not a bare buffer. Aether's `string` is
+     * either, and the runtime cannot free a bare one: given a plain char* it
+     * cannot tell a heap payload from a literal, so `string.free` no-ops and
+     * the value leaks. Every interpolated string a caller freed by hand, or
+     * handed to a helper that frees, leaked exactly that way (#1543).
+     *
+     * The buffer is adopted rather than copied, so the cost is one header
+     * allocation on top of the payload the format already needed. */
+    print_line(gen, "extern void* string_alloc_inline(size_t length);");
+    print_line(gen, "extern char* aether_string_mutable_data(void* s);");
     print_line(gen, "static void* _aether_interp(const char* fmt, ...) {");
     print_line(gen, "    va_list args, args2;");
     print_line(gen, "    va_start(args, fmt);");
     print_line(gen, "    va_copy(args2, args);");
     print_line(gen, "    int len = vsnprintf(NULL, 0, fmt, args);");
     print_line(gen, "    va_end(args);");
-    print_line(gen, "    char* str = (char*)malloc(len + 1);");
-    print_line(gen, "    vsnprintf(str, len + 1, fmt, args2);");
+    print_line(gen, "    if (len < 0) { va_end(args2); return (void*)0; }");
+    print_line(gen, "    void* owned = string_alloc_inline((size_t)len);");
+    print_line(gen, "    if (!owned) { va_end(args2); return (void*)0; }");
+    print_line(gen, "    vsnprintf(aether_string_mutable_data(owned), (size_t)len + 1, fmt, args2);");
     print_line(gen, "    va_end(args2);");
-    print_line(gen, "    return (void*)str;");
+    print_line(gen, "    return owned;");
     print_line(gen, "}");
     /* NULL-safe string helper for print/println — avoids double-evaluating
      * the expression. Goes through aether_string_data() which dispatches

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -321,9 +321,21 @@ The compiler treats these expressions as heap-allocated:
 | `string.trim(s)` | Stdlib, always `malloc`'d |
 | `string_new_with_length(data, n)` | Stdlib, the length-aware AetherString constructor (`bytes.finish` is built on it) |
 | `string.from_int` / `from_long` / `from_float` / `from_char` | Stdlib, each `string_new`s a fresh refcounted AetherString |
-| String interpolation `"foo ${x}"` | Compiler-allocated via `_aether_interp` |
+| String interpolation `"foo ${x}"` | Compiler-allocated via `_aether_interp`, a refcounted AetherString whose payload shares the header's allocation |
 | User-defined `-> string` function whose body provably returns heap | Structural escape analysis (see below) |
 | Tuple-returning function / `@heap` extern, per position | Per-position analysis (see below) |
+
+**Interpolation produces the refcounted shape.** It used to hand back a plain
+`malloc`'d buffer, and the runtime cannot free one of those: given a bare
+`char*` it cannot tell a heap payload from a static literal, so `string.free`
+no-ops on it. That was fine while the compiler's per-variable ownership flag
+was in reach, and a leak the moment the value crossed a boundary where it was
+not, such as a parameter of a helper that frees what it is handed (#1543).
+
+The payload lives in the same allocation as the header, so this costs a larger
+`malloc` rather than a second one: measured at +1.6% on a loop that does
+nothing but interpolate two million strings, which is inside that benchmark's
+run-to-run spread.
 
 The stdlib entries above are hard-coded as intrinsic heap sources in the
 codegen's `is_heap_string_expr` recognised by name regardless of how a

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -115,9 +115,18 @@ void string_release(const void* str) {
         /* Cap accounting: data buffer was allocated with `capacity`
          * bytes (length + 1 NUL terminator); struct is one
          * sizeof(AetherString). Both pair with the alloc-side
-         * accounting in string_new_with_length. */
-        aether_caps_free(s->data, s->capacity);
-        aether_caps_free(s, sizeof(AetherString));
+         * accounting in string_new_with_length.
+         *
+         * A string from string_alloc_inline holds both in ONE block, with
+         * `data` pointing just past the header, so freeing it separately
+         * would free an interior pointer. Recognised by position rather
+         * than by a flag: there is nothing to keep in sync. */
+        if (s->data == (char*)(s + 1)) {
+            aether_caps_free(s, sizeof(AetherString) + s->capacity);
+        } else {
+            aether_caps_free(s->data, s->capacity);
+            aether_caps_free(s, sizeof(AetherString));
+        }
     }
 }
 
@@ -775,6 +784,39 @@ size_t aether_string_length(const void* s) {
  * borrowed and freed by the enclosing scope while a stored closure still held
  * it. Retains an AetherString in place; promotes anything else to a refcounted
  * copy. Balanced by aether_string_release_captured at env teardown. */
+/* One allocation holding the header and the payload, with `data` pointing just
+ * past the header. The caller writes `length` bytes plus a terminator into it.
+ *
+ * This exists so a producer can hand back the REFCOUNTED shape without paying
+ * for a second allocation. Aether's `string` is either that or a plain buffer,
+ * and the runtime cannot free a plain one: given a bare char* it cannot tell a
+ * heap payload from a literal, so `string.free` no-ops and the value leaks.
+ * String interpolation is the producer that matters, and it is hot enough that
+ * an extra malloc per interpolation was measurable (#1543).
+ *
+ * string_release recognises the inline layout by comparing `data` against the
+ * byte after the header, so there is no flag to keep in sync and no way to
+ * free an interior pointer by mistake. */
+/* The writable payload of a string the caller just allocated. Only valid on a
+ * string it owns and has not yet shared: this is for producers filling in the
+ * bytes, not for mutating a string someone else holds. */
+char* aether_string_mutable_data(void* s) {
+    if (!s || !is_aether_string(s)) return NULL;
+    return ((AetherString*)s)->data;
+}
+
+AetherString* string_alloc_inline(size_t length) {
+    AetherString* s = (AetherString*)aether_caps_malloc(sizeof(AetherString) + length + 1);
+    if (!s) return NULL;
+    s->magic = AETHER_STRING_MAGIC;
+    s->ref_count = 1;
+    s->length = length;
+    s->capacity = length + 1;
+    s->data = (char*)(s + 1);
+    s->data[length] = '\0';
+    return s;
+}
+
 const char* aether_string_capture_owned(const char* s) {
     if (!s) return s;
     if (is_aether_string(s)) {

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -185,6 +185,15 @@ size_t      aether_string_length(const void* s);
 
 // Closure-capture ownership (#1398). capture_owned returns a pointer the
 // caller owns a reference to; release_captured gives it back.
+/* Allocates a refcounted string whose payload lives in the same block as its
+ * header, for producers that format their bytes in place. `length` excludes
+ * the terminator, which is written for you. NULL on allocation failure. */
+AetherString* string_alloc_inline(size_t length);
+
+/* Writable payload of a string the caller owns and has not shared, for
+ * producers filling in bytes. NULL when `s` is not a refcounted string. */
+char* aether_string_mutable_data(void* s);
+
 const char* aether_string_capture_owned(const char* s);
 void        aether_string_release_captured(const char* s);
 

--- a/tests/regression/test_string_free_interp_no_leak.ae
+++ b/tests/regression/test_string_free_interp_no_leak.ae
@@ -24,12 +24,13 @@
 // of a `free_it(s) { string.free(s) }` helper double-free, which is a crash
 // on glibc and a corrupt heap elsewhere. Both directions are pinned here.
 //
-// One shape is deliberately absent: handing a PLAIN-payload string (an
-// interpolation) to such a helper still leaks, because inside the helper the
-// parameter carries no ownership flag and the runtime free cannot tell a heap
-// payload from a literal. That is unchanged from before this fix, measured at
-// the same 100 leaks on either side, and needs per-parameter ownership rather
-// than anything here.
+// The shape that used to be absent is covered now: handing an interpolated
+// string to such a helper leaked, because inside the helper the parameter
+// carries no ownership flag and the runtime could not tell a heap payload from
+// a literal. Interpolation produces the refcounted shape today, so the runtime
+// can free it wherever it ends up, parameter or not (#1543). The payload lives
+// in the same allocation as its header, so that costs a larger malloc rather
+// than a second one.
 
 import std.string
 
@@ -80,7 +81,18 @@ main() {
     }
     println("  PASS a consuming helper leaves nothing for the caller to free")
 
-    // 4. Freeing a variable that holds a literal must not reach free() on
+    // 4. An interpolated string handed to a consuming helper. This is the
+    //    case that leaked: the helper cannot see an ownership flag, so the
+    //    value has to be reclaimable by the runtime alone.
+    n = 0
+    while n < 200 {
+        piece = "row ${n} of the table"
+        free_it(piece)
+        n = n + 1
+    }
+    println("  PASS an interpolation freed inside a helper is reclaimed")
+
+    // 5. Freeing a variable that holds a literal must not reach free() on
     //    static storage.
     lit = "static text"
     string.free(lit)


### PR DESCRIPTION
Closes the memory-safety hole I filed as #1543 while fixing #1539, rather than leaving it filed.

## The hole

An Aether `string` is either a refcounted AetherString or a plain malloc'd payload, and the runtime cannot free the second: given a bare `char*` it cannot tell a heap payload from a static literal, so `string_release` no-ops on it.

The compiler's per-variable ownership flag covered the direct case, which is why `string.free(interp)` in the same scope already worked. A **parameter carries no such flag**, so this leaked one block per call:

```aether
free_it(s: string) { string.free(s) }

v = "nested ${n}"
free_it(v)          // leaked, with nothing at the call site to suggest it
```

## The fix, and why it is shaped this way

Interpolation now returns the refcounted shape, which the runtime can reclaim wherever the value ends up, flag or no flag.

The obvious way to do that costs an allocation: format into a buffer, then wrap it. I measured it against `main` on a loop doing nothing but interpolating two million strings:

| | median | range | delta |
|---|---|---|---|
| main | 289.5 ms | 284-300 | |
| wrap a separate buffer | 336.9 ms | 322-343 | **+16.4%** |
| payload inline in the header's allocation | 293.5 ms | 290-294 | **+1.6%** |

24ns per interpolation is not a price worth paying on a path this hot, so the payload lives in the **same** allocation as the header, with `data` pointing just past it. `string_release` recognises that layout by comparing `data` against the byte after the header, rather than by a flag there is no way to keep in sync. One allocation either way, 32 bytes larger. +1.6% is inside that benchmark's own run-to-run spread.

`string_alloc_inline` and `aether_string_mutable_data` are the two entry points that makes possible: allocate once, let the producer format in place.

## Blast radius

This changes the representation of **every interpolated string in every program**, so the evidence matters more than usual:

- 985 of 993 `.ae` tests pass; the 8 failures fail identically on pristine `main` on this machine (Apple `ld` rejecting `--allow-multiple-definition`, gcov, a blocked bind, sandbox-killed interpreters, a local version stamp)
- `make contrib-check` green across all eight entries
- 230 C unit tests, `-Werror` build clean
- Every string-heavy regression test leak-checked at zero: interp, double-roundtrip, language, schema, cbor, actor-message-heap-string, or-block-error-slot

The regression test gains the case that was leaking, and that test leaks 200 blocks on pristine `main`.

Closes #1543