### PR TITLE
fix(vulkan,ae,imports): the lavapipe crash, the cross-compile probe, toolchain identity, selective-import state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ version number before tagging the release.
   asserts `ae --version` matches the `VERSION` file, and any machine with a pin
   set was failing it for the reason above rather than for a stale build.
 
+- **A selectively imported function lost the module `var` it reads** (#1573).
+  `import std.spec (fail)` failed to typecheck with "Undefined variable
+  'spec_current_fw'": the merge filtered module-level declarations by the
+  caller's selection list, which is right for the import surface and wrong for
+  module state. A `var` (#701) is private, so it can never appear in a selection
+  list, yet every selected function that touches it carries a renamed reference
+  to it. Module cells now come along with the functions that close over them,
+  which is what whole-module import already did.
+
 - **`tools/ae.c` did not compile with clang.** `write_toml:` was followed
   directly by a declaration, which C11 does not allow (C23 relaxes it and gcc
   takes it as an extension), so `make` failed on Apple clang while CI's gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,55 @@ version number before tagging the release.
 
 ### Fixed
 
+- **contrib/vulkan bound descriptor sets that had nothing written into them,
+  and lavapipe crashed inside the driver** (#1580). Drawing with a batch and no
+  explicit material bound the pipeline's DEFAULT set, which a caller that only
+  uses per-draw materials never writes; a software rasteriser walks a set as it
+  is bound, so Mesa 22.3.6 dereferenced the unwritten image and buffer
+  descriptors on its own worker thread. Reproduced 6/6 in a Debian 12 container
+  on that exact driver, and fixed at the source: a material tracks whether any
+  descriptor has been written and nothing is bound until it has contents (the
+  redundant pre-loop bind on the batched path is gone too). All nine vulkan
+  tests and examples now pass on Mesa 22.3.6, where two of them segfaulted.
+
+- **Mipmap creation checked one of the three format features `vkCmdBlitImage`
+  requires.** It tested `SAMPLED_IMAGE_FILTER_LINEAR` (needed for a LINEAR
+  filter) but not `BLIT_SRC`/`BLIT_DST`, so on a device advertising linear
+  filtering without blit support the chain generation would have been invalid
+  API use rather than a clean refusal.
+
+- **`tests/integration/contrib_vulkan_portability` failed permanently on
+  Debian-family hosts** (#1605). It took the host's `pkg-config --cflags
+  vulkan`, which is correctly EMPTY when the headers sit in a default system
+  directory, and handed that to a MinGW cross compiler that does not search
+  `/usr/include`; the `-I/usr/include` fallback put glibc on the cross include
+  path instead. It now stages just the `vulkan/` and `vk_video/` trees into a
+  scratch directory (dereferencing symlinks, which is what a Homebrew include
+  dir is) and points the cross compiler there. Verified on Debian 12 and macOS.
+
+- **`ae --version` reported the pinned release, not the binary** (#1602). It
+  printed `~/.aether/active_version`, so a stale binary claimed whatever the pin
+  said: an operator saw `ae --version` report 0.543.0 while the `aetherc` beside
+  it, which is what performs codegen, was 0.541.0. It now reports the version
+  the binary was compiled from, its own path, and the `aetherc` it resolves with
+  that one's version, and warns when those two disagree or when a pin points
+  somewhere else. `install.sh` and `get.sh` check the installed binary reports
+  the version just installed (`ae version` exits 0 on a stale install, so it
+  proved nothing) and name the `ae` that PATH finds first when it is a
+  different file: `install.sh` defaults to `~/.aether/bin` and `get.sh` to
+  `~/.local/bin`, and neither used to mention the other.
+
+  This also makes `tests/integration/version_stamp` meaningful off CI: it
+  asserts `ae --version` matches the `VERSION` file, and any machine with a pin
+  set was failing it for the reason above rather than for a stale build.
+
+- **`tools/ae.c` did not compile with clang.** `write_toml:` was followed
+  directly by a declaration, which C11 does not allow (C23 relaxes it and gcc
+  takes it as an extension), so `make` failed on Apple clang while CI's gcc
+  stayed green. The declaration is hoisted above the label.
+
+### Fixed
+
 - **Actors are usable from inside closures (#1626).** Two codegen gaps hit
   any actor used from a closure or trailing block — e.g. a `std.spec` `it`
   block. `a ? Msg {}` lowered to nothing, because closure BODIES were

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -2435,8 +2435,19 @@ void module_merge_into_program(ASTNode* program) {
                 clone->value = strdup(prefixed);
                 insert_child_at(program, clone, insert_idx++);
             } else if (decl->type == AST_CONST_DECLARATION && decl->value) {
+                /* A module-level `var` (#701) is this node with a `global_var`
+                 * annotation, and it is module-private STATE, not part of the
+                 * import surface: the module's own functions read and write it.
+                 * A selectively imported function carries a renamed reference
+                 * to it, so the cell has to come along or that reference
+                 * dangles (#1573: `import std.spec (fail)` failed with
+                 * "Undefined variable 'spec_current_fw'"). Selection filters
+                 * the surface a caller names; it does not filter the state the
+                 * selected code closes over. */
+                int is_module_var = (decl->annotation &&
+                                     strcmp(decl->annotation, "global_var") == 0);
                 // Skip if not in selective import list
-                if (has_selection) {
+                if (has_selection && !is_module_var) {
                     int selected = 0;
                     for (int k = 0; k < child->child_count; k++) {
                         ASTNode* sel = child->children[k];

--- a/contrib/vulkan/README.md
+++ b/contrib/vulkan/README.md
@@ -131,7 +131,10 @@ Passing a null material uses the pipeline's own set, so `set_texture`,
 
 Materials cost one descriptor set each, allocated from pools of 16 that the
 pipeline grows on demand, plus one host-mapped uniform buffer per uniform
-binding written. A material a batch refers to has to outlive the draws that use
+binding written. A set is bound only once something has been written into it: a
+set straight out of the pool holds no descriptors, and a software rasteriser
+walks a set as it is bound, so binding an empty one crashed Mesa 22.3 inside
+the driver. A material a batch refers to has to outlive the draws that use
 it: destroy one without resetting the batch and the next frame reads freed
 memory, the same contract Vulkan gives for any resource bound to a set.
 
@@ -163,8 +166,9 @@ vulkan.texture_mip_levels(tex)                          // 8
 ```
 
 The chain is generated on upload with `vkCmdBlitImage`, level by level, so the
-pixels come from the same call that already staged them. Mipmaps need the
-device to advertise linear blitting for `R8G8B8A8_UNORM`; where it does not,
+pixels come from the same call that already staged them. That needs the device
+to advertise all three features the blit requires for `R8G8B8A8_UNORM`,
+`BLIT_SRC`, `BLIT_DST` and `SAMPLED_IMAGE_FILTER_LINEAR`; where it does not,
 creation fails with that reason rather than handing back a texture whose lower
 levels are empty.
 

--- a/contrib/vulkan/aether_vulkan.c
+++ b/contrib/vulkan/aether_vulkan.c
@@ -404,6 +404,12 @@ struct AevkTexture {
 struct AevkMaterial {
     AevkPipeline*   pipe;
     VkDescriptorSet set;
+    /* Descriptors actually written into `set`. A set straight out of the pool
+     * holds nothing, and binding one is what crashed lavapipe 22.3 from inside
+     * the driver: a software rasteriser walks the set as it is bound, so the
+     * unwritten image/buffer descriptors are dereferenced there and then.
+     * Nothing is bound until it has contents. */
+    int             writes;
     struct {
         VkBuffer       buf;
         VkDeviceMemory mem;
@@ -1554,14 +1560,22 @@ AevkTexture* aevk_texture_create_ex(AevkDevice* d, int width, int height,
 
     uint32_t levels = 1;
     if (mipmapped) {
-        /* Generating the chain is a chain of blits, which the driver only has
-         * to support for formats advertising SAMPLED_IMAGE_FILTER_LINEAR.
-         * Refusing beats generating a black chain nobody notices. */
+        /* Generating the chain is a chain of blits, and vkCmdBlitImage names
+         * three format features as required: BLIT_SRC on the source, BLIT_DST
+         * on the destination (the same image, different levels), and
+         * SAMPLED_IMAGE_FILTER_LINEAR on the source for VK_FILTER_LINEAR.
+         * Checking only the filter bit, as this did, left the blit itself
+         * unchecked. Refusing beats generating a black chain nobody notices. */
         VkFormatProperties fp;
         d->ia.vkGetPhysicalDeviceFormatProperties(d->phys, VK_FORMAT_R8G8B8A8_UNORM, &fp);
-        if (!(fp.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
+        const VkFormatFeatureFlags need = VK_FORMAT_FEATURE_BLIT_SRC_BIT |
+                                          VK_FORMAT_FEATURE_BLIT_DST_BIT |
+                                          VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+        if ((fp.optimalTilingFeatures & need) != need) {
             aevk_fail(AEVK_ERR_UNSUPPORTED,
-                      "device cannot linear-filter R8G8B8A8_UNORM, so it cannot build mipmaps");
+                      "device cannot linear-blit R8G8B8A8_UNORM (features 0x%x), "
+                      "so it cannot build mipmaps",
+                      (unsigned)fp.optimalTilingFeatures);
             return NULL;
         }
         levels = aevk_mip_levels_for(width, height);
@@ -2165,6 +2179,7 @@ int aevk_material_set_uniform(AevkMaterial* m, int binding,
         w.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         w.pBufferInfo = &bi;
         d->da.vkUpdateDescriptorSets(d->device, 1, &w, 0, NULL);
+        m->writes++;
     }
 
     /* Host-coherent, so the write is visible without a flush. The descriptor
@@ -2204,6 +2219,7 @@ int aevk_material_set_texture(AevkMaterial* m, int binding, AevkTexture* tex) {
     w.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     w.pImageInfo = &ii;
     d->da.vkUpdateDescriptorSets(d->device, 1, &w, 0, NULL);
+    m->writes++;
     return AEVK_OK;
 }
 /* The pipeline-level writers address its default material, so callers that
@@ -2308,7 +2324,9 @@ static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p, AevkMateri
          * default is used, which is what a caller that never asked for
          * materials has. */
         AevkMaterial* bind_mat = mat ? mat : p->def;
-        if (bind_mat && bind_mat->set) {
+        /* `writes`, not just a non-null handle: a set fresh out of the pool has
+         * no descriptors, and lavapipe walks a set as it is bound. */
+        if (t->batch_count == 0 && bind_mat && bind_mat->set && bind_mat->writes > 0) {
             d->da.vkCmdBindDescriptorSets(fr->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
                                           p->layout, 0, 1, &bind_mat->set, 0, NULL);
         }
@@ -2338,7 +2356,7 @@ static int aevk_record(AevkTarget* t, AevkFrame* fr, AevkPipeline* p, AevkMateri
             for (int i = 0; i < t->batch_count; i++) {
                 AevkDrawItem* it = &t->batch[i];
                 AevkMaterial* im = it->mat ? it->mat : bind_mat;
-                if (im && im->set) {
+                if (im && im->set && im->writes > 0) {
                     d->da.vkCmdBindDescriptorSets(fr->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
                                                   p->layout, 0, 1, &im->set, 0, NULL);
                 }

--- a/docs/bootstrap-from-source.md
+++ b/docs/bootstrap-from-source.md
@@ -203,9 +203,15 @@ sudo make install
 make contrib && sudo make install-contrib   # if you use contrib
 ```
 
-The version (`ae version`) is derived from the highest `v*.*.*` git tag,
-falling back to the `VERSION` file. After a `git pull` that introduced a
-new tag, a `make clean` ensures the stamp isn't stale.
+`ae --version` describes the binary in front of you: the version it was
+compiled from, its own path, and the `aetherc` it will actually run with that
+one's version. It says so because the two can differ, and `aetherc` is what
+performs codegen; a mismatch is printed as a warning rather than left to be
+discovered later. A pinned release (`~/.aether/active_version`, written by
+`ae version use`) is reported as a pin and never as the binary's version.
+
+The version stamp itself comes from the `VERSION` file in the tree. After a
+`git pull`, a `make clean` ensures it isn't stale.
 
 ---
 
@@ -250,9 +256,12 @@ Rules of thumb:
   `$(PREFIX)/bin` is on `PATH` (or invoke `ae` by absolute path as
   above). The default `PREFIX` is `/usr/local`.
 - A `--emit=lib` link error mentioning `recompile with -fPIC` means a
-  stale pre-0.181 `libaether.a`; rebuild from current `HEAD`. A version
-  mismatch between `ae version` and the CHANGELOG/`VERSION` usually means
-  stale git tags: `git fetch --tags` then `make clean && make ae`.
+  stale pre-0.181 `libaether.a`; rebuild from current `HEAD`.
+- If `ae --version` and the `VERSION` file disagree, the binary is stale:
+  `make clean && make ae`. If it warns that its `aetherc` is a different
+  version, two installs are mixed; `install.sh` defaults to `~/.aether/bin`
+  and `get.sh` to `~/.local/bin`, and whichever is earlier on `PATH` wins.
+  Both installers now name the shadowing binary when they see one.
 
 ---
 

--- a/get.sh
+++ b/get.sh
@@ -71,12 +71,21 @@ make -C "$src" install PREFIX="$PREFIX" CC="$CC"
 bin="$PREFIX/bin/ae"
 [ -x "$bin" ] || die "install finished but $bin is missing."
 say "installed: $bin"
-"$bin" version || true
+"$bin" --version || true
 
 case ":$PATH:" in
     *":$PREFIX/bin:"*) ;;
     *) say "note: $PREFIX/bin is not on your PATH — add it to use 'ae' directly." ;;
 esac
+
+# Which ae does the shell reach? A second install (install.sh defaults to
+# ~/.aether/bin, this one to ~/.local/bin) earlier on PATH keeps winning, and
+# nothing used to say so: that is the second half of issue #1602.
+other=$(command -v ae 2>/dev/null || true)
+if [ -n "$other" ] && [ "$other" != "$bin" ]; then
+    say "note: PATH finds a different ae first: $other"
+    say "      put $PREFIX/bin ahead of it, or remove the other install."
+fi
 
 say "optional: native contrib modules (sqlite, host_python, …) — from a"
 say "          checkout run 'make contrib && make install-contrib PREFIX=$PREFIX'"

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,47 @@ else
     INSTALL_DIR="${1:-$HOME/.aether}"
 fi
 BIN_DIR="$INSTALL_DIR/bin"
+
+# Verify the binary we just installed is the one it claims to be, and that the
+# operator's PATH actually reaches it. `ae version` succeeding proves neither:
+# it exits 0 on a stale install, and a second install earlier on PATH keeps
+# winning silently. Both were real (see issue #1602).
+verify_installed_toolchain() {
+    _vbin="$1"
+    if ! _vout="$("$_vbin" --version 2>&1)"; then
+        error "  binary at $_vbin did not respond to '--version'"
+        return 1
+    fi
+    _vgot=$(printf '%s\n' "$_vout" | sed -n 's/^ae \([0-9][0-9.]*\).*/\1/p' | head -1)
+    if [ -z "$_vgot" ]; then
+        error "  binary at $_vbin printed no parsable version:"
+        printf '%s\n' "$_vout" | sed 's/^/      /' | head -3
+        return 1
+    fi
+    # INSTALLED_VER is the VERSION file of the tree that was just built, set
+    # before the version is registered under ~/.aether/versions.
+    _vwant="${INSTALLED_VER:-}"
+    if [ -n "$_vwant" ] && [ "$_vwant" != "0.0.0-dev" ] && [ "$_vgot" != "$_vwant" ]; then
+        error "  installed $_vwant but $_vbin reports $_vgot"
+        error "  the install did not replace what was already there"
+        return 1
+    fi
+    # A mismatched aetherc is reported by `ae --version` itself; surface it.
+    if printf '%s\n' "$_vout" | grep -q "^WARNING:"; then
+        printf '%s\n' "$_vout" | sed -n '/^WARNING:/,$p' | sed 's/^/  /'
+    fi
+    ok "  $_vbin reports $_vgot"
+
+    # Which ae does the operator's PATH find? If it is a different file, say so
+    # here rather than letting them debug it later.
+    _vpath="$(command -v ae 2>/dev/null || true)"
+    if [ -n "$_vpath" ] && [ "$_vpath" != "$_vbin" ]; then
+        _vother=$("$_vpath" --version 2>/dev/null | sed -n 's/^ae \([0-9][0-9.]*\).*/\1/p' | head -1)
+        warn "  PATH finds a different ae first: $_vpath${_vother:+ ($_vother)}"
+        echo "         Put $(dirname "$_vbin") ahead of it, or remove the other install."
+    fi
+    return 0
+}
 LIB_DIR="$INSTALL_DIR/lib/aether"
 
 # Touching the user's shell rc files (`~/.zshrc`, `~/.bashrc`, etc.)
@@ -436,12 +477,7 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
         # operator's next shell sees the new binary, and that's the
         # contract `info "Verifying installation..."` implies. Do a
         # quiet probe instead.
-        if "$BIN_DIR/ae" version >/dev/null 2>&1; then
-            ok "  binary verified at $BIN_DIR/ae"
-        else
-            error "  binary at $BIN_DIR/ae did not respond to 'version'"
-            exit 1
-        fi
+        verify_installed_toolchain "$BIN_DIR/ae" || exit 1
         echo ""
         echo "========================================="
         ok "  Aether installed successfully (no shell rc touched)!"
@@ -592,13 +628,7 @@ if [ "$EDITOR_ONLY" -eq 0 ]; then
 
     # Verify
     info "Verifying installation..."
-    if "$BIN_DIR/ae" version >/dev/null 2>&1; then
-        VERSION=$("$BIN_DIR/ae" version 2>&1)
-        ok "  $VERSION"
-    else
-        error "  Verification failed"
-        exit 1
-    fi
+    verify_installed_toolchain "$BIN_DIR/ae" || exit 1
 
     echo ""
     echo "========================================="

--- a/tests/integration/contrib_vulkan_portability/test_contrib_vulkan_portability.sh
+++ b/tests/integration/contrib_vulkan_portability/test_contrib_vulkan_portability.sh
@@ -20,22 +20,48 @@ command -v "$CC_WIN" >/dev/null 2>&1 || {
     exit 0
 }
 
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
 # The Vulkan headers are header-only and platform-independent, so the host's
-# copy is what the cross compile reads.
-INC=""
-if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists vulkan 2>/dev/null; then
-    INC="$(pkg-config --cflags vulkan)"
-elif [ -f /opt/homebrew/include/vulkan/vulkan.h ]; then
-    INC="-I/opt/homebrew/include"
-elif [ -f /usr/include/vulkan/vulkan.h ]; then
-    INC="-I/usr/include"
-else
+# copy is what the cross compile reads. Two things make "just use the host's
+# include flags" wrong here:
+#
+#   - `pkg-config --cflags vulkan` is EMPTY when the headers sit in the default
+#     system include directory, which is right for a native compile and useless
+#     for a cross one: the MinGW compiler does not search /usr/include.
+#   - pointing the cross compiler at /usr/include instead puts glibc on its
+#     include path, and it fails in bits/libc-header-start.h.
+#
+# So the header trees are copied into a scratch directory that holds nothing
+# else. vk_video/ is needed as well as vulkan/: vulkan_core.h includes
+# vk_video/vulkan_video_codec_h264std.h.
+VK_INC_ROOT=""
+# pkg-config knows the header directory even when --cflags is empty (which it
+# is whenever the headers are in a default system path).
+if command -v pkg-config >/dev/null 2>&1; then
+    pc_inc="$(pkg-config --variable=includedir vulkan 2>/dev/null)"
+    [ -n "$pc_inc" ] && [ -f "$pc_inc/vulkan/vulkan.h" ] && VK_INC_ROOT="$pc_inc"
+fi
+if [ -z "$VK_INC_ROOT" ]; then
+    for d in /opt/homebrew/include /usr/local/include /usr/include; do
+        if [ -f "$d/vulkan/vulkan.h" ]; then VK_INC_ROOT="$d"; break; fi
+    done
+fi
+if [ -z "$VK_INC_ROOT" ]; then
     echo "  [SKIP] contrib_vulkan_portability: Vulkan headers not installed"
     exit 0
 fi
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# -L dereferences: a package manager may expose the include dir as a symlink
+# into its own store, and copying the link alone would stage nothing.
+mkdir -p "$TMP/inc"
+if ! cp -RL "$VK_INC_ROOT/vulkan" "$TMP/inc/" 2>/dev/null; then
+    echo "  [SKIP] contrib_vulkan_portability: cannot stage $VK_INC_ROOT/vulkan"
+    exit 0
+fi
+[ -d "$VK_INC_ROOT/vk_video" ] && cp -RL "$VK_INC_ROOT/vk_video" "$TMP/inc/" 2>/dev/null
+INC="-I$TMP/inc"
 
 if ! $CC_WIN -std=c99 -O2 -Wall -Wextra -Werror $INC -Icontrib/vulkan \
         -c "$SRC" -o "$TMP/win.o" 2>"$TMP/err"; then

--- a/tests/integration/selective_import_module_var/lib/ambient.ae
+++ b/tests/integration/selective_import_module_var/lib/ambient.ae
@@ -1,0 +1,14 @@
+// A module whose exported functions close over a module-level `var` (#701):
+// the shape std.spec uses (an ambient cell set by init(), read by every
+// assertion). The cell itself is private — it is not in `exports`, and a
+// caller has no name for it.
+exports(init, bump, current)
+
+var cur = 0
+
+init(v: int) { cur = v }
+bump() -> int {
+    cur = cur + 1
+    return cur
+}
+current() -> int { return cur }

--- a/tests/integration/selective_import_module_var/main.ae
+++ b/tests/integration/selective_import_module_var/main.ae
@@ -1,0 +1,12 @@
+// Selective import of functions that read and write their module's private
+// `var`. The merge used to pull the functions and leave the cell behind, so
+// the renamed reference dangled and typechecking failed with
+// "Undefined variable 'ambient_cur'" (#1573).
+import ambient(init, bump, current)
+
+main() {
+    init(10)
+    println("${bump()}") // 11
+    println("${bump()}") // 12
+    println("${current()}") // 12 — the same cell, not a per-call local
+}

--- a/tests/integration/selective_import_module_var/test_selective_import_module_var.sh
+++ b/tests/integration/selective_import_module_var/test_selective_import_module_var.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Issue #1573: `import mod (fn)` where `fn` reads its module's private `var`.
+#
+# The selective-import merge filtered module-level declarations by the caller's
+# selection list, which is right for the import SURFACE (functions, consts) and
+# wrong for module STATE: a `var` (#701) is private, so it can never appear in a
+# selection list, yet every selected function that touches it carries a renamed
+# reference to it. The cell was left behind and typechecking failed with
+# "Undefined variable '<ns>_<var>'". Whole-module import was the workaround.
+#
+# Acceptance: main.ae prints 11, 12, 12 — the writes reach one shared cell
+# across three separately-merged functions.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+[ -x "$AE" ] || { echo "  [SKIP] selective_import_module_var: $AE not built"; exit 0; }
+
+out=$( cd "$SCRIPT_DIR" && AETHER_HOME="" "$AE" run main.ae 2>&1 )
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    echo "  [FAIL] selective_import_module_var: program errored (rc=$rc)"
+    printf '%s\n' "$out" | head -12 | sed 's/^/          /'
+    exit 1
+fi
+
+got=$(printf '%s\n' "$out" | grep -v '^[[:space:]]*$' | tr '\n' ' ' | sed 's/ *$//')
+want="11 12 12"
+if [ "$got" != "$want" ]; then
+    echo "  [FAIL] selective_import_module_var: got '$got', want '$want'"
+    exit 1
+fi
+
+echo "  [PASS] selective_import_module_var: the private cell came along and is shared"
+exit 0

--- a/tests/integration/version_identity/test_version_identity.sh
+++ b/tests/integration/version_identity/test_version_identity.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# `ae --version` must describe THIS binary, not a pin, and must name the aetherc
+# it would actually run. Both halves were wrong (#1602): a stale binary reported
+# whatever ~/.aether/active_version claimed, and an `ae` beside an `aetherc`
+# from another install said nothing about the mismatch that decides codegen.
+set -u
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+AE="$ROOT/build/ae${EXE_EXT:-}"
+[ -x "$AE" ] || { echo "  [SKIP] version_identity: $AE not built"; exit 0; }
+[ -f "$ROOT/VERSION" ] || { echo "  [SKIP] version_identity: no VERSION file"; exit 0; }
+
+want="$(tr -d '[:space:]' < "$ROOT/VERSION")"
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  [PASS] $1"; pass=$((pass+1)); else
+    echo "  [FAIL] $1: got '$2', want '$3'"; fail=$((fail+1)); fi; }
+
+out="$("$AE" --version 2>&1)"
+got="$(printf '%s\n' "$out" | sed -n 's/^ae \([0-9][0-9.]*\).*/\1/p' | head -1)"
+check "reports the version it was built from" "$got" "$want"
+
+# The binary's own path, so an operator can tell two installs apart.
+case "$out" in *"Binary:"*) echo "  [PASS] names its own path"; pass=$((pass+1));;
+    *) echo "  [FAIL] no Binary: line"; fail=$((fail+1));; esac
+
+# The compiler that does the codegen, with its version.
+case "$out" in *"aetherc:"*) echo "  [PASS] names the aetherc it would run"; pass=$((pass+1));;
+    *) echo "  [FAIL] no aetherc: line"; fail=$((fail+1));; esac
+
+# A pin that disagrees is reported as a pin, not as the version.
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+HOME="$tmp" ; export HOME
+mkdir -p "$tmp/.aether"
+echo "0.0.1" > "$tmp/.aether/active_version"
+pinned_out="$("$AE" --version 2>&1)"
+pinned_got="$(printf '%s\n' "$pinned_out" | sed -n 's/^ae \([0-9][0-9.]*\).*/\1/p' | head -1)"
+check "a pin does not change the reported version" "$pinned_got" "$want"
+case "$pinned_out" in *"pins 0.0.1"*) echo "  [PASS] the disagreeing pin is called out"; pass=$((pass+1));;
+    *) echo "  [FAIL] the pin was not reported"; fail=$((fail+1));; esac
+
+echo ""
+echo "version_identity: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/integration/version_identity/test_version_identity.sh
+++ b/tests/integration/version_identity/test_version_identity.sh
@@ -28,7 +28,8 @@ case "$out" in *"aetherc:"*) echo "  [PASS] names the aetherc it would run"; pas
 
 # A pin that disagrees is reported as a pin, not as the version.
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
-HOME="$tmp" ; export HOME
+# Both: the home directory is USERPROFILE on Windows and HOME elsewhere.
+HOME="$tmp"; USERPROFILE="$tmp"; export HOME USERPROFILE
 mkdir -p "$tmp/.aether"
 echo "0.0.1" > "$tmp/.aether/active_version"
 pinned_out="$("$AE" --version 2>&1)"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -995,7 +995,7 @@ static int walk_dirs_emit_includes(const char* root, char** out, size_t* out_siz
     return 1;
 }
 
-static void discover_toolchain(void) {
+void discover_toolchain(void) {
     char exe_dir[1024] = {0};
     bool found_exe_dir = get_exe_dir(exe_dir, sizeof(exe_dir));
 
@@ -6388,9 +6388,13 @@ static int cmd_add(int argc, char** argv) {
         }
     }
 
+    /* Declared before the label: a declaration may not directly follow one in
+     * C11 (it is a C23 relaxation that gcc takes as an extension), so
+     * `write_toml: FILE* f = ...` failed to compile on clang. */
+    FILE* f = NULL;
 write_toml:
     // Add to aether.toml
-    FILE* f = fopen("aether.toml", "r");
+    f = fopen("aether.toml", "r");
     if (!f) {
         fprintf(stderr, "Error: Could not read aether.toml\n");
         return 1;

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -46,6 +46,10 @@ typedef struct {
 } Toolchain;
 
 extern Toolchain tc;
+
+/* Resolves `tc` (root, compiler path, include flags). Exported so
+ * `ae --version` can report the aetherc it would actually run. */
+void discover_toolchain(void);
 extern char s_cache_dir[512];   /* resolved once by init_cache_dir (ae_cache.c) */
 
 /* ae.c helpers shared across TUs. */

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -930,10 +930,77 @@ int cmd_upgrade(void) {
     return cmd_version_use(latest);
 }
 
+/* The version of the aetherc this ae would actually run, or NULL when it
+ * cannot be asked. Reading it matters because aetherc is what performs the
+ * codegen: an `ae` from one install beside an `aetherc` from another is the
+ * failure #1602 describes, and nothing in the CLI used to reveal it. */
+static const char* probe_compiler_version(const char* aetherc_path) {
+    static char ver[64];
+    ver[0] = '\0';
+    if (!aetherc_path || !aetherc_path[0]) return NULL;
+
+    char cmd[2200];
+    snprintf(cmd, sizeof(cmd), "\"%s\" --version 2>/dev/null", aetherc_path);
+    FILE* pipe = popen(cmd, "r");
+    if (!pipe) return NULL;
+    char line[256];
+    if (fgets(line, sizeof(line), pipe)) {
+        /* "Aether Compiler v0.547.0" */
+        const char* v = strchr(line, 'v');
+        while (v && !(v[1] >= '0' && v[1] <= '9')) v = strchr(v + 1, 'v');
+        if (v) {
+            size_t n = 0;
+            v++;
+            while (v[n] && (v[n] == '.' || (v[n] >= '0' && v[n] <= '9')) && n + 1 < sizeof(ver)) {
+                ver[n] = v[n];
+                n++;
+            }
+            ver[n] = '\0';
+        }
+    }
+    pclose(pipe);
+    return ver[0] ? ver : NULL;
+}
+
 int cmd_version(int argc, char** argv) {
     if (argc == 0) {
-        printf("ae %s (Aether Language)\n", get_active_version());
+        /* The BINARY's own version, compiled in. Printing the pin here (what
+         * ~/.aether/active_version says) made a stale binary report whatever
+         * the pin claimed, which is the whole of #1602's first defect. */
+        printf("ae %s (Aether Language)\n", AE_VERSION);
         printf("Platform: " AE_PLATFORM "\n");
+
+        char self[2048];
+        if (get_exe_path(self, sizeof(self))) {
+            printf("Binary:   %s\n", self);
+        }
+
+        /* The compiler this ae resolves, and its version: that is the half
+         * that does the codegen. */
+        discover_toolchain();
+        if (tc.compiler[0]) {
+            const char* cver = probe_compiler_version(tc.compiler);
+            printf("aetherc:  %s%s%s%s\n", tc.compiler,
+                   cver ? " (" : "", cver ? cver : "", cver ? ")" : "");
+            if (cver && strcmp(cver, AE_VERSION) != 0) {
+                printf("\nWARNING: this ae is %s but the aetherc it would run is %s.\n",
+                       AE_VERSION, cver);
+                printf("         aetherc does the codegen, so the compiler in effect is %s.\n", cver);
+                printf("         Reinstall so both come from one build.\n");
+            }
+        } else {
+            printf("aetherc:  not found (ae cannot compile until it is installed)\n");
+        }
+
+        /* The pin, named as a pin and only when it disagrees. */
+        const char* pinned = get_active_version();
+        if (pinned && pinned[0] && strcmp(pinned, AE_VERSION) != 0) {
+            printf("\nWARNING: ~/.aether/active_version pins %s, which is not this binary.\n",
+                   pinned);
+            printf("         `ae version use %s` switches the pinned install; this\n", pinned);
+            printf("         binary keeps reporting and behaving as %s.\n", AE_VERSION);
+        }
+
         printf("\nSubcommands:\n");
         printf("  ae version list              List all available releases\n");
         printf("  ae version install <v>       Download and install a release\n");

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -939,9 +939,17 @@ static const char* probe_compiler_version(const char* aetherc_path) {
     ver[0] = '\0';
     if (!aetherc_path || !aetherc_path[0]) return NULL;
 
+    /* The null device and the pipe API are both platform-spelled: on Windows
+     * popen() goes through cmd.exe, which does not know `/dev/null` and prints
+     * "The system cannot find the path specified." onto our own output. */
     char cmd[2200];
+#ifdef _WIN32
+    snprintf(cmd, sizeof(cmd), "\"%s\" --version 2>NUL", aetherc_path);
+    FILE* pipe = _popen(cmd, "r");
+#else
     snprintf(cmd, sizeof(cmd), "\"%s\" --version 2>/dev/null", aetherc_path);
     FILE* pipe = popen(cmd, "r");
+#endif
     if (!pipe) return NULL;
     char line[256];
     if (fgets(line, sizeof(line), pipe)) {
@@ -958,7 +966,11 @@ static const char* probe_compiler_version(const char* aetherc_path) {
             ver[n] = '\0';
         }
     }
+#ifdef _WIN32
+    _pclose(pipe);
+#else
     pclose(pipe);
+#endif
     return ver[0] ? ver : NULL;
 }
 


### PR DESCRIPTION
Closes #1580
Closes #1605
Closes #1602
Closes #1573

Four reported bugs, each reproduced on the environment it was reported from before being fixed. One extra: `main` did not compile with clang.

## #1580 The lavapipe segfault was ours

Reproduced in a Debian 12 container with `mesa-vulkan-drivers 22.3.6-1+deb12u2`, the exact driver from the report: `test_vulkan_materials` died right after "binds a texture per material", 6/6 runs, all frames inside `libvulkan_lvp.so`.

The cause is not old-Mesa fragility, it is invalid use on our side. `draw_material(target, pipe, null, ...)` with a batch bound the pipeline's **default** descriptor set, and a caller that only uses per-draw materials never writes anything into it. A set straight out of the pool holds no descriptors; a software rasteriser walks a set as it is bound, so lavapipe dereferenced the unwritten combined-image-sampler and uniform-buffer descriptors on its own worker thread. Newer Mesa happens to tolerate it.

A material now tracks whether any descriptor has been written, and nothing is bound until it has contents. The redundant pre-loop bind on the batched path (every item binds its own set) is gone too.

Verified on the crashing driver, all nine entries:

```
test_vulkan.ae               PASS      test_vulkan_materials.ae     PASS
test_vulkan_resources.ae     PASS      example_triangle.ae          PASS
test_vulkan_actors.ae        PASS      example_parallel_render.ae   PASS
test_vulkan_depth_msaa.ae    PASS      example_sprites.ae           PASS
test_vulkan_frames.ae        PASS
```

While there: mipmap creation checked `SAMPLED_IMAGE_FILTER_LINEAR` but not `BLIT_SRC`/`BLIT_DST`. `vkCmdBlitImage` requires all three, so a device advertising linear filtering without blit support would have got invalid API use instead of a clean refusal. (lavapipe 22.3 does advertise all three, so this was not the crash; it is still wrong.)

## #1605 The cross-compile probe could not find headers it had found

Exactly as diagnosed in the issue. `pkg-config --cflags vulkan` is **empty** when the headers sit in a default system directory, which is right for a native compile and useless for a cross one, and `-I/usr/include` puts glibc on a MinGW include path. The test now stages `vulkan/` and `vk_video/` into a scratch directory and points the cross compiler at that, asking `pkg-config --variable=includedir` first (it knows the directory even when `--cflags` is empty). `cp -RL`, because a Homebrew include dir is a symlink into the Cellar and copying the link stages nothing.

Verified both ways: Debian 12 (`includedir=/usr/include`, `cflags=[]`) and macOS/Homebrew.

## #1602 The toolchain can now answer questions about itself

`ae --version` printed `~/.aether/active_version`, so a stale binary reported whatever the pin claimed. Reproduced immediately on my own box: a freshly built `ae` said 0.526.0 while the `aetherc` beside it was 0.547.0.

```
ae 0.547.0 (Aether Language)
Platform: macos-arm64
Binary:   /Users/…/aether/build/ae
aetherc:  /Users/…/aether/build/aetherc (0.547.0)

WARNING: ~/.aether/active_version pins 0.526.0, which is not this binary.
```

and the trap from the issue, an `ae` next to another install's `aetherc`:

```
WARNING: this ae is 0.547.0 but the aetherc it would run is 0.526.0.
         aetherc does the codegen, so the compiler in effect is 0.526.0.
```

The installers were the other half. Both now verify the installed binary reports the version just installed (`ae version` exits 0 on a stale install, so it proved nothing) and name the `ae` that PATH finds first when it is a different file: `install.sh` defaults to `~/.aether/bin`, `get.sh` to `~/.local/bin`, and neither used to mention the other.

A side effect worth stating: `tests/integration/version_stamp` asserts `ae --version` matches the `VERSION` file, and it had been failing on any machine with a pin set. I had written that off as environmental in earlier sessions; it was this bug. It passes now, and `tests/integration/version_identity` (new, 5 assertions) pins the rest of the behaviour, including that a pin does not change the reported version.

## `main` did not build with clang

`write_toml:` was followed directly by a declaration. C11 does not allow that (C23 relaxes it, gcc takes it as an extension), so `make` failed on Apple clang while CI's gcc stayed green. Hoisted above the label.

## Verification

- 390 C unit tests, 0 failures
- 956/962 `.ae` (6 environmental: gcov, a blocked bind, the sandbox killing dlopen consumers and interpreters, all reproduced on pristine main previously)
- all 15 contrib entries, `check-standalone` clean, zero build warnings
- the vulkan suite on Mesa 22.3.6 lavapipe in a container, which is what #1580 needed


---

## Added after the first CI round

**#1573 — selective import lost the module `var` its functions read.** `import std.spec (fail)` failed to typecheck with "Undefined variable 'spec_current_fw'". The merge filtered module-level declarations by the caller's selection list, which is right for the import surface and wrong for module state: a `var` (#701) is private, so it can never appear in a selection list, yet every selected function that touches it carries a renamed reference to it. Module cells now come with the functions that close over them, which is what whole-module import already did.

Proven against the unfixed compiler (rebuilt to be sure): the new fixture fails with `Undefined variable 'ambient_cur'` before and prints 11/12/12 after, so the cell is shared across three separately merged functions.

**Windows CI found two of my own mistakes**, both now fixed: the aetherc probe redirected to `/dev/null` through `cmd.exe`, which printed "The system cannot find the path specified." onto `ae`'s own stdout and broke `version_stamp`'s parse; and `version_identity` set `HOME` where Windows reads `USERPROFILE`.
