### PR TITLE
fix(codegen): a function parameter must shadow a consuming module's function (#1657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,37 @@ version number before tagging the release.
 
 ### Fixed
 
+- **A function parameter was silently replaced by a same-named function in a
+  CONSUMING module** (#1657). After module merging one program holds every
+  module's functions, including non-exported ones from the app. Codegen asked
+  "is there a top-level function with this name?" to decide whether an argument
+  was a bare function needing an env-ignoring adapter, and never checked
+  whether the name was a local binding — so a library's `btn(on_press: fn)` had
+  its PARAMETER replaced by an adapter for the app's unrelated
+  `on_press(view, x, y)`, discarding the caller's closure and its captured
+  environment with `.env = NULL`. The generated C is well-formed, the call
+  returns, and nothing happens; in aether-ui a button connected, fired, never
+  moved the model, and eventually segfaulted inside GLib on a 3-argument
+  adapter reached through a 0-argument signature.
+
+  A parameter is the innermost binding there is, so nothing outside the
+  function may be reachable under that name. The lookup now yields to an
+  enclosing parameter or declared local. Sibling of #1606, which fixed the
+  closure-parameter case in the module RENAMER; this is the CODEGEN half, a
+  separate pass with its own name resolution, and an ordinary function
+  parameter shadowed from a different module.
+
+  Worth recording for whoever touches this next: one of the three call sites
+  carried its own inlined copy of the whole-program scan rather than calling
+  the shared helper, which is exactly how the scope rule could be fixed in one
+  place and still violated in another. That site now goes through the helper.
+
+  Until this, a library's PARAMETER NAMES were effectively part of its public
+  API surface: an app choosing an ordinary name like `on_press` or `label` for
+  its own helper could break an unrelated library call, with no diagnostic
+  pointing at either file.
+
+
 - **`multicore_scheduler.c` now compiles for 32-bit targets** (#1652). The
   `Message` layout assertion was guarded by `#if INTPTR_MAX == INT64_MAX`; the
   `Mailbox` one directly below it was not, so every ILP32 triple failed to

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -55,9 +55,47 @@ static const char* arg_drain_lookup(ASTNode* node) {
 /* A bare reference to a top-level Aether function, as opposed to a closure or
  * an fn-typed variable. Its address is a real C symbol, which is the only thing
  * a C function-pointer field can hold. */
+/* Is `name` a parameter of the function currently being emitted?
+ *
+ * Parameters are AST_PATTERN_VARIABLE children of the AST_FUNCTION_DEFINITION,
+ * ahead of its BLOCK. Closures carry AST_CLOSURE_PARAM instead, so both are
+ * accepted; a closure's own parameters shadow just as a function's do. */
+static int name_is_enclosing_param(CodeGenerator* gen, const char* name) {
+    if (!gen || !gen->current_function || !name) return 0;
+    ASTNode* fn = gen->current_function;
+    for (int i = 0; i < fn->child_count; i++) {
+        ASTNode* c = fn->children[i];
+        if (!c) continue;
+        if (c->type == AST_BLOCK) break;   /* params precede the body */
+        if ((c->type == AST_PATTERN_VARIABLE || c->type == AST_CLOSURE_PARAM) &&
+            c->value && strcmp(c->value, name) == 0) return 1;
+    }
+    return 0;
+}
+
 static ASTNode* bare_top_level_fn(CodeGenerator* gen, ASTNode* node) {
     if (!gen || !gen->program || !node ||
         node->type != AST_IDENTIFIER || !node->value) return NULL;
+    /* #1657: a LOCAL BINDING WINS. This function asks "is there a top-level
+     * function with this name?", and after module merging that program
+     * contains every module's functions — including non-exported ones from a
+     * CONSUMING module. So a library function's parameter `on_press` matched
+     * an app's unrelated module-level `on_press`, and the call site emitted a
+     * bare-fn adapter for the app's function in place of the caller's
+     * closure, discarding .env with it. Silent: the C is well-formed, the
+     * call returns, and nothing happens.
+     *
+     * A parameter is the innermost binding there is, so nothing outside the
+     * function may be reachable under that name. Checking the enclosing
+     * function's own parameters is the scope rule this was missing; the
+     * declared-locals list is consulted too, so a local `on_press = ...`
+     * shadows equally.
+     *
+     * Same family as #1606, which fixed the closure-parameter case in the
+     * module renamer. This is the codegen half, and an ordinary function
+     * parameter shadowed from a DIFFERENT module, which survived that fix. */
+    if (name_is_enclosing_param(gen, node->value) ||
+        is_var_declared(gen, node->value)) return NULL;
     for (int i = 0; i < gen->program->child_count; i++) {
         ASTNode* pc = gen->program->children[i];
         if (pc && (pc->type == AST_FUNCTION_DEFINITION ||
@@ -5052,18 +5090,15 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                              * (*)(void)" — the silent type-check pass
                              * that the fn_ptr_coercion.md filing
                              * surfaced. */
-                            int arg_is_bare_fn = 0;
-                            if (arg->type == AST_IDENTIFIER && arg->value && gen->program) {
-                                for (int pi = 0; pi < gen->program->child_count; pi++) {
-                                    ASTNode* pc = gen->program->children[pi];
-                                    if (pc && (pc->type == AST_FUNCTION_DEFINITION ||
-                                               pc->type == AST_BUILDER_FUNCTION) &&
-                                        pc->value && strcmp(pc->value, arg->value) == 0) {
-                                        arg_is_bare_fn = 1;
-                                        break;
-                                    }
-                                }
-                            }
+                            /* #1657: use the shared helper rather than an
+                             * inline whole-program scan. This site had its own
+                             * copy of that loop, so it kept substituting an
+                             * adapter for a name that is really a PARAMETER of
+                             * the enclosing function — see bare_top_level_fn
+                             * for why a local binding must win. Duplicating
+                             * the search is what let the scope rule be fixed
+                             * in one place and still be violated here. */
+                            int arg_is_bare_fn = bare_top_level_fn(gen, arg) != NULL;
                             if (arg_is_bare_fn) {
                                 const char* bn = arg && arg->value ? arg->value : NULL;
                                 if (bn) register_bare_fn_adapter(gen, bn);

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -70,6 +70,7 @@ tests/integration/extern_tuple_param/
 tests/integration/extern_tuple_return/
 tests/integration/extern_tuple_var_passthrough/
 tests/integration/fault_cross_module/
+tests/integration/fn_param_shadows_consumer_fn/
 tests/integration/fn_typed_local_call/
 tests/integration/fn_value_rename/
 tests/integration/fs_glob_recursive_dedupe/

--- a/tests/integration/fn_param_shadows_consumer_fn/lib/ui/module.ae
+++ b/tests/integration/fn_param_shadows_consumer_fn/lib/ui/module.ae
@@ -1,0 +1,16 @@
+// A library that takes a callback parameter named `on_press`.
+//
+// Nothing here is unusual, and nothing here changes between the two builds the
+// test performs. That is the point of #1657: this module's emitted C differed
+// depending on what the CONSUMING app happened to name its own functions.
+exports(btn)
+
+box_it(f: fn) -> ptr {
+    return box_closure(f)
+}
+
+btn(_ctx: ptr, label: string, on_press: fn) -> ptr {
+    // `on_press` is a PARAMETER. It is the innermost binding there is, so it
+    // must win over any same-named function anywhere in the program.
+    return box_it(on_press)
+}

--- a/tests/integration/fn_param_shadows_consumer_fn/probe.ae
+++ b/tests/integration/fn_param_shadows_consumer_fn/probe.ae
@@ -1,0 +1,17 @@
+import lib.ui
+
+// A module-level function whose name collides with ui.btn's PARAMETER name.
+// It is never exported, never imported by ui, and never referenced from btn.
+// Its mere existence used to rewrite the parameter (#1657).
+on_press(view: ptr, x: int, y: int) {
+    println("consumer on_press — must NOT be what btn boxes")
+}
+
+main() {
+    captured = "captured-value"
+    boxed = ui.btn(0, "Shuffle") callback {
+        println("closure ran with ${captured}")
+    }
+    c = unbox_closure(boxed)
+    c()
+}

--- a/tests/integration/fn_param_shadows_consumer_fn/probe_control.ae
+++ b/tests/integration/fn_param_shadows_consumer_fn/probe_control.ae
@@ -1,0 +1,16 @@
+import lib.ui
+
+// Identical to probe.ae except the consumer's function is renamed. This is the
+// control: the library's emitted C must be the same either way.
+rc_on_press(view: ptr, x: int, y: int) {
+    println("consumer rc_on_press")
+}
+
+main() {
+    captured = "captured-value"
+    boxed = ui.btn(0, "Shuffle") callback {
+        println("closure ran with ${captured}")
+    }
+    c = unbox_closure(boxed)
+    c()
+}

--- a/tests/integration/fn_param_shadows_consumer_fn/test_fn_param_shadows_consumer_fn.sh
+++ b/tests/integration/fn_param_shadows_consumer_fn/test_fn_param_shadows_consumer_fn.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# #1657: a FUNCTION PARAMETER must shadow a same-named function defined in a
+# DIFFERENT, CONSUMING module.
+#
+# Sibling of #1606, which fixed the closure-parameter case in the module
+# renamer. This is the codegen half, and it survived that fix.
+#
+# After module merging, one program holds every module's functions — including
+# non-exported ones from the consuming app. Codegen asked "is there a top-level
+# function with this name?" to decide whether an argument was a bare function
+# needing an env-ignoring adapter, and never checked whether the name was
+# really a local binding. So a library's `btn(on_press: fn)` had its PARAMETER
+# replaced by an adapter for the app's unrelated `on_press(view, x, y)`:
+#
+#     void* boxed = ui_box_it((_AeClosure){
+#         .fn = (void(*)(void))_aether_bare_adapter_on_press, .env = NULL });
+#
+# The caller's closure was discarded and `.env = NULL` took its captures with
+# it. Silent: the C is well-formed, the call returns, and nothing happens. In
+# aether-ui this presented as a button that connected, fired, and never moved
+# the model — and eventually segfaulted in GLib, a 3-arg adapter reached
+# through a 0-arg signature.
+#
+# The library's PARAMETER NAMES were effectively part of its public API.
+#
+# Three properties are pinned, in increasing order of how legible the failure
+# would be:
+#
+#   1. the emitted C passes the PARAMETER, not an adapter — the direct check,
+#   2. the library's C is IDENTICAL whether or not the consumer defines a
+#      colliding name — the property that actually matters to a library author,
+#   3. the program RUNS and the captured variable survives — without this a
+#      future regression shows up only as a callback that silently does
+#      nothing, which is exactly how this hid.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMP="${TMPDIR:-/tmp}/ae_1657_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "  FAIL: $1"; exit 1; }
+
+cd "$SCRIPT_DIR"
+
+# --- 1. the colliding build must pass the parameter -------------------------
+"$AE" build --emit=csrc probe.ae -o "$TMP/probe" >"$TMP/log" 2>&1 \
+    || { cat "$TMP/log"; fail "probe.ae did not build"; }
+
+# Assert on the adapter's USE, not its mere presence. The discovery walk still
+# DECLARES an adapter for the consumer's on_press (it is a genuine bare
+# function, and a speculative declaration is dead code the C compiler drops).
+# The defect was the SUBSTITUTION at the call site, so that is what is pinned;
+# checking for the declaration would fail on harmless output and teach the next
+# person to weaken the test.
+if grep -q 'bare_adapter_on_press, .env = NULL' "$TMP/probe.c"; then
+    echo "  offending line:"
+    grep -n 'bare_adapter_on_press, .env = NULL' "$TMP/probe.c" | head -3 | sed 's/^/    /'
+    fail "the consumer's on_press replaced btn's parameter (#1657)"
+fi
+grep -q 'ui_box_it(on_press)' "$TMP/probe.c" \
+    || fail "btn does not pass its own parameter to box_it"
+
+# --- 2. the library's C must not depend on the consumer's names -------------
+"$AE" build --emit=csrc probe_control.ae -o "$TMP/ctrl" >"$TMP/log2" 2>&1 \
+    || { cat "$TMP/log2"; fail "probe_control.ae did not build"; }
+
+# Compare just the library function's body: the rest of the file legitimately
+# differs (the consumer's own function is named differently).
+# Match the DEFINITION (it has a parameter list with names, so `_ctx` appears)
+# rather than the forward declaration, and do not hardcode the return type.
+sed -n '/ui_btn(void\* _ctx/,/^}/p' "$TMP/probe.c" > "$TMP/a.txt"
+sed -n '/ui_btn(void\* _ctx/,/^}/p' "$TMP/ctrl.c"  > "$TMP/b.txt"
+[ -s "$TMP/a.txt" ] || fail "could not locate ui_btn in the emitted C"
+# cksum, not cmp: the Windows MSYS2 CI shell ships no diffutils.
+[ "$(cksum < "$TMP/a.txt")" = "$(cksum < "$TMP/b.txt")" ] \
+    || { echo "  colliding build:"; sed 's/^/    /' "$TMP/a.txt";
+         echo "  control build:";   sed 's/^/    /' "$TMP/b.txt";
+         fail "ui_btn's emitted C depends on the CONSUMER's function names"; }
+
+# --- 3. it must actually run, with captures intact --------------------------
+out="$("$AE" run probe.ae 2>&1)" || { echo "$out"; fail "probe.ae did not run"; }
+echo "$out" | grep -q 'closure ran with captured-value' \
+    || { echo "$out" | sed 's/^/    /'; fail "the closure did not run, or lost its captured variable"; }
+echo "$out" | grep -q 'must NOT be what btn boxes' \
+    && fail "the CONSUMER's on_press ran instead of the caller's closure"
+
+echo "  PASS: fn_param_shadows_consumer_fn: a parameter wins over a consuming module's function (#1657)"


### PR DESCRIPTION
Closes #1657.

**Based on `fix/1652-mailbox-alignment-assert` (PR #1656), not `main`** — rebase to `main` once that merges, or merge #1656 first and this retargets cleanly.

A library function's **parameter** was silently replaced by an unrelated module-level function of the same name, defined in a **consuming** module that never exported it. The caller's closure — and its captured environment — was discarded.

The same library source produced two different bodies depending only on what the *app* happened to name its own functions:

```c
// app defines a module-level on_press(view, x, y)
void* boxed = ui_box_closure((_AeClosure){
    .fn = (void(*)(void))_aether_bare_adapter_on_press, .env = NULL });

// app does not
void* boxed = ui_box_closure(on_press);        // the PARAMETER, correct
```

Note the shapes: a **3-argument** function installed where a **0-argument** callback belongs, and `.env = NULL` taking the captures with it. The C is well-formed, the call returns, and nothing happens.

## Cause

After module merging, one program holds every module's functions — including non-exported ones from the consumer. `bare_top_level_fn()` asked *"is there a top-level function with this name?"* to decide whether an argument was a bare function needing an env-ignoring adapter, and **never asked whether the name was a local binding**.

A parameter is the innermost binding there is, so nothing outside the function may be reachable under that name. The lookup now yields to an enclosing parameter or a declared local.

Sibling of #1606, which fixed the closure-parameter case in the module **renamer**. This is the **codegen** half — a separate pass with its own name resolution — and an ordinary function parameter shadowed from a *different* module, which survived that fix.

## The part worth a reviewer's eye

**One of the three adapter call sites carried its own inlined copy of the whole-program scan** instead of calling `bare_top_level_fn`. Fixing the helper left that site substituting exactly as before — my first attempt at this changed nothing, and it took instrumenting all three sites to find out why.

Duplicating a scope lookup is how the rule gets fixed in one place and still violated in another. That site now goes through the helper. If we later want a single shared "is this name locally bound?" predicate spanning both the renamer and codegen, this is the argument for it.

## Reduced further than the issue

The issue reported it could not be reduced below the full aether-ui app, and listed `_ctx`, the trailing-block form, and TU size as candidate ingredients. **None were needed.** It reduces to two files with no GUI and no clone — the missing ingredient is the **cross-module split** (the reporter's same-module attempt correctly does not reproduce).

That reduction is the regression test, pinning three properties in increasing order of legibility:

1. the emitted C passes the **parameter**, not an adapter — the direct check;
2. the library's C is **identical** whether or not the consumer defines a colliding name — the property a library author actually depends on;
3. the program **runs** with its captured variable intact — without which a future regression appears only as a callback that silently does nothing, which is exactly how this hid.

The test asserts on the adapter's *use*, not its presence: the discovery walk still declares an adapter for the consumer's genuine bare function, and that declaration is dead code the C compiler drops. Pinning the declaration would fail on harmless output and teach the next person to weaken the test.

## Testing

- Verified to **fail against the pre-fix compiler**, reproducing the issue's exact line, and pass after
- Passing a **genuine bare function** still works — the fix narrows the rule rather than removing the feature
- #1606's own regression test still passes
- `make test` — 394 passed, 0 failed
- `make test-ae` — 969 passed, 3 failed: the same three an unmodified tree fails (`http_client_forward_proxy`, `http_server_h2`, `windows_crt_symbols`, all environmental)
- `check-docs` clean

## Impact

Until this, a library's **parameter names were effectively part of its public API surface**. An app choosing an ordinary name like `on_press` or `label` for its own helper could break an unrelated library call, with no diagnostic pointing at either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
