### PR TITLE
fix(ci): the compiler leak gate must not pass without a leak detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **The compiler leak gate reported success without a leak detector.** It
+  greps each compile for a LeakSanitizer report, so on an ordinary build it
+  found nothing to find and passed, which reads as evidence while checking
+  nothing. It now skips explicitly unless the compiler is a sanitizer build
+  (`ASAN_OPTIONS=help=1` makes one print its flag list and an ordinary one
+  print nothing), and fails rather than skips when it cannot compile its probe
+  at all. Both directions checked in a container: green on the sanitizer
+  build, red with the constant-folding leak put back.
+
 ## [0.555.0]
 
 ### Fixed

--- a/tests/scripts/check_compiler_leaks.sh
+++ b/tests/scripts/check_compiler_leaks.sh
@@ -25,24 +25,27 @@ if [ ! -x "$AETHERC" ]; then
     exit 0
 fi
 
-# Refuse to pass silently on a build with no leak detector: a green result
-# here would otherwise mean nothing on macOS or on a non-sanitized build.
+# Refuse to report success without a leak detector. A sanitized binary prints
+# its flag list for ASAN_OPTIONS=help=1; an ordinary one prints nothing, and
+# every check below would then pass by finding no report to find, which is
+# worse than not running at all.
+if ! ASAN_OPTIONS=help=1 "$AETHERC" --version 2>&1 | grep -q "AddressSanitizer"; then
+    echo "  [SKIP] compiler leaks: $AETHERC is not a LeakSanitizer build"
+    exit 0
+fi
+
 probe_dir="$(mktemp -d)"
 cat > "$probe_dir/probe.ae" <<'AEOF'
 main() {
-    leaked = "x"
-    println("${leaked}")
+    println("probe")
 }
 AEOF
 if ! ASAN_OPTIONS=detect_leaks=1 "$AETHERC" "$probe_dir/probe.ae" "$probe_dir/probe.c" \
         >"$probe_dir/probe.log" 2>&1; then
-    echo "  [SKIP] compiler leaks: $AETHERC cannot compile a trivial program"
-    sed 's/^/        /' "$probe_dir/probe.log" | head -5
+    echo "  [FAIL] compiler leaks: $AETHERC cannot compile a trivial program"
+    sed 's/^/        /' "$probe_dir/probe.log" | head -8
     rm -rf "$probe_dir"
-    exit 0
-fi
-if ! grep -q "detect_leaks" "$probe_dir/probe.log" 2>/dev/null; then
-    : # a clean run prints nothing; the detector check below covers the rest
+    exit 1
 fi
 rm -rf "$probe_dir"
 


### PR DESCRIPTION
Follow-up to #1668, which I merged with a gate that could pass without checking anything.

`tests/scripts/check_compiler_leaks.sh` greps each compile for a LeakSanitizer report. On an ordinary build there is no detector, so it found nothing to find and printed PASS. That is worse than not running the gate: it reads as evidence. It did exactly that on my machine minutes after I wrote it, which is how this was caught.

A sanitized binary prints its flag list for `ASAN_OPTIONS=help=1`; an ordinary one prints nothing. The gate now:

- **skips explicitly** when the compiler is not a LeakSanitizer build, naming the reason;
- **fails** rather than skips when it cannot compile its probe at all, since that means the gate is broken rather than inapplicable.

Checked both directions in a gcc:13 container:

```
build rc=0
  [PASS] compiler leaks: 5 programs compile with no leaked allocation
gate rc=0
```

and with the constant-folding leak put back:

```
  [FAIL] compiler leaks: tests/regression/test_string_edge_cases.ae leaked 583 bytes
        Direct leak of 88 byte(s) in 1 object(s) allocated from:
            #1 create_ast_node compiler/ast.c:405
            #2 create_literal_node compiler/ast.c:681
  compiler leaks: 1 of 5 programs leaked
gate rc=1
```

On the CI leg nothing changes: that job builds with `-fsanitize=address -fsanitize=leak` immediately before, so the gate runs there as it did.
