### PR TITLE
feat(vulkan): materials, draw batching, 16-bit indices and mipmaps

### DIFF
--- a/.github/scripts/contrib_check.sh
+++ b/.github/scripts/contrib_check.sh
@@ -80,11 +80,13 @@ TESTS=(
   "vulkan/actors|$VK/test_vulkan_actors.ae|$VK/aether_vulkan.c|run||vulkan"
   "vulkan/depth-msaa|$VK/test_vulkan_depth_msaa.ae|$VK/aether_vulkan.c|run||vulkan"
   "vulkan/frames|$VK/test_vulkan_frames.ae|$VK/aether_vulkan.c|run||vulkan"
+  "vulkan/materials|$VK/test_vulkan_materials.ae|$VK/aether_vulkan.c|run||vulkan"
   # The examples are RUN, not just compiled. An example that only builds
   # rots into decoration: both of these render and write a PPM, so a
   # regression that leaves them producing nothing fails here.
   "vulkan/example-triangle|$VK/example_triangle.ae|$VK/aether_vulkan.c|run||vulkan"
   "vulkan/example-parallel|$VK/example_parallel_render.ae|$VK/aether_vulkan.c|run||vulkan"
+  "vulkan/example-sprites|$VK/example_sprites.ae|$VK/aether_vulkan.c|run||vulkan"
 )
 
 # Kill any stray cache/test binaries squatting ports before we start (aborted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Added
+
+- **contrib/vulkan: materials, draw batching, 16-bit indices and mipmaps.** A
+  pipeline owned one descriptor set, so a frame could use exactly one texture:
+  binding a second overwrote what the first draw was still going to read.
+  `material_create(pipe)` now gives each draw its own set, and a target holds a
+  list of draws (`batch_add(t, mat, first, count)`, `batch_reset(t)`), each
+  naming the material it uses. Four differently textured sprites in one frame
+  from one pipeline is `example_sprites.ae`. Sets come from pools of 16 the
+  pipeline grows on demand; an empty batch stays the default and draws all the
+  geometry once, so every existing caller is unchanged.
+
+  `indices_reserve_ex(t, count, 16)` halves the index buffer for meshes under
+  65536 vertices, and refuses a value the width cannot hold rather than
+  wrapping it into the wrong triangle.
+
+  `texture_create_ex(dev, w, h, mipmapped, linear, repeat)` builds a mip chain
+  on upload with `vkCmdBlitImage` and chooses the sampler filter and addressing
+  mode. A 128x128 checkerboard minified eight times reads back as pure black
+  and white texels without a chain and as its true mean of 128 with one.
+  Mipmaps require the device to advertise linear blitting, and creation fails
+  with that reason rather than returning empty levels.
+
 ## [0.532.0]
 
 ### Added

--- a/contrib/vulkan/README.md
+++ b/contrib/vulkan/README.md
@@ -40,15 +40,15 @@ main() {
 }
 ```
 
-`example_triangle.ae` is that program in full, and `example_parallel_render.ae`
-is four actors rendering their own tile on one shared device and writing a 2x2
-contact sheet. Both are RUN by `make contrib-check`, not merely compiled: an
-example nobody executes rots into decoration.
+`example_triangle.ae` is that program in full, `example_parallel_render.ae` is
+four actors rendering their own tile on one shared device and writing a 2x2
+contact sheet, and `example_sprites.ae` draws four differently textured sprites
+in a single frame. All three are RUN by `make contrib-check`, not merely
+compiled: an example nobody executes rots into decoration.
 
-`example_triangle.ae` is that program in full. It is not limited to a triangle:
-the pipeline is built from whatever SPIR-V you hand it, and `pipeline_create`
-uses a built-in vertex format of an interleaved `vec2` position plus `vec3`
-colour.
+None of it is limited to a triangle: the pipeline is built from whatever SPIR-V
+you hand it, and `pipeline_create` uses a built-in vertex format of an
+interleaved `vec2` position plus `vec3` colour.
 
 For anything past that, `pipeline_create_ex` takes a vertex layout you
 describe, a push-constant block, and the shader resources the shaders read:
@@ -88,11 +88,92 @@ vulkan.indices_set(target, 0, 0)
 A texture must be uploaded before it is bound: an image that was never given
 pixels has no defined contents to sample, so binding one is refused rather than
 drawn. Push constants are capped at 128 bytes, the minimum every Vulkan device
-guarantees. A pipeline owns one descriptor set, which is enough for a
-transform, a material and its textures; per-draw sets are not yet a thing here.
+guarantees.
 
 Coordinates are Vulkan NDC. x and y run -1 to 1, **y points down**, and a
 front-facing triangle is counter-clockwise.
+
+## Materials: several textures in one frame
+
+The calls above bind to the pipeline, which owns one descriptor set. That is
+enough for one object. A frame with two textures needs two sets, because the
+second bind would otherwise overwrite what the first draw is still going to
+read, and a `vkQueueWaitIdle` between draws is not a fix.
+
+A material is one set of bound resources. Several are made from one pipeline,
+and a frame holds a list of draws, each naming the material it uses:
+
+```aether
+mat_a = vulkan.material_create(pipe)
+mat_b = vulkan.material_create(pipe)
+defer vulkan.material_destroy(mat_a)
+defer vulkan.material_destroy(mat_b)
+
+vulkan.material_set_texture(mat_a, 0, tex_a)
+vulkan.material_set_texture(mat_b, 0, tex_b)
+vulkan.material_floats(mat_a, 1, 4)          // a vec4 per material
+vulkan.material_float(mat_a, 1, 0, 1.0)
+
+vulkan.batch_add(target, mat_a, 0, 6)        // indices 0..5 with mat_a
+vulkan.batch_add(target, mat_b, 6, 6)        // indices 6..11 with mat_b
+vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0)
+```
+
+`batch_add` slices the geometry already uploaded: by index when the target has
+an index buffer, by vertex otherwise. An empty batch, which is the default and
+what every earlier caller has, draws all of it once. `batch_reset` goes back to
+that. The range is checked when the draw is added and again for the frame it is
+drawn in, since geometry can be re-uploaded in between.
+
+`draw_material` blocks like `draw`; `submit_material` pipelines like `submit`.
+Passing a null material uses the pipeline's own set, so `set_texture`,
+`uniform_floats` and `uniform_float` keep working unchanged.
+
+Materials cost one descriptor set each, allocated from pools of 16 that the
+pipeline grows on demand, plus one host-mapped uniform buffer per uniform
+binding written. A material a batch refers to has to outlive the draws that use
+it: destroy one without resetting the batch and the next frame reads freed
+memory, the same contract Vulkan gives for any resource bound to a set.
+
+## 16-bit indices
+
+`indices_reserve` gives 32-bit indices. `indices_reserve_ex(t, count, 16)`
+halves the index buffer, which is the right width for any mesh under 65536
+vertices:
+
+```aether
+vulkan.indices_reserve_ex(target, 24, 16)
+vulkan.indices_set(target, 0, 0)
+```
+
+`indices_set` refuses a value the chosen width cannot hold, so a wrapped index
+cannot silently draw the wrong triangle. Changing the width reallocates, and
+the previous contents do not carry over: write the indices again after
+reserving.
+
+## Mipmaps and sampler options
+
+`texture_create` gives a single-level image sampled with a linear filter and
+clamped addressing. `texture_create_ex` chooses:
+
+```aether
+tex = vulkan.texture_create_ex(dev, 128, 128, 1, 1, 0)  // mipmapped, linear, clamped
+vulkan.texture_upload(tex, bytes.data(rgba), 128 * 128 * 4)
+vulkan.texture_mip_levels(tex)                          // 8
+```
+
+The chain is generated on upload with `vkCmdBlitImage`, level by level, so the
+pixels come from the same call that already staged them. Mipmaps need the
+device to advertise linear blitting for `R8G8B8A8_UNORM`; where it does not,
+creation fails with that reason rather than handing back a texture whose lower
+levels are empty.
+
+The difference is measurable rather than decorative. A 128x128 one-texel
+checkerboard drawn into 16 pixels, which is eight times minification, comes out
+of a non-mipmapped texture as pure black and white texels (mean brightness 255
+on this hardware: the sample points all landed on the white squares) and out of
+a mipmapped one at 128, the texture's actual average. `test_vulkan_materials.ae`
+asserts both.
 
 ## Depth and multisampling
 
@@ -291,8 +372,9 @@ rather than on a defect. What proves the pair is correct is the render test.
 ## Testing
 
 `test_vulkan.ae`, `test_vulkan_resources.ae`, `test_vulkan_actors.ae`,
-`test_vulkan_depth_msaa.ae` and `test_vulkan_frames.ae` run from
-`make contrib-check`, along with both examples. With no driver it prints SKIP
+`test_vulkan_depth_msaa.ae`, `test_vulkan_frames.ae` and
+`test_vulkan_materials.ae` run from `make contrib-check`, along with all three
+examples. With no driver it prints SKIP
 and passes, which is the same path a user's program takes. With a driver it
 renders and checks pixels, covering the failure modes as well as the happy one:
 zero and negative sizes, a size past `maxImageDimension2D`, empty SPIR-V, a
@@ -328,6 +410,17 @@ a target with no depth attachment and requires it to DISAGREE. The MSAA case
 counts pixels that are neither background nor a saturated primary: 0 at one
 sample, 105 at four on this hardware.
 
+`test_vulkan_materials.ae` is built so each of the three features fails it if
+it does nothing. Two quads with different textures are drawn in one frame and
+each half is checked for its own colour, which is exactly what one shared
+descriptor set cannot produce. The 16-bit frame is compared to the 32-bit one
+byte for byte over the whole readback rather than at a few sample points. The
+mipmap case requires every pixel of the minified quad to be a single texel
+without a chain and the averaged mean with one. It also checks the refusals: a
+draw past the uploaded geometry, at both add and draw time, an empty or
+negative draw range, an index width that is neither 16 nor 32, a material
+without a pipeline, and a uniform write to a binding that has no buffer.
+
 The Linux CI leg installs lavapipe so the GPU path runs on a runner with no GPU,
 and then asserts the test did **not** skip. A skip there would be silent loss of
 coverage.
@@ -342,7 +435,6 @@ plan in someone's head.
 | Surfaces, swapchains, presenting to a window, and the aether-ui handle seam | #1505 | P1 |
 | Generating declarations from `vk.xml` rather than by hand | #1506 | P1 |
 | A CI leak gate (lavapipe's JIT defeats valgrind; LSan module suppressions are the route) | #1507 | P1 |
-| Per-draw descriptor sets, 16-bit indices, texture mipmaps | #1540 | P3 |
 | Building and running contrib on Windows (the `_WIN32` branch is compiled, never run) | #1511 | P2 |
 | More colour formats, and PNG output rather than PPM | #1514 | P3 |
 | Compute pipelines | #1515 | P3 |

--- a/contrib/vulkan/aether_vulkan.c
+++ b/contrib/vulkan/aether_vulkan.c
@@ -193,7 +193,8 @@ static const char* const k_loader_names[] = {
     X(vkCreateSampler)              \
     X(vkDestroySampler)             \
     X(vkCmdPipelineBarrier)         \
-    X(vkCmdCopyBufferToImage)
+    X(vkCmdCopyBufferToImage)       \
+    X(vkCmdBlitImage)
 
 #define AEVK_DECL(name) PFN_##name name;
 
@@ -268,6 +269,15 @@ struct AevkDevice {
 #define AEVK_MAX_DESC     8
 #define AEVK_MAX_PUSH     128   /* the guaranteed minimum every device offers */
 
+/* One draw inside a frame. `first`/`count` address indices when the target
+ * has an index buffer and vertices otherwise, so a batch slices whatever
+ * geometry is already uploaded rather than needing its own copy. */
+typedef struct {
+    AevkMaterial* mat;
+    int           first;
+    int           count;
+} AevkDrawItem;
+
 typedef struct {
     VkCommandBuffer cmd;
     VkFence         fence;
@@ -283,11 +293,19 @@ typedef struct {
      * so push bytes are compared by value rather than by size alone. */
     int             recorded;
     AevkPipeline*   rec_pipe;
+    AevkMaterial*   rec_mat;
     int             rec_vertices;
     int             rec_indices;
     float           rec_clear[4];
     uint32_t        rec_push_size;
     unsigned char   rec_push[AEVK_MAX_PUSH];
+    /* The batch is compared by version rather than by value: every mutation
+     * bumps it, so a slot holding an older list re-records. Material CONTENTS
+     * are deliberately not part of this; a descriptor set and a mapped uniform
+     * buffer are read when the GPU executes, not when the command is
+     * recorded. */
+    unsigned        rec_batch_version;
+    int             rec_batch_count;
 } AevkFrame;
 
 struct AevkTarget {
@@ -329,6 +347,12 @@ struct AevkTarget {
     void*          ibuf_ptr;
     int            ibuf_capacity;   /* indices the allocation can hold */
     int            index_count;     /* 0 draws non-indexed */
+    int            index_bits;      /* 16 or 32 */
+
+    AevkDrawItem*  batch;
+    int            batch_count;
+    int            batch_cap;
+    unsigned       batch_version;
 
     unsigned char  push_data[AEVK_MAX_PUSH];
     uint32_t       push_size;
@@ -365,6 +389,7 @@ struct AevkBindings {
 struct AevkTexture {
     AevkDevice*    dev;
     int            width, height;
+    uint32_t       mip_levels;
     VkImage        image;
     VkDeviceMemory mem;
     VkImageView    view;
@@ -372,26 +397,44 @@ struct AevkTexture {
     int            uploaded;   /* 0 until the first upload lays it out */
 };
 
-struct AevkPipeline {
-    AevkDevice*      dev;
-    VkShaderModule   vert, frag;
-    VkPipelineLayout layout;
-    VkPipeline       pipeline;
-
-    /* Shader resources. One descriptor set per pipeline: enough for a
-     * transform, a material and its textures, and the lifetime is the
-     * pipeline's so nothing outlives its pool. */
-    VkDescriptorSetLayout set_layout;
-    VkDescriptorPool      pool;
-    VkDescriptorSet       set;
-    uint32_t              push_bytes;
-
+/* One descriptor set plus the uniform buffers written into it: a material.
+ * Several can exist per pipeline, so one pipeline draws several objects with
+ * different textures and constants in a frame instead of needing a pipeline
+ * per material, which would duplicate the shader modules for nothing. */
+struct AevkMaterial {
+    AevkPipeline*   pipe;
+    VkDescriptorSet set;
     struct {
         VkBuffer       buf;
         VkDeviceMemory mem;
         void*          ptr;
         VkDeviceSize   size;
     } ub[AEVK_MAX_DESC];
+};
+
+#define AEVK_SETS_PER_POOL 16
+#define AEVK_MAX_POOLS     64
+
+struct AevkPipeline {
+    AevkDevice*      dev;
+    VkShaderModule   vert, frag;
+    VkPipelineLayout layout;
+    VkPipeline       pipeline;
+    uint32_t         push_bytes;
+
+    /* Descriptor pools, grown a block at a time: a fixed maxSets would put a
+     * ceiling on how many materials a scene can have, and sizing one pool for
+     * the worst case would waste memory for the common one. */
+    VkDescriptorSetLayout set_layout;
+    VkDescriptorPool      pools[AEVK_MAX_POOLS];
+    int                   pool_count;
+    int                   sets_in_pool;   /* used in the newest pool */
+    VkDescriptorPoolSize  pool_sizes[2];
+    uint32_t              pool_size_count;
+
+    /* The set pipeline_set_uniform / pipeline_set_texture write to, so code
+     * that never asks for a material keeps working unchanged. */
+    AevkMaterial*    def;
 };
 
 /* ------------------------------------------------------------------------ */
@@ -977,6 +1020,7 @@ AevkTarget* aevk_target_create_ex(AevkDevice* d, int width, int height,
     t->height = height;
     t->readback_size = (VkDeviceSize)bytes;
     t->samples = samples;
+    t->index_bits = 32;
     t->has_depth = want_depth ? 1 : 0;
     t->depth_format = depth_format;
 
@@ -1215,7 +1259,77 @@ void aevk_target_destroy(AevkTarget* t) {
         if (t->depth_mem)    d->da.vkFreeMemory(d->device, t->depth_mem, NULL);
         AEVK_MUTEX_UNLOCK(&d->lock);
     }
+    free(t->batch);
     free(t);
+}
+
+/* Draw batching (#1540). An empty batch is the default and draws all the
+ * geometry once, which is every caller that never asks for one. */
+int aevk_batch_reset(AevkTarget* t) {
+    aevk_clear_error();
+    if (!t) return aevk_fail(AEVK_ERR_ARG, "target is null");
+    AEVK_MUTEX_LOCK(&t->dev->lock);
+    t->batch_count = 0;
+    t->batch_version++;
+    AEVK_MUTEX_UNLOCK(&t->dev->lock);
+    return AEVK_OK;
+}
+
+int aevk_batch_add(AevkTarget* t, AevkMaterial* mat, int first, int count) {
+    aevk_clear_error();
+    if (!t) return aevk_fail(AEVK_ERR_ARG, "target is null");
+    if (first < 0) return aevk_fail(AEVK_ERR_ARG, "first must not be negative, got %d", first);
+    if (count <= 0) return aevk_fail(AEVK_ERR_ARG, "draw count must be positive, got %d", count);
+
+    AEVK_MUTEX_LOCK(&t->dev->lock);
+    /* Checked here against the geometry uploaded so far, so a mistake is
+     * reported where it was made. A batch built before any geometry is legal
+     * and is caught at draw time instead. */
+    int limit = t->index_count > 0 ? t->index_count : t->vertex_count;
+    if (limit > 0 && (long long)first + (long long)count > (long long)limit) {
+        AEVK_MUTEX_UNLOCK(&t->dev->lock);
+        return aevk_fail(AEVK_ERR_ARG, "draw covers %d..%lld but only %d are uploaded",
+                         first, (long long)first + count - 1, limit);
+    }
+    if (t->batch_count == t->batch_cap) {
+        int cap = t->batch_cap ? t->batch_cap * 2 : 8;
+        AevkDrawItem* grown = (AevkDrawItem*)realloc(t->batch, (size_t)cap * sizeof(*grown));
+        if (!grown) {
+            AEVK_MUTEX_UNLOCK(&t->dev->lock);
+            return aevk_fail(AEVK_ERR_OOM, "out of memory");
+        }
+        t->batch = grown;
+        t->batch_cap = cap;
+    }
+    t->batch[t->batch_count].mat = mat;
+    t->batch[t->batch_count].first = first;
+    t->batch[t->batch_count].count = count;
+    t->batch_count++;
+    t->batch_version++;
+    AEVK_MUTEX_UNLOCK(&t->dev->lock);
+    return AEVK_OK;
+}
+
+int aevk_batch_count(const AevkTarget* t) { return t ? t->batch_count : 0; }
+
+/* Ranges are checked here rather than at add time: the geometry a batch
+ * slices can be re-uploaded between adding and drawing, so the count that
+ * matters is the one in effect for THIS frame. */
+static int aevk_batch_check(AevkTarget* t, AevkPipeline* p) {
+    int limit = t->index_count > 0 ? t->index_count : t->vertex_count;
+    const char* what = t->index_count > 0 ? "indices" : "vertices";
+    for (int i = 0; i < t->batch_count; i++) {
+        AevkDrawItem* it = &t->batch[i];
+        if ((long long)it->first + (long long)it->count > (long long)limit) {
+            return aevk_fail(AEVK_ERR_ARG,
+                             "draw %d covers %s %d..%lld but only %d are uploaded",
+                             i, what, it->first, (long long)it->first + it->count - 1, limit);
+        }
+        if (it->mat && p && it->mat->pipe != p) {
+            return aevk_fail(AEVK_ERR_ARG, "draw %d uses a material of another pipeline", i);
+        }
+    }
+    return AEVK_OK;
 }
 
 int aevk_target_has_depth(const AevkTarget* t) { return t ? t->has_depth : 0; }
@@ -1362,6 +1476,28 @@ static int aevk_submit_once(AevkDevice* d, VkCommandBuffer cmd) {
     return AEVK_OK;
 }
 
+static void aevk_image_barrier_levels(AevkDevice* d, VkCommandBuffer cmd, VkImage img,
+                                      uint32_t base_level, uint32_t level_count,
+                                      VkImageLayout from, VkImageLayout to,
+                                      VkAccessFlags src_access, VkAccessFlags dst_access,
+                                      VkPipelineStageFlags src_stage,
+                                      VkPipelineStageFlags dst_stage) {
+    VkImageMemoryBarrier b = {0};
+    b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    b.oldLayout = from;
+    b.newLayout = to;
+    b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.image = img;
+    b.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    b.subresourceRange.baseMipLevel = base_level;
+    b.subresourceRange.levelCount = level_count;
+    b.subresourceRange.layerCount = 1;
+    b.srcAccessMask = src_access;
+    b.dstAccessMask = dst_access;
+    d->da.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, NULL, 0, NULL, 1, &b);
+}
+
 static void aevk_image_barrier(AevkDevice* d, VkCommandBuffer cmd, VkImage img,
                                VkImageLayout from, VkImageLayout to,
                                VkAccessFlags src_access, VkAccessFlags dst_access,
@@ -1382,7 +1518,28 @@ static void aevk_image_barrier(AevkDevice* d, VkCommandBuffer cmd, VkImage img,
     d->da.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, NULL, 0, NULL, 1, &b);
 }
 
+/* How many mip levels a full chain needs: halving until 1x1. */
+static uint32_t aevk_mip_levels_for(int width, int height) {
+    uint32_t levels = 1;
+    int w = width, h = height;
+    while (w > 1 || h > 1) {
+        w = (w > 1) ? w / 2 : 1;
+        h = (h > 1) ? h / 2 : 1;
+        levels++;
+    }
+    return levels;
+}
+
 AevkTexture* aevk_texture_create(AevkDevice* d, int width, int height) {
+    return aevk_texture_create_ex(d, width, height, 0, 0, 0);
+}
+
+/* `mipmapped` builds a full mip chain, which needs the device to support
+ * linear blitting of the format. `linear_filter` picks LINEAR over NEAREST for
+ * magnification, minification and between mip levels. `repeat` picks REPEAT
+ * over CLAMP_TO_EDGE for addressing. */
+AevkTexture* aevk_texture_create_ex(AevkDevice* d, int width, int height,
+                                    int mipmapped, int linear_filter, int repeat) {
     aevk_clear_error();
     if (!d) { aevk_fail(AEVK_ERR_ARG, "device is null"); return NULL; }
     if (width <= 0 || height <= 0) {
@@ -1395,11 +1552,27 @@ AevkTexture* aevk_texture_create(AevkDevice* d, int width, int height) {
         return NULL;
     }
 
+    uint32_t levels = 1;
+    if (mipmapped) {
+        /* Generating the chain is a chain of blits, which the driver only has
+         * to support for formats advertising SAMPLED_IMAGE_FILTER_LINEAR.
+         * Refusing beats generating a black chain nobody notices. */
+        VkFormatProperties fp;
+        d->ia.vkGetPhysicalDeviceFormatProperties(d->phys, VK_FORMAT_R8G8B8A8_UNORM, &fp);
+        if (!(fp.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
+            aevk_fail(AEVK_ERR_UNSUPPORTED,
+                      "device cannot linear-filter R8G8B8A8_UNORM, so it cannot build mipmaps");
+            return NULL;
+        }
+        levels = aevk_mip_levels_for(width, height);
+    }
+
     AevkTexture* tex = (AevkTexture*)calloc(1, sizeof(*tex));
     if (!tex) { aevk_fail(AEVK_ERR_OOM, "out of memory"); return NULL; }
     tex->dev = d;
     tex->width = width;
     tex->height = height;
+    tex->mip_levels = levels;
 
     VkImageCreateInfo ii = {0};
     ii.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -1408,11 +1581,14 @@ AevkTexture* aevk_texture_create(AevkDevice* d, int width, int height) {
     ii.extent.width = (uint32_t)width;
     ii.extent.height = (uint32_t)height;
     ii.extent.depth = 1;
-    ii.mipLevels = 1;
+    ii.mipLevels = levels;
     ii.arrayLayers = 1;
     ii.samples = VK_SAMPLE_COUNT_1_BIT;
     ii.tiling = VK_IMAGE_TILING_OPTIMAL;
-    ii.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    /* TRANSFER_SRC as well as DST: building the chain blits level N-1 into
+     * level N, so the image reads from itself. */
+    ii.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+               VK_IMAGE_USAGE_SAMPLED_BIT;
     ii.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ii.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     VkResult r = d->da.vkCreateImage(d->device, &ii, NULL, &tex->image);
@@ -1440,20 +1616,24 @@ AevkTexture* aevk_texture_create(AevkDevice* d, int width, int height) {
     vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
     vi.format = VK_FORMAT_R8G8B8A8_UNORM;
     vi.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vi.subresourceRange.levelCount = 1;
+    vi.subresourceRange.levelCount = levels;
     vi.subresourceRange.layerCount = 1;
     r = d->da.vkCreateImageView(d->device, &vi, NULL, &tex->view);
     if (r != VK_SUCCESS) { aevk_fail(AEVK_ERR_OOM, "vkCreateImageView failed (%d)", (int)r); goto fail; }
 
     VkSamplerCreateInfo si = {0};
     si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    si.magFilter = VK_FILTER_NEAREST;
-    si.minFilter = VK_FILTER_NEAREST;
-    si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-    si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    si.maxLod = 0.0f;
+    VkFilter filter = linear_filter ? VK_FILTER_LINEAR : VK_FILTER_NEAREST;
+    VkSamplerAddressMode mode = repeat ? VK_SAMPLER_ADDRESS_MODE_REPEAT
+                                       : VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    si.magFilter = filter;
+    si.minFilter = filter;
+    si.mipmapMode = linear_filter ? VK_SAMPLER_MIPMAP_MODE_LINEAR
+                                  : VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    si.addressModeU = mode;
+    si.addressModeV = mode;
+    si.addressModeW = mode;
+    si.maxLod = (float)levels;
     si.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
     r = d->da.vkCreateSampler(d->device, &si, NULL, &tex->sampler);
     if (r != VK_SUCCESS) { aevk_fail(AEVK_ERR_OOM, "vkCreateSampler failed (%d)", (int)r); goto fail; }
@@ -1462,6 +1642,10 @@ AevkTexture* aevk_texture_create(AevkDevice* d, int width, int height) {
 fail:
     aevk_texture_destroy(tex);
     return NULL;
+}
+
+int aevk_texture_mip_levels(const AevkTexture* tex) {
+    return tex ? (int)tex->mip_levels : 0;
 }
 
 void aevk_texture_destroy(AevkTexture* tex) {
@@ -1512,10 +1696,12 @@ int aevk_texture_upload(AevkTexture* tex, const void* rgba, size_t len) {
     VkCommandBuffer cmd = VK_NULL_HANDLE;
     rc = aevk_run_once(d, &cmd);
     if (rc == AEVK_OK) {
-        aevk_image_barrier(d, cmd, tex->image,
-                           VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                           0, VK_ACCESS_TRANSFER_WRITE_BIT,
-                           VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+        aevk_image_barrier_levels(d, cmd, tex->image, 0, tex->mip_levels,
+                                  VK_IMAGE_LAYOUT_UNDEFINED,
+                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                  0, VK_ACCESS_TRANSFER_WRITE_BIT,
+                                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                  VK_PIPELINE_STAGE_TRANSFER_BIT);
 
         VkBufferImageCopy copy = {0};
         copy.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1526,12 +1712,65 @@ int aevk_texture_upload(AevkTexture* tex, const void* rgba, size_t len) {
         d->da.vkCmdCopyBufferToImage(cmd, staging, tex->image,
                                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
 
-        aevk_image_barrier(d, cmd, tex->image,
-                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                           VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                           VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
-                           VK_PIPELINE_STAGE_TRANSFER_BIT,
-                           VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        if (tex->mip_levels > 1) {
+            /* Each level is blitted from the one above, so level N-1 has to be
+             * readable before level N is written. Walking the chain one level
+             * at a time is what keeps that ordering explicit. */
+            int mw = tex->width, mh = tex->height;
+            for (uint32_t level = 1; level < tex->mip_levels; level++) {
+                aevk_image_barrier_levels(d, cmd, tex->image, level - 1, 1,
+                                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                          VK_ACCESS_TRANSFER_WRITE_BIT,
+                                          VK_ACCESS_TRANSFER_READ_BIT,
+                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                          VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+                int nw = (mw > 1) ? mw / 2 : 1;
+                int nh = (mh > 1) ? mh / 2 : 1;
+                VkImageBlit blit = {0};
+                blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                blit.srcSubresource.mipLevel = level - 1;
+                blit.srcSubresource.layerCount = 1;
+                blit.srcOffsets[1].x = mw;
+                blit.srcOffsets[1].y = mh;
+                blit.srcOffsets[1].z = 1;
+                blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+                blit.dstSubresource.mipLevel = level;
+                blit.dstSubresource.layerCount = 1;
+                blit.dstOffsets[1].x = nw;
+                blit.dstOffsets[1].y = nh;
+                blit.dstOffsets[1].z = 1;
+                d->da.vkCmdBlitImage(cmd,
+                                     tex->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                     tex->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                     1, &blit, VK_FILTER_LINEAR);
+
+                aevk_image_barrier_levels(d, cmd, tex->image, level - 1, 1,
+                                          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                          VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                          VK_ACCESS_TRANSFER_READ_BIT,
+                                          VK_ACCESS_SHADER_READ_BIT,
+                                          VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+                mw = nw;
+                mh = nh;
+            }
+            /* The last level was never blitted from, so it is still DST. */
+            aevk_image_barrier_levels(d, cmd, tex->image, tex->mip_levels - 1, 1,
+                                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                      VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+                                      VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                      VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        } else {
+            aevk_image_barrier(d, cmd, tex->image,
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                               VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT,
+                               VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        }
         rc = aevk_submit_once(d, cmd);
     }
     AEVK_MUTEX_UNLOCK(&d->lock);
@@ -1540,6 +1779,86 @@ int aevk_texture_upload(AevkTexture* tex, const void* rgba, size_t len) {
     d->da.vkFreeMemory(d->device, staging_mem, NULL);
     if (rc == AEVK_OK) tex->uploaded = 1;
     return rc;
+}
+
+/* Adds a pool. Called when the newest one is full, or for the first set. */
+static int aevk_pipeline_add_pool(AevkPipeline* p) {
+    AevkDevice* d = p->dev;
+    if (p->pool_count >= AEVK_MAX_POOLS) {
+        return aevk_fail(AEVK_ERR_OOM, "at most %d descriptor pools per pipeline (%d materials)",
+                         AEVK_MAX_POOLS, AEVK_MAX_POOLS * AEVK_SETS_PER_POOL);
+    }
+    VkDescriptorPoolCreateInfo dpi = {0};
+    dpi.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    dpi.maxSets = AEVK_SETS_PER_POOL;
+    dpi.poolSizeCount = p->pool_size_count;
+    dpi.pPoolSizes = p->pool_sizes;
+    VkResult r = d->da.vkCreateDescriptorPool(d->device, &dpi, NULL, &p->pools[p->pool_count]);
+    if (r != VK_SUCCESS) {
+        return aevk_fail(AEVK_ERR_OOM, "vkCreateDescriptorPool failed (%d)", (int)r);
+    }
+    p->pool_count++;
+    p->sets_in_pool = 0;
+    return AEVK_OK;
+}
+
+AevkMaterial* aevk_material_create(AevkPipeline* p) {
+    aevk_clear_error();
+    if (!p) { aevk_fail(AEVK_ERR_ARG, "pipeline is null"); return NULL; }
+    if (!p->set_layout) {
+        aevk_fail(AEVK_ERR_ARG,
+                  "pipeline was created without bindings, so it has no materials");
+        return NULL;
+    }
+    AevkDevice* d = p->dev;
+
+    if (p->pool_count == 0 || p->sets_in_pool >= AEVK_SETS_PER_POOL) {
+        if (aevk_pipeline_add_pool(p) != AEVK_OK) return NULL;
+    }
+
+    AevkMaterial* m = (AevkMaterial*)calloc(1, sizeof(*m));
+    if (!m) { aevk_fail(AEVK_ERR_OOM, "out of memory"); return NULL; }
+    m->pipe = p;
+
+    VkDescriptorSetAllocateInfo dsi = {0};
+    dsi.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    dsi.descriptorPool = p->pools[p->pool_count - 1];
+    dsi.descriptorSetCount = 1;
+    dsi.pSetLayouts = &p->set_layout;
+    VkResult r = d->da.vkAllocateDescriptorSets(d->device, &dsi, &m->set);
+
+    /* A driver may report the pool full before maxSets is reached, since
+     * descriptor counts can run out first. Take that as "add a pool" rather
+     * than as failure. */
+    if (r == VK_ERROR_OUT_OF_POOL_MEMORY || r == VK_ERROR_FRAGMENTED_POOL) {
+        if (aevk_pipeline_add_pool(p) != AEVK_OK) { free(m); return NULL; }
+        dsi.descriptorPool = p->pools[p->pool_count - 1];
+        r = d->da.vkAllocateDescriptorSets(d->device, &dsi, &m->set);
+    }
+    if (r != VK_SUCCESS) {
+        aevk_fail(AEVK_ERR_OOM, "vkAllocateDescriptorSets failed (%d)", (int)r);
+        free(m);
+        return NULL;
+    }
+    p->sets_in_pool++;
+    return m;
+}
+
+/* The set itself is owned by its pool and goes when the pipeline does; what
+ * this reclaims is the uniform buffers written into it. Destroy materials
+ * before the pipeline that made them. */
+void aevk_material_destroy(AevkMaterial* m) {
+    if (!m) return;
+    AevkPipeline* p = m->pipe;
+    if (p && p->dev && p->dev->device) {
+        AevkDevice* d = p->dev;
+        for (int i = 0; i < AEVK_MAX_DESC; i++) {
+            if (m->ub[i].ptr) d->da.vkUnmapMemory(d->device, m->ub[i].mem);
+            if (m->ub[i].buf) d->da.vkDestroyBuffer(d->device, m->ub[i].buf, NULL);
+            if (m->ub[i].mem) d->da.vkFreeMemory(d->device, m->ub[i].mem, NULL);
+        }
+    }
+    free(m);
 }
 
 AevkPipeline* aevk_pipeline_create(AevkDevice* d, AevkTarget* t,
@@ -1613,27 +1932,15 @@ AevkPipeline* aevk_pipeline_create_ex(AevkDevice* d, AevkTarget* t,
         if (n_img) { sizes[nsizes].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
                      sizes[nsizes++].descriptorCount = n_img; }
 
-        VkDescriptorPoolCreateInfo dpi = {0};
-        dpi.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        dpi.maxSets = 1;
-        dpi.poolSizeCount = nsizes;
-        dpi.pPoolSizes = sizes;
-        r = d->da.vkCreateDescriptorPool(d->device, &dpi, NULL, &p->pool);
-        if (r != VK_SUCCESS) {
-            aevk_fail(AEVK_ERR_OOM, "vkCreateDescriptorPool failed (%d)", (int)r);
-            goto fail;
+        /* Counts are per set; a pool holds AEVK_SETS_PER_POOL of them. */
+        for (uint32_t i = 0; i < nsizes; i++) {
+            p->pool_sizes[i] = sizes[i];
+            p->pool_sizes[i].descriptorCount = sizes[i].descriptorCount * AEVK_SETS_PER_POOL;
         }
+        p->pool_size_count = nsizes;
 
-        VkDescriptorSetAllocateInfo dsi = {0};
-        dsi.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        dsi.descriptorPool = p->pool;
-        dsi.descriptorSetCount = 1;
-        dsi.pSetLayouts = &p->set_layout;
-        r = d->da.vkAllocateDescriptorSets(d->device, &dsi, &p->set);
-        if (r != VK_SUCCESS) {
-            aevk_fail(AEVK_ERR_OOM, "vkAllocateDescriptorSets failed (%d)", (int)r);
-            goto fail;
-        }
+        p->def = aevk_material_create(p);
+        if (!p->def) goto fail;
     }
 
     VkPushConstantRange pcr = {0};
@@ -1787,13 +2094,12 @@ void aevk_pipeline_destroy(AevkPipeline* p) {
         if (p->frag)     d->da.vkDestroyShaderModule(d->device, p->frag, NULL);
         if (p->vert)     d->da.vkDestroyShaderModule(d->device, p->vert, NULL);
         /* Sets are freed with their pool; the layout outlives neither. */
-        if (p->pool)       d->da.vkDestroyDescriptorPool(d->device, p->pool, NULL);
-        if (p->set_layout) d->da.vkDestroyDescriptorSetLayout(d->device, p->set_layout, NULL);
-        for (int i = 0; i < AEVK_MAX_DESC; i++) {
-            if (p->ub[i].ptr) d->da.vkUnmapMemory(d->device, p->ub[i].mem);
-            if (p->ub[i].buf) d->da.vkDestroyBuffer(d->device, p->ub[i].buf, NULL);
-            if (p->ub[i].mem) d->da.vkFreeMemory(d->device, p->ub[i].mem, NULL);
+        aevk_material_destroy(p->def);
+        p->def = NULL;
+        for (int i = 0; i < p->pool_count; i++) {
+            d->da.vkDestroyDescriptorPool(d->device, p->pools[i], NULL);
         }
+        if (p->set_layout) d->da.vkDestroyDescriptorSetLayout(d->device, p->set_layout, NULL);
         AEVK_MUTEX_UNLOCK(&d->lock);
     }
     free(p);
@@ -1803,15 +2109,17 @@ void aevk_pipeline_destroy(AevkPipeline* p) {
 /* Shader resources: uniform buffers, textures, push constants              */
 /* ------------------------------------------------------------------------ */
 
-int aevk_pipeline_set_uniform(AevkPipeline* p, int binding,
+int aevk_material_set_uniform(AevkMaterial* m, int binding,
                               const void* data, size_t len) {
     aevk_clear_error();
+    if (!m) return aevk_fail(AEVK_ERR_ARG, "material is null");
+    AevkPipeline* p = m->pipe;
     if (!p || !data) return aevk_fail(AEVK_ERR_ARG, "pipeline or data is null");
     if (binding < 0 || binding >= AEVK_MAX_DESC) {
         return aevk_fail(AEVK_ERR_ARG, "binding must be 0..%d", AEVK_MAX_DESC - 1);
     }
     if (len == 0) return aevk_fail(AEVK_ERR_ARG, "uniform data is empty");
-    if (!p->set) {
+    if (!m->set) {
         return aevk_fail(AEVK_ERR_ARG,
                          "pipeline was created without bindings, so it has no descriptor set");
     }
@@ -1819,39 +2127,39 @@ int aevk_pipeline_set_uniform(AevkPipeline* p, int binding,
 
     /* Reuse the buffer while it is big enough; a uniform that changes every
      * frame must not allocate every frame. */
-    if (p->ub[binding].buf && p->ub[binding].size < (VkDeviceSize)len) {
-        if (p->ub[binding].ptr) d->da.vkUnmapMemory(d->device, p->ub[binding].mem);
-        d->da.vkDestroyBuffer(d->device, p->ub[binding].buf, NULL);
-        d->da.vkFreeMemory(d->device, p->ub[binding].mem, NULL);
-        p->ub[binding].buf = VK_NULL_HANDLE;
-        p->ub[binding].mem = VK_NULL_HANDLE;
-        p->ub[binding].ptr = NULL;
-        p->ub[binding].size = 0;
+    if (m->ub[binding].buf && m->ub[binding].size < (VkDeviceSize)len) {
+        if (m->ub[binding].ptr) d->da.vkUnmapMemory(d->device, m->ub[binding].mem);
+        d->da.vkDestroyBuffer(d->device, m->ub[binding].buf, NULL);
+        d->da.vkFreeMemory(d->device, m->ub[binding].mem, NULL);
+        m->ub[binding].buf = VK_NULL_HANDLE;
+        m->ub[binding].mem = VK_NULL_HANDLE;
+        m->ub[binding].ptr = NULL;
+        m->ub[binding].size = 0;
     }
 
-    if (!p->ub[binding].buf) {
+    if (!m->ub[binding].buf) {
         int rc = aevk_make_buffer(d, (VkDeviceSize)len, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
                                   VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                                  &p->ub[binding].buf, &p->ub[binding].mem);
+                                  &m->ub[binding].buf, &m->ub[binding].mem);
         if (rc != AEVK_OK) return rc;
-        VkResult r = d->da.vkMapMemory(d->device, p->ub[binding].mem, 0,
-                                       (VkDeviceSize)len, 0, &p->ub[binding].ptr);
+        VkResult r = d->da.vkMapMemory(d->device, m->ub[binding].mem, 0,
+                                       (VkDeviceSize)len, 0, &m->ub[binding].ptr);
         if (r != VK_SUCCESS) {
-            d->da.vkDestroyBuffer(d->device, p->ub[binding].buf, NULL);
-            d->da.vkFreeMemory(d->device, p->ub[binding].mem, NULL);
-            p->ub[binding].buf = VK_NULL_HANDLE;
-            p->ub[binding].mem = VK_NULL_HANDLE;
+            d->da.vkDestroyBuffer(d->device, m->ub[binding].buf, NULL);
+            d->da.vkFreeMemory(d->device, m->ub[binding].mem, NULL);
+            m->ub[binding].buf = VK_NULL_HANDLE;
+            m->ub[binding].mem = VK_NULL_HANDLE;
             return aevk_fail(AEVK_ERR_OOM, "vkMapMemory failed (%d)", (int)r);
         }
-        p->ub[binding].size = (VkDeviceSize)len;
+        m->ub[binding].size = (VkDeviceSize)len;
 
         VkDescriptorBufferInfo bi = {0};
-        bi.buffer = p->ub[binding].buf;
+        bi.buffer = m->ub[binding].buf;
         bi.range = (VkDeviceSize)len;
         VkWriteDescriptorSet w = {0};
         w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        w.dstSet = p->set;
+        w.dstSet = m->set;
         w.dstBinding = (uint32_t)binding;
         w.descriptorCount = 1;
         w.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -1861,17 +2169,19 @@ int aevk_pipeline_set_uniform(AevkPipeline* p, int binding,
 
     /* Host-coherent, so the write is visible without a flush. The descriptor
      * already points at this buffer, so no set update is needed per frame. */
-    memcpy(p->ub[binding].ptr, data, len);
+    memcpy(m->ub[binding].ptr, data, len);
     return AEVK_OK;
 }
 
-int aevk_pipeline_set_texture(AevkPipeline* p, int binding, AevkTexture* tex) {
+int aevk_material_set_texture(AevkMaterial* m, int binding, AevkTexture* tex) {
     aevk_clear_error();
+    if (!m) return aevk_fail(AEVK_ERR_ARG, "material is null");
+    AevkPipeline* p = m->pipe;
     if (!p || !tex) return aevk_fail(AEVK_ERR_ARG, "pipeline or texture is null");
     if (binding < 0 || binding >= AEVK_MAX_DESC) {
         return aevk_fail(AEVK_ERR_ARG, "binding must be 0..%d", AEVK_MAX_DESC - 1);
     }
-    if (!p->set) {
+    if (!m->set) {
         return aevk_fail(AEVK_ERR_ARG,
                          "pipeline was created without bindings, so it has no descriptor set");
     }
@@ -1888,7 +2198,7 @@ int aevk_pipeline_set_texture(AevkPipeline* p, int binding, AevkTexture* tex) {
     ii.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     VkWriteDescriptorSet w = {0};
     w.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    w.dstSet = p->set;
+    w.dstSet = m->set;
     w.dstBinding = (uint32_t)binding;
     w.descriptorCount = 1;
     w.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -1896,6 +2206,28 @@ int aevk_pipeline_set_texture(AevkPipeline* p, int binding, AevkTexture* tex) {
     d->da.vkUpdateDescriptorSets(d->device, 1, &w, 0, NULL);
     return AEVK_OK;
 }
+/* The pipeline-level writers address its default material, so callers that
+ * never ask for one see no change. */
+int aevk_pipeline_set_uniform(AevkPipeline* p, int binding, const void* data, size_t len) {
+    aevk_clear_error();
+    if (!p) return aevk_fail(AEVK_ERR_ARG, "pipeline is null");
+    if (!p->def) {
+        return aevk_fail(AEVK_ERR_ARG,
+                         "pipeline was created without bindings, so it has no descriptor set");
+    }
+    return aevk_material_set_uniform(p->def, binding, data, len);
+}
+
+int aevk_pipeline_set_texture(AevkPipeline* p, int binding, AevkTexture* tex) {
+    aevk_clear_error();
+    if (!p) return aevk_fail(AEVK_ERR_ARG, "pipeline is null");
+    if (!p->def) {
+        return aevk_fail(AEVK_ERR_ARG,
+                         "pipeline was created without bindings, so it has no descriptor set");
+    }
+    return aevk_material_set_texture(p->def, binding, tex);
+}
+
 
 int aevk_target_set_push(AevkTarget* t, const void* data, size_t len) {
     aevk_clear_error();
@@ -1914,6 +2246,7 @@ int aevk_target_set_push(AevkTarget* t, const void* data, size_t len) {
  * set_vertices is a thin wrapper over it so the grow-and-map path exists
  * once. */
 int aevk_ae_verts_reserve(void* tp, int count);
+int aevk_ae_indices_reserve_ex(void* tp, int count, int bits);
 
 /* ------------------------------------------------------------------------ */
 /* Geometry, draw, readback                                                  */
@@ -1927,7 +2260,7 @@ int aevk_target_set_vertices(AevkTarget* t, const float* data, int count) {
     return AEVK_OK;
 }
 
-static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p,
+static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p, AevkMaterial* mat,
                        float r, float g, float b, float a) {
     AevkDevice* d = t->dev;
     VkResult vr = d->da.vkResetCommandBuffer(fr->cmd, 0);
@@ -1971,9 +2304,13 @@ static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p,
         d->da.vkCmdSetViewport(fr->cmd, 0, 1, &vp);
         d->da.vkCmdSetScissor(fr->cmd, 0, 1, &sc);
         d->da.vkCmdBindPipeline(fr->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, p->pipeline);
-        if (p->set) {
+        /* The material decides which set is bound; without one the pipeline's
+         * default is used, which is what a caller that never asked for
+         * materials has. */
+        AevkMaterial* bind_mat = mat ? mat : p->def;
+        if (bind_mat && bind_mat->set) {
             d->da.vkCmdBindDescriptorSets(fr->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                          p->layout, 0, 1, &p->set, 0, NULL);
+                                          p->layout, 0, 1, &bind_mat->set, 0, NULL);
         }
         /* Push whatever the pipeline declared room for, so a caller who set
          * fewer bytes than the range still gets a defined block. */
@@ -1989,7 +2326,30 @@ static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p,
         VkDeviceSize off = 0;
         d->da.vkCmdBindVertexBuffers(fr->cmd, 0, 1, &t->vbuf, &off);
         if (t->index_count > 0) {
-            d->da.vkCmdBindIndexBuffer(fr->cmd, t->ibuf, 0, VK_INDEX_TYPE_UINT32);
+            d->da.vkCmdBindIndexBuffer(fr->cmd, t->ibuf, 0,
+                                       (t->index_bits == 16) ? VK_INDEX_TYPE_UINT16
+                                                             : VK_INDEX_TYPE_UINT32);
+        }
+        if (t->batch_count > 0) {
+            /* Several draws inside the one render pass, each free to bind its
+             * own material. Rebinding the set between draws is the whole
+             * reason per-draw sets exist: with one set per pipeline the second
+             * draw would overwrite what the first is still going to read. */
+            for (int i = 0; i < t->batch_count; i++) {
+                AevkDrawItem* it = &t->batch[i];
+                AevkMaterial* im = it->mat ? it->mat : bind_mat;
+                if (im && im->set) {
+                    d->da.vkCmdBindDescriptorSets(fr->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                                  p->layout, 0, 1, &im->set, 0, NULL);
+                }
+                if (t->index_count > 0) {
+                    d->da.vkCmdDrawIndexed(fr->cmd, (uint32_t)it->count, 1,
+                                           (uint32_t)it->first, 0, 0);
+                } else {
+                    d->da.vkCmdDraw(fr->cmd, (uint32_t)it->count, 1, (uint32_t)it->first, 0);
+                }
+            }
+        } else if (t->index_count > 0) {
             d->da.vkCmdDrawIndexed(fr->cmd, (uint32_t)t->index_count, 1, 0, 0, 0);
         } else {
             d->da.vkCmdDraw(fr->cmd, (uint32_t)t->vertex_count, 1, 0, 0);
@@ -2011,15 +2371,18 @@ static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p,
 
     fr->recorded = 1;
     fr->rec_pipe = p;
+    fr->rec_mat = mat;
     fr->rec_vertices = t->vertex_count;
     fr->rec_clear[0] = r; fr->rec_clear[1] = g; fr->rec_clear[2] = b; fr->rec_clear[3] = a;
     fr->rec_indices = t->index_count;
     fr->rec_push_size = t->push_size;
     if (t->push_size) memcpy(fr->rec_push, t->push_data, t->push_size);
+    fr->rec_batch_version = t->batch_version;
+    fr->rec_batch_count = t->batch_count;
     return AEVK_OK;
 }
 
-static int aevk_draw_locked(AevkTarget* t, AevkPipeline* p,
+static int aevk_draw_locked(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
                             float r, float g, float b, float a);
 
 int aevk_draw(AevkTarget* t, AevkPipeline* p, float r, float g, float b, float a) {
@@ -2032,7 +2395,7 @@ int aevk_draw(AevkTarget* t, AevkPipeline* p, float r, float g, float b, float a
 
     AevkDevice* d = t->dev;
     AEVK_MUTEX_LOCK(&d->lock);
-    int rc = aevk_draw_locked(t, p, r, g, b, a);
+    int rc = aevk_draw_locked(t, p, NULL, r, g, b, a);
     AEVK_MUTEX_UNLOCK(&d->lock);
     return rc;
 }
@@ -2077,23 +2440,31 @@ static int aevk_wait_frame_locked(AevkTarget* t, int slot) {
  * The slot is reused round-robin, so the wait here is for the work this slot
  * held `frame_count` submissions ago, not for the one just queued: that is the
  * whole point, and it is also what bounds the queue depth. */
-static int aevk_submit_locked(AevkTarget* t, AevkPipeline* p,
+static int aevk_submit_locked(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
                               float r, float g, float b, float a) {
     AevkDevice* d = t->dev;
     int slot = t->next_frame;
+
+    if (t->batch_count > 0 && p) {
+        int brc = aevk_batch_check(t, p);
+        if (brc != AEVK_OK) return brc;
+    }
 
     int rc = aevk_wait_frame_locked(t, slot);
     if (rc != AEVK_OK) return rc;
 
     AevkFrame* fr = &t->frames[slot];
-    int stale = !fr->recorded || fr->rec_pipe != p || fr->rec_vertices != t->vertex_count ||
+    int stale = !fr->recorded || fr->rec_pipe != p || fr->rec_mat != mat ||
+                fr->rec_vertices != t->vertex_count ||
                 fr->rec_clear[0] != r || fr->rec_clear[1] != g ||
                 fr->rec_clear[2] != b || fr->rec_clear[3] != a ||
                 fr->rec_indices != t->index_count ||
                 fr->rec_push_size != t->push_size ||
+                fr->rec_batch_version != t->batch_version ||
+                fr->rec_batch_count != t->batch_count ||
                 (t->push_size && memcmp(fr->rec_push, t->push_data, t->push_size) != 0);
     if (stale) {
-        rc = aevk_record(t, fr, p, r, g, b, a);
+        rc = aevk_record(t, fr, p, mat, r, g, b, a);
         if (rc != AEVK_OK) { fr->recorded = 0; return rc; }
     }
 
@@ -2115,9 +2486,9 @@ static int aevk_submit_locked(AevkTarget* t, AevkPipeline* p,
     return slot;
 }
 
-static int aevk_draw_locked(AevkTarget* t, AevkPipeline* p,
+static int aevk_draw_locked(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
                             float r, float g, float b, float a) {
-    int slot = aevk_submit_locked(t, p, r, g, b, a);
+    int slot = aevk_submit_locked(t, p, mat, r, g, b, a);
     if (slot < 0) return slot;
     return aevk_wait_frame_locked(t, slot);
 }
@@ -2173,7 +2544,39 @@ int aevk_submit(AevkTarget* t, AevkPipeline* p, float r, float g, float b, float
     }
     AevkDevice* d = t->dev;
     AEVK_MUTEX_LOCK(&d->lock);
-    int slot = aevk_submit_locked(t, p, r, g, b, a);
+    int slot = aevk_submit_locked(t, p, NULL, r, g, b, a);
+    AEVK_MUTEX_UNLOCK(&d->lock);
+    return slot;
+}
+
+/* Draws with a specific material, so one pipeline serves several objects with
+ * different textures and constants in a frame. Otherwise identical to draw. */
+int aevk_draw_material(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
+                       float r, float g, float b, float a) {
+    aevk_clear_error();
+    if (!t) return aevk_fail(AEVK_ERR_ARG, "target is null");
+    if (p && p->dev != t->dev) return aevk_fail(AEVK_ERR_ARG, "pipeline belongs to another device");
+    if (mat && mat->pipe != p) return aevk_fail(AEVK_ERR_ARG, "material belongs to another pipeline");
+    if (p && t->vertex_count > 0 && !t->vbuf) {
+        return aevk_fail(AEVK_ERR_ARG, "vertices were never uploaded");
+    }
+    AevkDevice* d = t->dev;
+    AEVK_MUTEX_LOCK(&d->lock);
+    int rc = aevk_draw_locked(t, p, mat, r, g, b, a);
+    AEVK_MUTEX_UNLOCK(&d->lock);
+    return rc;
+}
+
+/* The non-blocking sibling of draw_material. */
+int aevk_submit_material(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
+                         float r, float g, float b, float a) {
+    aevk_clear_error();
+    if (!t) return aevk_fail(AEVK_ERR_ARG, "target is null");
+    if (p && p->dev != t->dev) return aevk_fail(AEVK_ERR_ARG, "pipeline belongs to another device");
+    if (mat && mat->pipe != p) return aevk_fail(AEVK_ERR_ARG, "material belongs to another pipeline");
+    AevkDevice* d = t->dev;
+    AEVK_MUTEX_LOCK(&d->lock);
+    int slot = aevk_submit_locked(t, p, mat, r, g, b, a);
     AEVK_MUTEX_UNLOCK(&d->lock);
     return slot;
 }
@@ -2374,16 +2777,97 @@ int aevk_ae_uniform_float(void* pp, int binding, int index, double value) {
     if (binding < 0 || binding >= AEVK_MAX_DESC) {
         return aevk_fail(AEVK_ERR_ARG, "binding must be 0..%d", AEVK_MAX_DESC - 1);
     }
-    if (!p->ub[binding].ptr) {
+    AevkMaterial* m = p->def;
+    if (!m || !m->ub[binding].ptr) {
         return aevk_fail(AEVK_ERR_ARG, "call uniform_floats for binding %d first", binding);
     }
-    int n = (int)(p->ub[binding].size / sizeof(float));
+    int n = (int)(m->ub[binding].size / sizeof(float));
     if (index < 0 || index >= n) {
         return aevk_fail(AEVK_ERR_ARG, "uniform float %d is outside 0..%d", index, n - 1);
     }
     float f = (float)value;
-    memcpy((char*)p->ub[binding].ptr + (size_t)index * sizeof(float), &f, sizeof(f));
+    memcpy((char*)m->ub[binding].ptr + (size_t)index * sizeof(float), &f, sizeof(f));
     return AEVK_OK;
+}
+
+int aevk_ae_batch_reset(void* t) { return aevk_batch_reset((AevkTarget*)t); }
+int aevk_ae_batch_add(void* t, void* m, int first, int count) {
+    return aevk_batch_add((AevkTarget*)t, (AevkMaterial*)m, first, count);
+}
+int aevk_ae_batch_count(void* t) { return aevk_batch_count((const AevkTarget*)t); }
+
+void* aevk_ae_material_create(void* pp) {
+    return (void*)aevk_material_create((AevkPipeline*)pp);
+}
+void aevk_ae_material_destroy(void* mp) { aevk_material_destroy((AevkMaterial*)mp); }
+
+int aevk_ae_material_set_texture(void* mp, int binding, void* tex) {
+    return aevk_material_set_texture((AevkMaterial*)mp, binding, (AevkTexture*)tex);
+}
+
+int aevk_ae_material_set_uniform(void* mp, int binding, const void* data, int len) {
+    if (len < 0) return aevk_fail(AEVK_ERR_ARG, "negative uniform length");
+    return aevk_material_set_uniform((AevkMaterial*)mp, binding, data, (size_t)len);
+}
+
+int aevk_ae_material_floats(void* mp, int binding, int count) {
+    AevkMaterial* m = (AevkMaterial*)mp;
+    aevk_clear_error();
+    if (!m) return aevk_fail(AEVK_ERR_ARG, "material is null");
+    if (count <= 0) return aevk_fail(AEVK_ERR_ARG, "uniform float count must be positive");
+    size_t bytes = (size_t)count * sizeof(float);
+    float stack[64];
+    float* zero = stack;
+    if (count > (int)(sizeof(stack) / sizeof(stack[0]))) {
+        zero = (float*)calloc((size_t)count, sizeof(float));
+        if (!zero) return aevk_fail(AEVK_ERR_OOM, "out of memory");
+    } else {
+        memset(stack, 0, bytes);
+    }
+    int rc = aevk_material_set_uniform(m, binding, zero, bytes);
+    if (zero != stack) free(zero);
+    return rc;
+}
+
+int aevk_ae_material_float(void* mp, int binding, int index, double value) {
+    AevkMaterial* m = (AevkMaterial*)mp;
+    aevk_clear_error();
+    if (!m) return aevk_fail(AEVK_ERR_ARG, "material is null");
+    if (binding < 0 || binding >= AEVK_MAX_DESC) {
+        return aevk_fail(AEVK_ERR_ARG, "binding must be 0..%d", AEVK_MAX_DESC - 1);
+    }
+    if (!m->ub[binding].ptr) {
+        return aevk_fail(AEVK_ERR_ARG, "call material_floats for binding %d first", binding);
+    }
+    int n = (int)(m->ub[binding].size / sizeof(float));
+    if (index < 0 || index >= n) {
+        return aevk_fail(AEVK_ERR_ARG, "uniform float %d is outside 0..%d", index, n - 1);
+    }
+    float f = (float)value;
+    memcpy((char*)m->ub[binding].ptr + (size_t)index * sizeof(float), &f, sizeof(f));
+    return AEVK_OK;
+}
+
+int aevk_ae_draw_material(void* t, void* p, void* m,
+                          double r, double g, double b, double a) {
+    return aevk_draw_material((AevkTarget*)t, (AevkPipeline*)p, (AevkMaterial*)m,
+                              (float)r, (float)g, (float)b, (float)a);
+}
+
+int aevk_ae_submit_material(void* t, void* p, void* m,
+                            double r, double g, double b, double a) {
+    return aevk_submit_material((AevkTarget*)t, (AevkPipeline*)p, (AevkMaterial*)m,
+                                (float)r, (float)g, (float)b, (float)a);
+}
+
+void* aevk_ae_texture_create_ex(void* d, int w, int h,
+                                int mipmapped, int linear_filter, int repeat) {
+    return (void*)aevk_texture_create_ex((AevkDevice*)d, w, h,
+                                         mipmapped, linear_filter, repeat);
+}
+
+int aevk_ae_texture_mip_levels(void* tex) {
+    return aevk_texture_mip_levels((const AevkTexture*)tex);
 }
 
 int aevk_ae_set_push(void* t, const void* data, int len) {
@@ -2460,17 +2944,29 @@ int aevk_ae_verts_set_float(void* tp, int float_index, double value) {
  * worth a second code path at this size, and a caller who needs it can say
  * so when there is a reason. */
 int aevk_ae_indices_reserve(void* tp, int count) {
+    return aevk_ae_indices_reserve_ex(tp, count, 32);
+}
+
+/* `bits` is 16 or 32. Sixteen halves the index memory and the bandwidth to
+ * read it, which is worth having for the meshes that fit: anything under
+ * 65,536 vertices, i.e. most of them. */
+int aevk_ae_indices_reserve_ex(void* tp, int count, int bits) {
     AevkTarget* t = (AevkTarget*)tp;
     aevk_clear_error();
     if (!t) return aevk_fail(AEVK_ERR_ARG, "target is null");
     if (count < 0) return aevk_fail(AEVK_ERR_ARG, "index count must not be negative");
-    if ((size_t)count > (size_t)(SIZE_MAX / sizeof(uint32_t))) {
+    if (bits != 16 && bits != 32) {
+        return aevk_fail(AEVK_ERR_ARG, "index width must be 16 or 32 bits (got %d)", bits);
+    }
+    size_t stride = (bits == 16) ? sizeof(uint16_t) : sizeof(uint32_t);
+    if ((size_t)count > (size_t)(SIZE_MAX / stride)) {
         return aevk_fail(AEVK_ERR_ARG, "index count %d is too large", count);
     }
 
     AevkDevice* d = t->dev;
-    if (count > t->ibuf_capacity) {
-        VkDeviceSize need = (VkDeviceSize)count * sizeof(uint32_t);
+    int width_changed = (t->index_bits != bits);
+    if (count > t->ibuf_capacity || width_changed) {
+        VkDeviceSize need = (VkDeviceSize)count * (VkDeviceSize)stride;
         d->da.vkDeviceWaitIdle(d->device);
         if (t->ibuf_ptr) { d->da.vkUnmapMemory(d->device, t->ibuf_mem); t->ibuf_ptr = NULL; }
         if (t->ibuf)     { d->da.vkDestroyBuffer(d->device, t->ibuf, NULL); t->ibuf = VK_NULL_HANDLE; }
@@ -2486,8 +2982,9 @@ int aevk_ae_indices_reserve(void* tp, int count) {
         if (r != VK_SUCCESS) return aevk_fail(AEVK_ERR_OOM, "vkMapMemory failed (%d)", (int)r);
         t->ibuf_capacity = count;
     }
-    if (t->index_count != count) aevk_invalidate_records(t);
+    if (t->index_count != count || width_changed) aevk_invalidate_records(t);
     t->index_count = count;
+    t->index_bits = bits;
     return AEVK_OK;
 }
 
@@ -2503,7 +3000,15 @@ int aevk_ae_indices_set(void* tp, int index, int value) {
         return aevk_fail(AEVK_ERR_ARG, "index %d points past the %d uploaded vertices",
                          value, t->vertex_count);
     }
-    ((uint32_t*)t->ibuf_ptr)[index] = (uint32_t)value;
+    if (t->index_bits == 16) {
+        if (value > 65535) {
+            return aevk_fail(AEVK_ERR_ARG,
+                             "vertex index %d does not fit in a 16-bit index", value);
+        }
+        ((uint16_t*)t->ibuf_ptr)[index] = (uint16_t)value;
+    } else {
+        ((uint32_t*)t->ibuf_ptr)[index] = (uint32_t)value;
+    }
     aevk_invalidate_records(t);
     return AEVK_OK;
 }

--- a/contrib/vulkan/aether_vulkan.h
+++ b/contrib/vulkan/aether_vulkan.h
@@ -36,6 +36,7 @@ typedef struct AevkPipeline AevkPipeline;
 typedef struct AevkLayout AevkLayout;
 typedef struct AevkBindings AevkBindings;
 typedef struct AevkTexture AevkTexture;
+typedef struct AevkMaterial AevkMaterial;
 
 /* 1 when a loader AND at least one physical device are present. Cheap after
  * the first call: the probe result is cached, including the negative. */
@@ -132,8 +133,54 @@ int           aevk_bindings_texture(AevkBindings* b, int binding);
  * A texture must be uploaded before it is bound: sampling an image that was
  * never given pixels is undefined, so binding one is refused. */
 AevkTexture* aevk_texture_create(AevkDevice* dev, int width, int height);
+
+/* As above, with a mip chain and sampler choices. `mipmapped` builds a full
+ * chain on upload, so a minified texture stops aliasing; it needs the device
+ * to support linear blitting of R8G8B8A8_UNORM and is refused otherwise rather
+ * than producing an empty chain. `linear_filter` selects LINEAR over NEAREST
+ * for magnification, minification and between levels; `repeat` selects REPEAT
+ * over CLAMP_TO_EDGE. */
+AevkTexture* aevk_texture_create_ex(AevkDevice* dev, int width, int height,
+                                    int mipmapped, int linear_filter, int repeat);
+
+/* Mip levels the texture carries: 1 when it was not built mipmapped. */
+int aevk_texture_mip_levels(const AevkTexture* tex);
 void         aevk_texture_destroy(AevkTexture* tex);
 int          aevk_texture_upload(AevkTexture* tex, const void* rgba, size_t len);
+
+/* --- materials -------------------------------------------------------------- */
+
+/* A descriptor set plus the uniform buffers written into it. Several per
+ * pipeline, so one pipeline draws several objects with different textures and
+ * constants in a frame rather than needing a pipeline per material, which
+ * would duplicate the shader modules for nothing.
+ *
+ * Descriptor pools grow a block at a time, so there is no fixed ceiling on how
+ * many a scene may have. Destroy materials before the pipeline that made them:
+ * the set belongs to a pool the pipeline owns. */
+AevkMaterial* aevk_material_create(AevkPipeline* p);
+void          aevk_material_destroy(AevkMaterial* m);
+int           aevk_material_set_uniform(AevkMaterial* m, int binding,
+                                        const void* data, size_t len);
+int           aevk_material_set_texture(AevkMaterial* m, int binding, AevkTexture* tex);
+
+/* Draw or submit with a specific material. Passing NULL uses the pipeline's
+ * default, which is what `aevk_draw` and `aevk_submit` do. */
+int aevk_draw_material(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
+                       float r, float g, float b, float a);
+int aevk_submit_material(AevkTarget* t, AevkPipeline* p, AevkMaterial* mat,
+                         float r, float g, float b, float a);
+
+/* Several draws inside one frame, each with its own material. `first` and
+ * `count` address indices when the target has an index buffer and vertices
+ * otherwise. An empty batch, the default, draws all the geometry once.
+ *
+ * A material referenced by a batch must outlive the draws that use it:
+ * destroying one without resetting the batch leaves a dangling reference,
+ * the same contract Vulkan gives for a resource bound to a descriptor set. */
+int aevk_batch_reset(AevkTarget* t);
+int aevk_batch_add(AevkTarget* t, AevkMaterial* mat, int first, int count);
+int aevk_batch_count(const AevkTarget* t);
 
 /* Writes a uniform buffer, creating and binding it on first use, then
  * copying on every call. Host-coherent, so a per-frame update is a memcpy

--- a/contrib/vulkan/example_sprites.ae
+++ b/contrib/vulkan/example_sprites.ae
@@ -1,0 +1,248 @@
+// Four sprites, four textures, one pipeline, one frame.
+//
+// Each sprite gets a material: its own texture and its own tint. They are
+// queued as four draws inside a single frame, so the GPU never sees a bind
+// between them and the CPU submits once. The geometry is indexed with 16-bit
+// indices, which is what a sprite batch of any size wants, and the textures
+// carry mip chains so drawing them smaller than they are stays smooth.
+//
+// Build (from the repo root):
+//   ae build contrib/vulkan/example_sprites.ae \
+//       --extra contrib/vulkan/aether_vulkan.c -o sprites
+//
+// With no driver installed it prints a line saying so and exits 0.
+
+import std.bytes
+import std.string
+import std.fs
+import contrib.vulkan
+
+const TEX = 128        // texture side
+const SIDE = 256       // output side
+
+load_spv(path: string) -> (string, int) {
+    data, length, err = fs.read_binary(path)
+    // The error slot is owned even when it is empty, so it is freed on both
+    // paths: skipping it leaks one block per shader loaded.
+    ok = err == ""
+    string.free(err)
+    if ok == 0 { return ("", 0) }
+    return (data, length)
+}
+
+// A square sprite centred at (cx, cy) with half-width h, UVs 0..1.
+sprite_quad(t: ptr, base_vertex: int, cx: float, cy: float, h: float) {
+    f = base_vertex * 7
+    xs = [cx - h, cx + h, cx + h, cx - h]
+    ys = [cy - h, cy - h, cy + h, cy + h]
+    us = [0.0, 1.0, 1.0, 0.0]
+    vs = [0.0, 0.0, 1.0, 1.0]
+    i = 0
+    while i < 4 {
+        _ = vulkan.verts_set_float(t, f, xs[i])
+        _ = vulkan.verts_set_float(t, f + 1, ys[i])
+        _ = vulkan.verts_set_float(t, f + 2, 0.0)
+        _ = vulkan.verts_set_float(t, f + 3, 0.0)
+        _ = vulkan.verts_set_float(t, f + 4, 1.0)
+        _ = vulkan.verts_set_float(t, f + 5, us[i])
+        _ = vulkan.verts_set_float(t, f + 6, vs[i])
+        f = f + 7
+        i = i + 1
+    }
+}
+
+sprite_indices(t: ptr, slot: int) {
+    base = slot * 4
+    order = [0, 1, 2, 2, 3, 0]
+    i = 0
+    while i < 6 {
+        _ = vulkan.indices_set(t, slot * 6 + i, base + order[i])
+        i = i + 1
+    }
+}
+
+// One value per texel, 0..255, four different patterns.
+pattern(kind: int, x: int, y: int) -> int {
+    if kind == 0 {
+        // A one-texel checkerboard: the pattern mipmaps exist for.
+        if (x + y) % 2 == 0 { return 255 }
+        return 0
+    }
+    if kind == 1 {
+        return x * 255 / (TEX - 1)
+    }
+    if kind == 2 {
+        dx = x - TEX / 2
+        dy = y - TEX / 2
+        if dx * dx + dy * dy < (TEX / 3) * (TEX / 3) { return 255 }
+        return 40
+    }
+    if (x + y) % 16 < 8 { return 230 }
+    return 30
+}
+
+make_texture(dev: ptr, kind: int) -> ptr {
+    tex = vulkan.texture_create_ex(dev, TEX, TEX, 1, 1, 0)
+    if tex == null { return null }
+
+    n = TEX * TEX * 4
+    px = bytes.new(n)
+    _ = bytes.set_length(px, n)
+    y = 0
+    while y < TEX {
+        x = 0
+        while x < TEX {
+            v = pattern(kind, x, y)
+            o = (y * TEX + x) * 4
+            _ = bytes.set(px, o, v)
+            _ = bytes.set(px, o + 1, v)
+            _ = bytes.set(px, o + 2, v)
+            _ = bytes.set(px, o + 3, 255)
+            x = x + 1
+        }
+        y = y + 1
+    }
+    st = vulkan.texture_upload(tex, bytes.data(px), n)
+    bytes.free(px)
+    if st != vulkan.OK {
+        vulkan.texture_destroy(tex)
+        return null
+    }
+    return tex
+}
+
+// A tint per sprite, so the four share one grayscale-sampling shader and still
+// come out in different colours.
+tint(m: ptr, r: float, g: float, b: float) {
+    _ = vulkan.material_floats(m, 1, 4)
+    _ = vulkan.material_float(m, 1, 0, r)
+    _ = vulkan.material_float(m, 1, 1, g)
+    _ = vulkan.material_float(m, 1, 2, b)
+    _ = vulkan.material_float(m, 1, 3, 1.0)
+}
+
+main() {
+    println("=== four sprites, one frame ===")
+
+    if vulkan.available() != 1 {
+        println("no Vulkan driver: ${vulkan.last_error()}")
+        return
+    }
+    dev = vulkan.device_create()
+    if dev == null {
+        println("device_create failed: ${vulkan.last_error()}")
+        return
+    }
+    println("device: ${vulkan.device_name()}")
+
+    target = vulkan.target_create(dev, SIDE, SIDE)
+    if target == null {
+        println("target_create failed: ${vulkan.last_error()}")
+        vulkan.device_destroy(dev)
+        return
+    }
+
+    vs, vl = load_spv("contrib/vulkan/shaders/textured.vert.spv")
+    fs_, fl = load_spv("contrib/vulkan/shaders/textured.frag.spv")
+
+    lay = vulkan.layout_create()
+    _ = vulkan.layout_binding(lay, 0, 28, vulkan.PER_VERTEX)
+    _ = vulkan.layout_attr(lay, 0, 0, vulkan.FORMAT_R32G32_SFLOAT, 0)
+    _ = vulkan.layout_attr(lay, 1, 0, vulkan.FORMAT_R32G32B32_SFLOAT, 8)
+    _ = vulkan.layout_attr(lay, 2, 0, vulkan.FORMAT_R32G32_SFLOAT, 20)
+
+    binds = vulkan.bindings_create()
+    _ = vulkan.bindings_texture(binds, 0)
+    _ = vulkan.bindings_uniform(binds, 1)
+
+    pipe = vulkan.pipeline_create_ex(dev, target, vs, vl, fs_, fl, lay, 0, binds)
+    string.free(vs)
+    string.free(fs_)
+    if pipe == null {
+        println("pipeline_create failed: ${vulkan.last_error()}")
+        vulkan.bindings_destroy(binds)
+        vulkan.layout_destroy(lay)
+        vulkan.target_destroy(target)
+        vulkan.device_destroy(dev)
+        return
+    }
+
+    // Sixteen vertices, four quads. 16-bit indices: a sprite batch rarely has
+    // more than 65535 vertices, and the index buffer is half the size.
+    _ = vulkan.verts_reserve_n(target, 16, 7)
+    sprite_quad(target, 0, -0.35, -0.35, 0.28)
+    sprite_quad(target, 4,  0.35, -0.35, 0.28)
+    sprite_quad(target, 8, -0.35,  0.35, 0.28)
+    sprite_quad(target, 12, 0.35,  0.35, 0.28)
+
+    if vulkan.indices_reserve_ex(target, 24, 16) != vulkan.OK {
+        println("indices: ${vulkan.last_error()}")
+    }
+    i = 0
+    while i < 4 {
+        sprite_indices(target, i)
+        i = i + 1
+    }
+
+    // One material per sprite. This is what lets all four share the pipeline:
+    // each carries its own descriptor set, so the second draw does not
+    // overwrite what the first one is going to read.
+    mats = [null, null, null, null]
+    texs = [null, null, null, null]
+    reds = [1.0, 0.3, 0.4, 1.0]
+    greens = [0.4, 0.9, 0.6, 0.85]
+    blues = [0.35, 0.5, 1.0, 0.3]
+
+    _ = vulkan.batch_reset(target)
+    ok = 1
+    i = 0
+    while i < 4 {
+        texs[i] = make_texture(dev, i)
+        mats[i] = vulkan.material_create(pipe)
+        if texs[i] == null || mats[i] == null {
+            println("sprite ${i}: ${vulkan.last_error()}")
+            ok = 0
+        } else {
+            _ = vulkan.material_set_texture(mats[i], 0, texs[i])
+            tint(mats[i], reds[i], greens[i], blues[i])
+            _ = vulkan.batch_add(target, mats[i], i * 6, 6)
+        }
+        i = i + 1
+    }
+
+    if ok == 1 {
+        println("draws in the frame: ${vulkan.batch_count(target)}")
+        println("mip levels per texture: ${vulkan.texture_mip_levels(texs[0])}")
+
+        if vulkan.draw_material(target, pipe, null, 0.07, 0.07, 0.1, 1.0) != vulkan.OK {
+            println("draw failed: ${vulkan.last_error()}")
+        } else if vulkan.save_ppm(target, "sprites.ppm") != vulkan.OK {
+            println("save failed: ${vulkan.last_error()}")
+        } else {
+            println("wrote sprites.ppm (${SIDE}x${SIDE}, four sprites in one frame)")
+            // Each sprite centre, so the run says what it drew rather than
+            // only that it drew something.
+            // Sprite centres in pixels: NDC -0.35 and +0.35 on a 256 target.
+            xs = [83, 173, 83, 173]
+            ys = [83, 83, 173, 173]
+            i = 0
+            while i < 4 {
+                px = vulkan.pixel(target, xs[i], ys[i])
+                println("  sprite ${i}: rgb ${vulkan.red(px)},${vulkan.green(px)},${vulkan.blue(px)}")
+                i = i + 1
+            }
+        }
+    }
+
+    i = 0
+    while i < 4 {
+        vulkan.material_destroy(mats[i])
+        vulkan.texture_destroy(texs[i])
+        i = i + 1
+    }
+    vulkan.pipeline_destroy(pipe)
+    vulkan.bindings_destroy(binds)
+    vulkan.layout_destroy(lay)
+    vulkan.target_destroy(target)
+    vulkan.device_destroy(dev)
+}

--- a/contrib/vulkan/module.ae
+++ b/contrib/vulkan/module.ae
@@ -40,6 +40,8 @@
 //                             layout, push_bytes, bindings) -> ptr
 //
 //   vulkan.texture_create(dev, w, h)    -> ptr     RGBA sampled image
+//   vulkan.texture_create_ex(dev, w, h, mipmapped, linear, repeat) -> ptr
+//   vulkan.texture_mip_levels(tex)      -> int
 //   vulkan.texture_upload(tex, data, len) -> int   upload before binding
 //   vulkan.texture_destroy(tex)
 //   vulkan.set_texture(p, binding, tex) -> int
@@ -53,7 +55,20 @@
 //   vulkan.verts_reserve_n(t, count, floats_per_vertex) -> int
 //   vulkan.verts_set_float(t, float_index, value)       -> int
 //   vulkan.indices_reserve(t, count)    -> int     0 draws non-indexed
+//   vulkan.indices_reserve_ex(t, count, bits) -> int   bits is 16 or 32
 //   vulkan.indices_set(t, i, vertex)    -> int
+//
+//   vulkan.material_create(p)           -> ptr     one binding set per draw
+//   vulkan.material_destroy(m)
+//   vulkan.material_set_texture(m, binding, tex) -> int
+//   vulkan.material_set_uniform(m, binding, data, len) -> int
+//   vulkan.material_floats(m, binding, count)    -> int
+//   vulkan.material_float(m, binding, i, v)      -> int
+//   vulkan.batch_reset(t)               -> int     back to one draw
+//   vulkan.batch_add(t, m, first, count) -> int    a draw inside the frame
+//   vulkan.batch_count(t)               -> int
+//   vulkan.draw_material(t, p, m, r, g, b, a)    -> int
+//   vulkan.submit_material(t, p, m, r, g, b, a)  -> int
 //   vulkan.pixel(t, x, y)               -> int     0xRRGGBBAA, -1 outside
 //   vulkan.copy_rgba(t, dest, dest_len) -> int     status
 //   vulkan.save_ppm(t, path)            -> int     status
@@ -106,14 +121,26 @@ exports (
     aevk_ae_push_floats, aevk_ae_push_float,
     aevk_ae_uniform_floats, aevk_ae_uniform_float,
     aevk_ae_verts_reserve_n, aevk_ae_verts_set_float,
-    aevk_ae_indices_reserve, aevk_ae_indices_set,
+    aevk_ae_indices_reserve, aevk_ae_indices_reserve_ex, aevk_ae_indices_set,
+    aevk_ae_texture_create_ex, aevk_ae_texture_mip_levels,
+    aevk_ae_material_create, aevk_ae_material_destroy,
+    aevk_ae_material_set_texture, aevk_ae_material_set_uniform,
+    aevk_ae_material_floats, aevk_ae_material_float,
+    aevk_ae_draw_material, aevk_ae_submit_material,
+    aevk_ae_batch_reset, aevk_ae_batch_add, aevk_ae_batch_count,
     pipeline_create_ex,
     layout_create, layout_destroy, layout_binding, layout_attr,
     bindings_create, bindings_destroy, bindings_uniform, bindings_texture,
     texture_create, texture_destroy, texture_upload,
     set_uniform, set_texture, set_push,
     push_floats, push_float, uniform_floats, uniform_float,
-    verts_reserve_n, verts_set_float, indices_reserve, indices_set,
+    verts_reserve_n, verts_set_float, indices_reserve, indices_reserve_ex,
+    indices_set,
+    texture_create_ex, texture_mip_levels,
+    material_create, material_destroy, material_set_texture,
+    material_set_uniform, material_floats, material_float,
+    draw_material, submit_material,
+    batch_reset, batch_add, batch_count,
     FORMAT_R32_SFLOAT, FORMAT_R32G32_SFLOAT,
     FORMAT_R32G32B32_SFLOAT, FORMAT_R32G32B32A32_SFLOAT,
     FORMAT_R8G8B8A8_UNORM,
@@ -160,6 +187,9 @@ extern aevk_ae_bindings_uniform(b: ptr, binding: int) -> int
 extern aevk_ae_bindings_texture(b: ptr, binding: int) -> int
 
 extern aevk_ae_texture_create(dev: ptr, w: int, h: int) -> ptr
+extern aevk_ae_texture_create_ex(dev: ptr, w: int, h: int, mipmapped: int,
+                                 linear_filter: int, repeat: int) -> ptr
+extern aevk_ae_texture_mip_levels(tex: ptr) -> int
 extern aevk_ae_texture_destroy(tex: ptr)
 extern aevk_ae_texture_upload(tex: ptr, rgba: ptr, len: int) -> int
 
@@ -174,7 +204,22 @@ extern aevk_ae_uniform_float(p: ptr, binding: int, index: int, value: float) -> 
 extern aevk_ae_verts_reserve_n(t: ptr, count: int, floats_per_vertex: int) -> int
 extern aevk_ae_verts_set_float(t: ptr, float_index: int, value: float) -> int
 extern aevk_ae_indices_reserve(t: ptr, count: int) -> int
+extern aevk_ae_indices_reserve_ex(t: ptr, count: int, bits: int) -> int
 extern aevk_ae_indices_set(t: ptr, index: int, value: int) -> int
+
+extern aevk_ae_material_create(p: ptr) -> ptr
+extern aevk_ae_material_destroy(m: ptr)
+extern aevk_ae_material_set_texture(m: ptr, binding: int, tex: ptr) -> int
+extern aevk_ae_material_set_uniform(m: ptr, binding: int, data: ptr, len: int) -> int
+extern aevk_ae_material_floats(m: ptr, binding: int, count: int) -> int
+extern aevk_ae_material_float(m: ptr, binding: int, index: int, value: float) -> int
+extern aevk_ae_batch_reset(t: ptr) -> int
+extern aevk_ae_batch_add(t: ptr, m: ptr, first: int, count: int) -> int
+extern aevk_ae_batch_count(t: ptr) -> int
+extern aevk_ae_draw_material(t: ptr, p: ptr, m: ptr,
+                             r: float, g: float, b: float, a: float) -> int
+extern aevk_ae_submit_material(t: ptr, p: ptr, m: ptr,
+                               r: float, g: float, b: float, a: float) -> int
 
 extern aevk_ae_verts_reserve(t: ptr, count: int) -> int
 extern aevk_ae_verts_set(t: ptr, index: int, x: float, y: float,
@@ -307,6 +352,19 @@ pipeline_create_ex(dev: ptr, t: ptr, vert_spv: string, vert_len: int,
 // An RGBA texture. Upload before binding: an image with no pixels has no
 // defined contents to sample, so binding one is refused rather than drawn.
 texture_create(dev: ptr, w: int, h: int) -> ptr { return aevk_ae_texture_create(dev, w, h) }
+// As above with a mip chain and sampler choices. A mipmapped texture stops
+// aliasing when it is drawn smaller than it is; `linear` filters instead of
+// picking the nearest texel, and `repeat` wraps instead of clamping at the
+// edge. Mipmaps need the device to support linear blitting, and creation
+// fails rather than returning a texture with an empty chain when it does not.
+texture_create_ex(dev: ptr, w: int, h: int, mipmapped: int,
+                  linear: int, repeat: int) -> ptr {
+    return aevk_ae_texture_create_ex(dev, w, h, mipmapped, linear, repeat)
+}
+
+// Levels in the chain: 1 for a texture created without mipmaps.
+texture_mip_levels(tex: ptr) -> int { return aevk_ae_texture_mip_levels(tex) }
+
 texture_destroy(tex: ptr) { aevk_ae_texture_destroy(tex) }
 texture_upload(tex: ptr, rgba: ptr, len: int) -> int {
     return aevk_ae_texture_upload(tex, rgba, len)
@@ -346,6 +404,56 @@ verts_set_float(t: ptr, float_index: int, value: float) -> int {
 // 32-bit indices. Reserving 0 goes back to non-indexed drawing.
 indices_reserve(t: ptr, count: int) -> int { return aevk_ae_indices_reserve(t, count) }
 indices_set(t: ptr, index: int, value: int) -> int { return aevk_ae_indices_set(t, index, value) }
+
+// 16-bit indices halve the index buffer for meshes under 65536 vertices,
+// which is most of them. `bits` is 16 or 32; a value that will not fit in the
+// chosen width is refused at indices_set rather than wrapping silently.
+indices_reserve_ex(t: ptr, count: int, bits: int) -> int {
+    return aevk_ae_indices_reserve_ex(t, count, bits)
+}
+
+// A material is one set of bound resources: draw two quads with different
+// textures in a single frame by making two materials from one pipeline,
+// instead of rebinding between draws and having the second overwrite the
+// first. The pipeline's own set_texture / uniform_float keep working; they
+// address its default material.
+material_create(p: ptr) -> ptr { return aevk_ae_material_create(p) }
+material_destroy(m: ptr) { aevk_ae_material_destroy(m) }
+material_set_texture(m: ptr, binding: int, tex: ptr) -> int {
+    return aevk_ae_material_set_texture(m, binding, tex)
+}
+material_set_uniform(m: ptr, binding: int, data: ptr, len: int) -> int {
+    return aevk_ae_material_set_uniform(m, binding, data, len)
+}
+material_floats(m: ptr, binding: int, count: int) -> int {
+    return aevk_ae_material_floats(m, binding, count)
+}
+material_float(m: ptr, binding: int, index: int, value: float) -> int {
+    return aevk_ae_material_float(m, binding, index, value)
+}
+
+// A batch is several draws inside one frame, each with its own material:
+// two quads with different textures without rebinding between them. Each
+// entry slices the geometry already uploaded, by index when the target has
+// an index buffer and by vertex otherwise. An empty batch, the default,
+// draws everything once.
+//
+// A material a batch refers to has to outlive the draws that use it: destroy
+// one without resetting the batch and the next frame reads freed memory.
+batch_reset(t: ptr) -> int { return aevk_ae_batch_reset(t) }
+batch_add(t: ptr, m: ptr, first: int, count: int) -> int {
+    return aevk_ae_batch_add(t, m, first, count)
+}
+batch_count(t: ptr) -> int { return aevk_ae_batch_count(t) }
+
+// draw_material blocks like draw; submit_material pipelines like submit.
+// Passing a null material uses the pipeline's default one.
+draw_material(t: ptr, p: ptr, m: ptr, r: float, g: float, b: float, a: float) -> int {
+    return aevk_ae_draw_material(t, p, m, r, g, b, a)
+}
+submit_material(t: ptr, p: ptr, m: ptr, r: float, g: float, b: float, a: float) -> int {
+    return aevk_ae_submit_material(t, p, m, r, g, b, a)
+}
 
 // Channel accessors for the packed value pixel() returns.
 red(px: int) -> int { return (px >> 24) & 255 }

--- a/contrib/vulkan/test_vulkan_materials.ae
+++ b/contrib/vulkan/test_vulkan_materials.ae
@@ -1,0 +1,437 @@
+// contrib.vulkan materials, draw batching, 16-bit indices and mipmaps (#1540).
+//
+// Phase 2 gave a pipeline one descriptor set, so a frame could use exactly one
+// texture: binding a second overwrote the first. Phase 3 gives each draw its
+// own set (a material) and lets a frame hold several draws, which is the point
+// of having them.
+//
+// Every check reads pixels back. "The call returned OK" would pass against a
+// shader that ignored the bindings entirely, which is the failure these
+// features actually have.
+//
+// Runs anywhere: with no driver it prints SKIP and exits 0.
+
+import std.bytes
+import std.string
+import std.fs
+import contrib.vulkan
+
+extern exit(code: int)
+
+check(cond: int, label: string) -> int {
+    if cond == 1 {
+        println("  PASS ${label}")
+        return 0
+    }
+    println("  FAIL ${label}")
+    return 1
+}
+
+check_eq(got: int, want: int, label: string) -> int {
+    if got == want {
+        println("  PASS ${label} (${got})")
+        return 0
+    }
+    println("  FAIL ${label}: got ${got}, want ${want}")
+    return 1
+}
+
+load_spv(path: string) -> (string, int) {
+    data, length, err = fs.read_binary(path)
+    // The error slot is owned even when it is empty, so it is freed on both
+    // paths: skipping it leaks one block per shader loaded.
+    ok = err == ""
+    string.free(err)
+    if ok == 0 { return ("", 0) }
+    return (data, length)
+}
+
+// A 1x1 opaque texture of one colour, which is enough to tell two materials
+// apart by the pixels they produce.
+solid_texture(dev: ptr, r: int, g: int, b: int) -> ptr {
+    tex = vulkan.texture_create(dev, 1, 1)
+    if tex == null { return null }
+    px = bytes.new(4)
+    _ = bytes.set_length(px, 4)
+    _ = bytes.set(px, 0, r)
+    _ = bytes.set(px, 1, g)
+    _ = bytes.set(px, 2, b)
+    _ = bytes.set(px, 3, 255)
+    st = vulkan.texture_upload(tex, bytes.data(px), 4)
+    bytes.free(px)
+    if st != vulkan.OK {
+        vulkan.texture_destroy(tex)
+        return null
+    }
+    return tex
+}
+
+// A tint of 1,1,1,1: the sampled texel passes through unchanged, so a wrong
+// pixel means a wrong texture rather than a wrong multiply.
+white_tint(m: ptr) -> int {
+    st = vulkan.material_floats(m, 1, 4)
+    if st != vulkan.OK { return st }
+    i = 0
+    while i < 4 {
+        _ = vulkan.material_float(m, 1, i, 1.0)
+        i = i + 1
+    }
+    return vulkan.OK
+}
+
+// One quad of the seven-float layout (x, y, nx, ny, nz, u, v), spanning
+// x0..x1 horizontally and the full height, with UVs covering the texture.
+write_quad(t: ptr, base_vertex: int, x0: float, x1: float) {
+    f = base_vertex * 7
+    xs = [x0, x1, x1, x0]
+    ys = [-1.0, -1.0, 1.0, 1.0]
+    us = [0.0, 1.0, 1.0, 0.0]
+    vs = [0.0, 0.0, 1.0, 1.0]
+    i = 0
+    while i < 4 {
+        _ = vulkan.verts_set_float(t, f, xs[i])
+        _ = vulkan.verts_set_float(t, f + 1, ys[i])
+        _ = vulkan.verts_set_float(t, f + 2, 0.0)
+        _ = vulkan.verts_set_float(t, f + 3, 0.0)
+        _ = vulkan.verts_set_float(t, f + 4, 1.0)
+        _ = vulkan.verts_set_float(t, f + 5, us[i])
+        _ = vulkan.verts_set_float(t, f + 6, vs[i])
+        f = f + 7
+        i = i + 1
+    }
+}
+
+// A square quad centred on the origin, half-width `h`, UVs 0..1. Small `h`
+// with a large texture is minification, which is what mipmaps are for.
+write_centred_quad(t: ptr, h: float) {
+    write_quad(t, 0, -h, h)
+    // write_quad spans the full height; squash it to the same half-width.
+    _ = vulkan.verts_set_float(t, 1, -h)
+    _ = vulkan.verts_set_float(t, 8, -h)
+    _ = vulkan.verts_set_float(t, 15, h)
+    _ = vulkan.verts_set_float(t, 22, h)
+}
+
+// Two triangles per quad, wound counter-clockwise.
+write_quad_indices(t: ptr, slot: int, base_vertex: int) {
+    order = [0, 1, 2, 2, 3, 0]
+    i = 0
+    while i < 6 {
+        _ = vulkan.indices_set(t, slot * 6 + i, base_vertex + order[i])
+        i = i + 1
+    }
+}
+
+main() {
+    println("=== contrib.vulkan materials ===")
+    failures = 0
+
+    if vulkan.available() != 1 {
+        println("SKIP: no Vulkan driver (${vulkan.last_error()})")
+        return
+    }
+    dev = vulkan.device_create()
+    if dev == null {
+        println("SKIP: device_create failed (${vulkan.last_error()})")
+        return
+    }
+    target = vulkan.target_create(dev, 64, 64)
+    if target == null {
+        println("FAIL: target_create (${vulkan.last_error()})")
+        vulkan.device_destroy(dev)
+        exit(1)
+    }
+
+    xvs, xvl = load_spv("contrib/vulkan/shaders/textured.vert.spv")
+    xfs, xfl = load_spv("contrib/vulkan/shaders/textured.frag.spv")
+    failures = failures + check(xvl > 0 && xfl > 0, "textured SPIR-V loaded")
+    if xvl == 0 || xfl == 0 {
+        vulkan.target_destroy(target)
+        vulkan.device_destroy(dev)
+        println("1 FAILURE(S)")
+        exit(1)
+    }
+
+    lay = vulkan.layout_create()
+    _ = vulkan.layout_binding(lay, 0, 28, vulkan.PER_VERTEX)
+    _ = vulkan.layout_attr(lay, 0, 0, vulkan.FORMAT_R32G32_SFLOAT, 0)
+    _ = vulkan.layout_attr(lay, 1, 0, vulkan.FORMAT_R32G32B32_SFLOAT, 8)
+    _ = vulkan.layout_attr(lay, 2, 0, vulkan.FORMAT_R32G32_SFLOAT, 20)
+
+    binds = vulkan.bindings_create()
+    _ = vulkan.bindings_texture(binds, 0)
+    _ = vulkan.bindings_uniform(binds, 1)
+
+    pipe = vulkan.pipeline_create_ex(dev, target, xvs, xvl, xfs, xfl, lay, 0, binds)
+    string.free(xvs)
+    string.free(xfs)
+    failures = failures + check(pipe != null, "pipeline created")
+    if pipe == null {
+        println("  ${vulkan.last_error()}")
+        vulkan.bindings_destroy(binds)
+        vulkan.layout_destroy(lay)
+        vulkan.target_destroy(target)
+        vulkan.device_destroy(dev)
+        println("1 FAILURE(S)")
+        exit(1)
+    }
+
+    // ---- two textures in one frame, from one pipeline -------------------
+    // Left quad and right quad, eight vertices, twelve indices. Each half is
+    // drawn with its own material. With one set per pipeline, as phase 2 had,
+    // the second binding would overwrite the first and both halves would come
+    // out the same colour.
+    _ = vulkan.verts_reserve_n(target, 8, 7)
+    write_quad(target, 0, -1.0, 0.0)
+    write_quad(target, 4, 0.0, 1.0)
+    _ = vulkan.indices_reserve(target, 12)
+    write_quad_indices(target, 0, 0)
+    write_quad_indices(target, 1, 4)
+
+    tex_red = solid_texture(dev, 255, 0, 0)
+    tex_blue = solid_texture(dev, 0, 0, 255)
+    failures = failures + check(tex_red != null && tex_blue != null, "two textures uploaded")
+
+    mat_red = vulkan.material_create(pipe)
+    mat_blue = vulkan.material_create(pipe)
+    failures = failures + check(mat_red != null && mat_blue != null, "two materials created")
+    if mat_red == null || mat_blue == null { println("  ${vulkan.last_error()}") }
+
+    failures = failures + check_eq(vulkan.material_set_texture(mat_red, 0, tex_red),
+                                   vulkan.OK, "red texture bound to its own material")
+    failures = failures + check_eq(vulkan.material_set_texture(mat_blue, 0, tex_blue),
+                                   vulkan.OK, "blue texture bound to its own material")
+    failures = failures + check_eq(white_tint(mat_red), vulkan.OK, "material uniform written")
+    _ = white_tint(mat_blue)
+
+    failures = failures + check_eq(vulkan.batch_count(target), 0, "a target starts unbatched")
+    failures = failures + check_eq(vulkan.batch_add(target, mat_red, 0, 6), vulkan.OK,
+                                   "first draw added")
+    failures = failures + check_eq(vulkan.batch_add(target, mat_blue, 6, 6), vulkan.OK,
+                                   "second draw added")
+    failures = failures + check_eq(vulkan.batch_count(target), 2, "the batch holds two draws")
+
+    failures = failures + check_eq(vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0),
+                                   vulkan.OK, "batched frame drawn")
+    left = vulkan.pixel(target, 16, 32)
+    right = vulkan.pixel(target, 48, 32)
+    failures = failures + check(vulkan.red(left) > 200 && vulkan.blue(left) < 60,
+                                "left quad sampled the red material")
+    failures = failures + check(vulkan.blue(right) > 200 && vulkan.red(right) < 60,
+                                "right quad sampled the blue material")
+
+    // Uniforms are per material too, and are read when the GPU runs the frame
+    // rather than when it was recorded: dimming one must not touch the other,
+    // and must take effect without any geometry change to force a re-record.
+    i = 0
+    while i < 3 {
+        _ = vulkan.material_float(mat_blue, 1, i, 0.25)
+        i = i + 1
+    }
+    _ = vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0)
+    dim = vulkan.blue(vulkan.pixel(target, 48, 32))
+    still_red = vulkan.red(vulkan.pixel(target, 16, 32))
+    failures = failures + check(dim > 20 && dim < 120, "one material's uniform dims only its draw")
+    failures = failures + check(still_red > 200, "the other material is untouched")
+    _ = white_tint(mat_blue)
+
+    // ---- batch validation ------------------------------------------------
+    failures = failures + check(vulkan.batch_add(target, mat_red, 6, 12) != vulkan.OK,
+                                "a draw past the uploaded indices is refused")
+    failures = failures + check(vulkan.batch_add(target, mat_red, 0, 0) != vulkan.OK,
+                                "an empty draw is refused")
+    failures = failures + check(vulkan.batch_add(target, mat_red, -1, 6) != vulkan.OK,
+                                "a negative offset is refused")
+
+    // Geometry can shrink after a batch was built, so the range is checked
+    // again for the frame it is actually drawn in.
+    _ = vulkan.indices_reserve(target, 6)
+    write_quad_indices(target, 0, 0)
+    failures = failures + check(vulkan.draw_material(target, pipe, null,
+                                                     0.0, 0.0, 0.0, 1.0) != vulkan.OK,
+                                "a batch outliving its geometry is refused at draw")
+    _ = vulkan.indices_reserve(target, 12)
+    write_quad_indices(target, 0, 0)
+    write_quad_indices(target, 1, 4)
+
+    failures = failures + check_eq(vulkan.batch_reset(target), vulkan.OK, "batch reset")
+    failures = failures + check_eq(vulkan.batch_count(target), 0, "reset empties the batch")
+
+    // Unbatched, the whole index buffer is one draw with one material, which
+    // is what every caller from phase 2 has.
+    _ = vulkan.draw_material(target, pipe, mat_red, 0.0, 0.0, 0.0, 1.0)
+    whole_left = vulkan.pixel(target, 16, 32)
+    whole_right = vulkan.pixel(target, 48, 32)
+    failures = failures + check(vulkan.red(whole_left) > 200 && vulkan.red(whole_right) > 200,
+                                "an empty batch draws all the geometry once")
+
+    // ---- 16-bit indices --------------------------------------------------
+    // Same geometry, same materials, half the index buffer. The frames must be
+    // identical byte for byte: a wrong index width shows as garbage geometry.
+    need = vulkan.rgba_size(target)
+    wide = bytes.new(need)
+    _ = bytes.set_length(wide, need)
+    narrow = bytes.new(need)
+    _ = bytes.set_length(narrow, need)
+
+    _ = vulkan.batch_add(target, mat_red, 0, 6)
+    _ = vulkan.batch_add(target, mat_blue, 6, 6)
+    _ = vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0)
+    failures = failures + check_eq(vulkan.copy_rgba(target, bytes.data(wide), need),
+                                   vulkan.OK, "32-bit indexed frame captured")
+
+    failures = failures + check_eq(vulkan.indices_reserve_ex(target, 12, 16), vulkan.OK,
+                                   "16-bit index buffer reserved")
+    write_quad_indices(target, 0, 0)
+    write_quad_indices(target, 1, 4)
+    _ = vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0)
+    failures = failures + check_eq(vulkan.copy_rgba(target, bytes.data(narrow), need),
+                                   vulkan.OK, "16-bit indexed frame captured")
+
+    same = 1
+    i = 0
+    while i < need {
+        if bytes.get(wide, i) != bytes.get(narrow, i) { same = 0 }
+        i = i + 1
+    }
+    failures = failures + check(same, "16-bit indices render identically to 32-bit")
+    bytes.free(wide)
+    bytes.free(narrow)
+
+    failures = failures + check(vulkan.indices_reserve_ex(target, 12, 8) != vulkan.OK,
+                                "an index width other than 16 or 32 is refused")
+    failures = failures + check(vulkan.indices_set(target, 0, 99) != vulkan.OK,
+                                "an index past the vertex count is still refused")
+    write_quad_indices(target, 0, 0)
+
+    // ---- mipmaps ---------------------------------------------------------
+    // A 128x128 checkerboard of single texels drawn into 16 pixels: eight
+    // times minification. Point-sampling that picks one texel per pixel and
+    // the quad comes out of pure black and white texels; a mip chain averages
+    // it towards the texture's mean, which is mid-grey.
+    _ = vulkan.batch_reset(target)
+    _ = vulkan.verts_reserve_n(target, 4, 7)
+    write_centred_quad(target, 0.125)
+    _ = vulkan.indices_reserve(target, 6)
+    write_quad_indices(target, 0, 0)
+
+    side = 128
+    tex_mip = vulkan.texture_create_ex(dev, side, side, 1, 1, 0)
+    tex_flat = vulkan.texture_create_ex(dev, side, side, 0, 0, 0)
+    failures = failures + check(tex_mip != null && tex_flat != null, "both textures created")
+    if tex_mip == null { println("  ${vulkan.last_error()}") }
+
+    failures = failures + check_eq(vulkan.texture_mip_levels(tex_mip), 8,
+                                   "a 128x128 mipmapped texture has eight levels")
+    failures = failures + check_eq(vulkan.texture_mip_levels(tex_flat), 1,
+                                   "without mipmaps there is one level")
+
+    board = bytes.new(side * side * 4)
+    _ = bytes.set_length(board, side * side * 4)
+    y = 0
+    while y < side {
+        x = 0
+        while x < side {
+            v = 0
+            if (x + y) % 2 == 0 { v = 255 }
+            o = (y * side + x) * 4
+            _ = bytes.set(board, o, v)
+            _ = bytes.set(board, o + 1, v)
+            _ = bytes.set(board, o + 2, v)
+            _ = bytes.set(board, o + 3, 255)
+            x = x + 1
+        }
+        y = y + 1
+    }
+    failures = failures + check_eq(vulkan.texture_upload(tex_mip, bytes.data(board),
+                                                         side * side * 4),
+                                   vulkan.OK, "checkerboard uploaded with a mip chain")
+    _ = vulkan.texture_upload(tex_flat, bytes.data(board), side * side * 4)
+    bytes.free(board)
+
+    mat_mip = vulkan.material_create(pipe)
+    mat_flat = vulkan.material_create(pipe)
+    _ = vulkan.material_set_texture(mat_mip, 0, tex_mip)
+    _ = vulkan.material_set_texture(mat_flat, 0, tex_flat)
+    _ = white_tint(mat_mip)
+    _ = white_tint(mat_flat)
+
+    _ = vulkan.draw_material(target, pipe, mat_flat, 0.0, 0.0, 0.0, 1.0)
+    flat_extreme = 1
+    flat_sum = 0
+    n = 0
+    py = 29
+    while py < 36 {
+        px_ = 29
+        while px_ < 36 {
+            g = vulkan.green(vulkan.pixel(target, px_, py))
+            if g > 30 && g < 225 { flat_extreme = 0 }
+            flat_sum = flat_sum + g
+            n = n + 1
+            px_ = px_ + 1
+        }
+        py = py + 1
+    }
+
+    _ = vulkan.draw_material(target, pipe, mat_mip, 0.0, 0.0, 0.0, 1.0)
+    mip_mid = 1
+    mip_sum = 0
+    py = 29
+    while py < 36 {
+        px_ = 29
+        while px_ < 36 {
+            g = vulkan.green(vulkan.pixel(target, px_, py))
+            if g < 90 || g > 165 { mip_mid = 0 }
+            mip_sum = mip_sum + g
+            px_ = px_ + 1
+        }
+        py = py + 1
+    }
+
+    failures = failures + check(flat_extreme,
+                                "minified without mipmaps: every pixel is a single texel")
+    failures = failures + check(mip_mid,
+                                "minified with mipmaps: every pixel is the averaged mean")
+    println("    (mean brightness ${flat_sum / n} without, ${mip_sum / n} with)")
+
+    // Sampler options are per texture, and a bad one is refused rather than
+    // silently ignored.
+    failures = failures + check(vulkan.texture_create_ex(dev, 0, 8, 0, 1, 1) == null,
+                                "a zero-sized texture is refused")
+    clamped = vulkan.texture_create_ex(dev, 4, 4, 0, 1, 1)
+    failures = failures + check(clamped != null, "repeat addressing accepted")
+    vulkan.texture_destroy(clamped)
+
+    // ---- error paths on the new handles -----------------------------------
+    failures = failures + check(vulkan.material_create(null) == null,
+                                "a material needs a pipeline")
+    failures = failures + check(vulkan.material_float(mat_mip, 0, 0, 1.0) != vulkan.OK,
+                                "writing a float to a binding with no buffer is refused")
+    failures = failures + check(vulkan.material_floats(null, 1, 4) != vulkan.OK,
+                                "a null material is refused")
+    failures = failures + check(vulkan.batch_add(null, mat_mip, 0, 3) != vulkan.OK,
+                                "a null target is refused")
+    vulkan.material_destroy(null)
+
+    vulkan.material_destroy(mat_mip)
+    vulkan.material_destroy(mat_flat)
+    vulkan.material_destroy(mat_red)
+    vulkan.material_destroy(mat_blue)
+    vulkan.texture_destroy(tex_mip)
+    vulkan.texture_destroy(tex_flat)
+    vulkan.texture_destroy(tex_red)
+    vulkan.texture_destroy(tex_blue)
+    vulkan.pipeline_destroy(pipe)
+    vulkan.bindings_destroy(binds)
+    vulkan.layout_destroy(lay)
+    vulkan.target_destroy(target)
+    vulkan.device_destroy(dev)
+
+    println("")
+    if failures == 0 {
+        println("All PASS")
+    } else {
+        println("${failures} FAILURE(S)")
+        exit(1)
+    }
+}


### PR DESCRIPTION
Closes #1540

## What was wrong

A pipeline owned exactly one descriptor set. A frame could therefore use exactly one texture: binding a second overwrote what the first draw was still going to read, and there is no ordering fix for that short of a queue wait between draws. Indices were always 32-bit, and textures were always a single level sampled linearly with clamped addressing.

## Materials and batching

`material_create(pipe)` gives a draw its own descriptor set plus the uniform buffers written into it. A target holds a list of draws, each naming its material:

```aether
vulkan.material_set_texture(mat_a, 0, tex_a)
vulkan.material_set_texture(mat_b, 0, tex_b)
vulkan.batch_add(target, mat_a, 0, 6)
vulkan.batch_add(target, mat_b, 6, 6)
vulkan.draw_material(target, pipe, null, 0.0, 0.0, 0.0, 1.0)
```

All the draws go inside one render pass, one command buffer, one submission. `batch_add` slices the geometry already uploaded, by index when the target has an index buffer and by vertex otherwise. The range is validated when the draw is added and again for the frame it is drawn in, since geometry can be re-uploaded in between.

Descriptor sets come from pools of 16 that the pipeline grows on demand, so a scene has no fixed ceiling, and `VK_ERROR_OUT_OF_POOL_MEMORY` is treated as "add a pool" rather than as failure. The recorded-command cache gains a batch version, so changing the draw list re-records every slot rather than the next one only; material contents are deliberately not part of that test, because a descriptor set and a host-mapped uniform buffer are read when the GPU executes, not when the command was recorded.

An empty batch is the default and draws all the geometry once, and a null material uses the pipeline's own set, so `set_texture`, `uniform_floats` and `uniform_float` and every existing caller behave exactly as before.

## 16-bit indices

`indices_reserve_ex(t, count, 16)` halves the index buffer for meshes under 65536 vertices. Changing the width reallocates and invalidates the recordings, and `indices_set` refuses a value the width cannot hold rather than wrapping it into the wrong triangle.

## Mipmaps and sampler options

`texture_create_ex(dev, w, h, mipmapped, linear, repeat)` builds the chain on upload with `vkCmdBlitImage`, level by level with a barrier per level so each level is readable before the next is written. Mipmaps need the device to advertise `SAMPLED_IMAGE_FILTER_LINEAR` for `R8G8B8A8_UNORM`; where it does not, creation fails with that reason rather than handing back a texture whose lower levels are empty.

## Proof, not status codes

`test_vulkan_materials.ae` reads pixels back for every claim:

- two quads with different textures in one frame, each half checked for its own colour, which one shared set cannot produce
- one material's uniform dimmed, and the other's pixels required to be unchanged
- the 16-bit frame compared to the 32-bit frame **byte for byte over the whole readback**, not at sample points
- the minified checkerboard required to be pure black and white texels without a chain and the averaged mean with one: mean brightness **255 without, 128 with**, on an M1 Pro
- refusals: a draw past the uploaded geometry at both add and draw time, an empty or negative range, an index width that is neither 16 nor 32, a material with no pipeline, a uniform write to a binding with no buffer, a zero-sized texture

`example_sprites.ae` draws four differently textured, differently tinted sprites in one frame with 16-bit indices and mipmapped textures, and writes a PPM. Both the test and the example are RUN by `make contrib-check`, not merely compiled, and both are 0 leaks under `leaks --atExit` with `MallocStackLogging`.

All 15 contrib entries pass locally. Docs are in `contrib/vulkan/README.md` (three new sections, plus the stale "per-draw sets are not yet a thing here" line and a duplicated paragraph removed) and the module header of `contrib/vulkan/module.ae`.