### PR TITLE
ci: tell the website when a release ships

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -663,3 +663,46 @@ jobs:
           aether-*.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Tell the website a version shipped (#1748).
+    #
+    # aesite regenerates its docs from a released aether tree and stamps the
+    # version on the page. Doing that by hand meant doing it late: the site
+    # sat on v0.562 while this repo shipped 0.580, so the front page named a
+    # version nobody could download and the docs described a toolchain that
+    # had moved on.
+    #
+    # A cross-repo dispatch needs a token this repo's GITHUB_TOKEN cannot
+    # provide, so it is a PAT with `contents: write` on aesite, stored as
+    # AESITE_SYNC_TOKEN. When the secret is absent — a fork, or before it is
+    # configured — the step says so and succeeds: aesite also checks daily on
+    # its own, so a missing dispatch delays the site rather than stalling it,
+    # and a release must not fail because a downstream notification could not
+    # be sent.
+    - name: Notify aesite
+      if: success()
+      env:
+        AESITE_TOKEN: ${{ secrets.AESITE_SYNC_TOKEN }}
+        TAG: ${{ steps.tag.outputs.tag }}
+      run: |
+        set -euo pipefail
+        if [ -z "${AESITE_TOKEN:-}" ]; then
+          echo "::notice::AESITE_SYNC_TOKEN is not set — skipping the site notification."
+          echo "aesite's daily sync will pick up $TAG within 24h, or run its"
+          echo "'sync aether release' workflow manually to publish it now."
+          exit 0
+        fi
+        code=$(curl -sS -o /tmp/dispatch.out -w '%{http_code}' -X POST \
+          -H "Authorization: token $AESITE_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/aether-lang-dev/aesite/dispatches \
+          -d "{\"event_type\":\"aether-release\",\"client_payload\":{\"tag\":\"$TAG\"}}")
+        if [ "$code" = "204" ]; then
+          echo "aesite notified: $TAG"
+        else
+          # Not fatal: the release itself is published and correct, and the
+          # site's daily check is the backstop. Loud, so it is fixed.
+          echo "::warning::aesite dispatch returned HTTP $code — the site will"
+          echo "::warning::sync on its daily schedule instead. Response:"
+          sed 's/^/  /' /tmp/dispatch.out | head -5
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **A release now updates the website.** The publish job dispatches to
+  `aesite`, which regenerates its docs from the released tree, stamps the
+  version on the page, moves its toolchain pin, and deploys. Doing that by
+  hand meant doing it late: the site sat on v0.562 while this repo shipped
+  0.580, so the front page named a version nobody could download and the docs
+  described a toolchain that had moved on.
+
+  The dispatch needs a token this repo's `GITHUB_TOKEN` cannot provide, so it
+  reads `AESITE_SYNC_TOKEN`. When that secret is absent the step says so and
+  succeeds, because a release must not fail over a downstream notification,
+  and the site checks daily on its own. A missing token delays the site by up
+  to a day rather than stalling it.
+
+## [current]
+
 ### Removed
 
 - **Two plan documents that were being published as documentation.**


### PR DESCRIPTION
The website is generated from this repo's `docs/` and stamped with this repo's `VERSION`, and updating it was a manual step. Manual steps are done late: **the site sat on v0.562 while this repo shipped 0.580** — eighteen releases where aether-lang.dev named a version nobody could download and served docs for a toolchain that had moved on.

The publish job now dispatches `aether-release` to aesite with the tag, after the GitHub release is created. aesite regenerates from that tag, stamps the version, moves its toolchain pin, and deploys.

Site side: aether-lang-dev/aesite#6.

## Why it cannot fail a release

A cross-repo dispatch needs a token `GITHUB_TOKEN` cannot provide, so the step reads `AESITE_SYNC_TOKEN`. Two ways that goes wrong, both handled:

- **Secret absent** (a fork, or before it is configured): the step logs a notice naming the tag and how to publish it, and succeeds.
- **Dispatch rejected** (expired or under-scoped token): warns loudly with the HTTP code and body, and succeeds.

Neither should turn a release red. The release itself is published and correct, and aesite checks daily on its own — so the worst case is the site publishing a day late rather than not at all. Loud, because a notification that silently never arrives is invisible.

## The one manual step

`AESITE_SYNC_TOKEN` must be added to this repo's secrets: a PAT with `contents: write` on `aether-lang-dev/aesite`. I cannot create it. Until it exists, releases log the notice and the site follows within a day.

## Verified

- `release.yml` parses; the `publish` job's last step is `Notify aesite`
- The step is `if: success()` and gated on the release having been created
- The site side was tested end to end against the real `v0.581.0` tag: 67 pages regenerated, version stamped, pin rewritten, YAML still valid — details in the aesite PR