### PR TITLE
chore(changelog): record the #1657 fix under [current] so the release can cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **A function parameter is no longer shadowed by a same-named function in a
+  consuming module** (#1657). `bare_top_level_fn` asked only "is there a
+  top-level function with this name?", and after module merging that program
+  holds every module's functions, including non-exported ones belonging to the
+  *consuming* app. So `ui/module.ae`'s `btn(_ctx, label, on_press: fn)` matched
+  an app's unrelated module-level `on_press`, and the call site emitted a
+  bare-fn adapter for the app's function in place of the caller's closure,
+  discarding its captured environment with it.
+
+  The generated C was well formed, so nothing complained: the call compiled,
+  ran, and did nothing. Where the two signatures differed it was worse than
+  silent. aether-ui's `apps/rubiks_cube` defines `on_press(view, x, y)`, so
+  every one of its buttons received a three-argument adapter for a zero-
+  argument callback and the first click crashed the process, SIGBUS on macOS
+  and SIGSEGV on Linux, storing through a register that held no pointer.
+
+  A parameter is the innermost binding there is, so the lookup now rejects any
+  name bound by the enclosing function's parameters or its declared locals
+  before considering top-level functions. Same family as #1606, which fixed
+  the closure-parameter case in the module renamer; this is the codegen half,
+  for an ordinary parameter shadowed from a different module.
+
 ## [0.552.0]
 
 ### Added


### PR DESCRIPTION
The Release workflow failed on `main` at b5f3d8a3 with:

```
No '## [current]' section in CHANGELOG.md, so 0.553.0
would ship with nothing recorded.
```

Timing, not anything wrong with the change itself: the release PR for v0.552.0 (#1659) merged at 14:34 and consumed the previous `[current]` section, and #1658 merged after it without adding a new one. The auto-bump then had nothing to record and correctly refused to cut the version.

This adds the entry for #1657 under `## [current]`, which is all the bump needs to proceed.

Worth noting because aether-ui's CI installs the toolchain through `get.sh`, which resolves the latest **tag** rather than `main`. Until a release is cut, the #1657 fix is on `main` but not reachable by anything installing that way, so the crash it causes stays reproducible for consumers.