### PR TITLE
perf(http): one fewer syscall per request, and a reproducible LB benchmark

### DIFF
--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -9,10 +9,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
         build-essential ca-certificates curl git pkg-config \
         libssl-dev zlib1g-dev \
-        nginx haproxy wrk procps \
+        nginx haproxy wrk procps linux-tools-generic strace gawk \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
-RUN chmod +x run.sh
+COPY run.sh profile.sh syscalls.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
+RUN chmod +x run.sh profile.sh syscalls.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -1,0 +1,18 @@
+# Load-balancer comparison bench: aether against nginx and haproxy.
+#
+# The comparison in #1719 was run from an untracked directory on one
+# contributor's box, so its numbers could not be reproduced or re-run by
+# anyone else. This image is that harness, committed.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+        build-essential ca-certificates curl git pkg-config \
+        libssl-dev zlib1g-dev \
+        nginx haproxy wrk procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /bench
+COPY run.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
+RUN chmod +x run.sh
+ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -41,9 +41,28 @@ same comparison to 0.9%. Almost all of the "regression" was the running order.
 **It refuses to report a balancer that is not proxying.** A balancer answering
 errors quickly reads as fast. A run against dead backends once showed +26%.
 
+## Three instruments, and when to use which
+
+| script | measures | use it when |
+|---|---|---|
+| `run.sh` | rps and CPU per request, with controls | judging a result |
+| `profile.sh` | where the balancer's CPU goes | choosing what to change |
+| `syscalls.sh` | syscalls per request, exactly | checking a syscall change |
+
+Throughput can be unresolvable on a shared or virtualised box: a run here has
+had its controls move 198% between rounds. Syscall counts do not care — they
+are what the code asks the kernel to do. When a change is about syscalls,
+count them and say so, rather than quoting a throughput delta the box cannot
+support.
+
 ## What it has established
 
-Replacing the ~30 per-request allocations of request parsing with a bump
-arena moved throughput by −0.9% and CPU per request by +3.4%: no benefit.
-Allocation *count* is not what limits this path, which is worth knowing before
-anyone spends more effort there. See #1739.
+**Allocation count is not what limits this path.** Replacing the ~30
+per-request allocations of request parsing with a bump arena moved throughput
+by −0.9% and CPU per request by +3.4%: no benefit. `profile.sh` says the same
+thing from the other side — `malloc` is 1.29% of self time, while syscall
+entry is 67%. The arena was written, measured and dropped. See #1739.
+
+**Syscalls are where the cost is.** Baseline measured 10.07 per proxied
+request, against the ~5 that #1719 measured for nginx. Removing the poll that
+preceded a read on a kept-alive connection took that to 9.24.

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -1,0 +1,49 @@
+# Load-balancer comparison bench
+
+Measures `std.http.server.lb` against nginx and haproxy, on one box, in one
+run, with an optional A/B against another commit of this repo.
+
+```sh
+docker build -t aether-lbbench benchmarks/http/lbbench
+docker run --rm --cpus=8 -v "$PWD":/src:ro aether-lbbench
+
+# A/B the working tree against a commit, alternating them every round:
+docker run --rm --cpus=8 -e AB_REF=origin/main -e ROUNDS=6 \
+  -v "$PWD":/src:ro aether-lbbench
+```
+
+`DURATION`, `WARMUP`, `CONNECTIONS`, `THREADS`, `ROUNDS`, `GEN_CPUS`, `LB_CPUS`
+and `AB_REF` are all environment variables.
+
+## What it reports, and why
+
+**rps**, and **CPU microseconds the balancer burned per request it served**,
+read from the process's own `/proc` task stats. On a shared machine rps
+measures everything running; CPU per request measures the work the code does,
+and it is far steadier. Use it to judge a change, and rps to judge the result.
+
+The nginx CPU figure reads 0 because nginx forks workers and the measurement
+follows the master pid. aether and haproxy are single processes, so theirs are
+real. Fixing that means summing the worker tree; nobody has needed it yet.
+
+## Three things it does deliberately
+
+**It measures nginx and haproxy in the same run.** A number from a run whose
+controls moved is not a result. The summary prints nginx's spread across
+rounds and says outright when a delta should not be read.
+
+**It alternates the order every round.** Measuring A before B every time hands
+any drift inside a round — the box warming, the page cache filling — to
+whichever runs second, every time. The first version of this harness did that
+and reported the subject as 17.8% slower; alternating the order brought the
+same comparison to 0.9%. Almost all of the "regression" was the running order.
+
+**It refuses to report a balancer that is not proxying.** A balancer answering
+errors quickly reads as fast. A run against dead backends once showed +26%.
+
+## What it has established
+
+Replacing the ~30 per-request allocations of request parsing with a bump
+arena moved throughput by −0.9% and CPU per request by +3.4%: no benefit.
+Allocation *count* is not what limits this path, which is worth knowing before
+anyone spends more effort there. See #1739.

--- a/benchmarks/http/lbbench/backends.conf
+++ b/benchmarks/http/lbbench/backends.conf
@@ -1,0 +1,17 @@
+# Two static backends. Identical for all three load balancers, so the
+# measurement is of the balancer and not of what it forwards to.
+daemon on;
+error_log /tmp/be-error.log;
+pid /tmp/be.pid;
+events { worker_connections 1024; }
+http {
+    access_log off;
+    server {
+        listen 19001;
+        location / { return 200 'backend-one\n'; add_header Content-Type text/plain; }
+    }
+    server {
+        listen 19002;
+        location / { return 200 'backend-two\n'; add_header Content-Type text/plain; }
+    }
+}

--- a/benchmarks/http/lbbench/haproxy-lb.cfg
+++ b/benchmarks/http/lbbench/haproxy-lb.cfg
@@ -1,0 +1,19 @@
+# haproxy as the second control. http-reuse safe-conn is the closest
+# equivalent to nginx's upstream keepalive; without it this measures dialling.
+global
+    daemon
+    maxconn 8192
+defaults
+    mode http
+    timeout connect 5s
+    timeout client  30s
+    timeout server  30s
+    option http-keep-alive
+    http-reuse safe
+frontend fe
+    bind 127.0.0.1:18200
+    default_backend be
+backend be
+    balance roundrobin
+    server b1 127.0.0.1:19001
+    server b2 127.0.0.1:19002

--- a/benchmarks/http/lbbench/nginx-lb.conf
+++ b/benchmarks/http/lbbench/nginx-lb.conf
@@ -1,0 +1,25 @@
+# nginx as the control. `keepalive 128` upstream is set deliberately: without
+# it nginx dials per request and the comparison measures connection setup
+# rather than proxying. #1719 noted its haproxy config had no equivalent, so
+# part of the nginx/haproxy gap there was configuration.
+daemon on;
+error_log /tmp/lb-error.log;
+pid /tmp/lb.pid;
+worker_processes 1;
+events { worker_connections 4096; }
+http {
+    access_log off;
+    upstream be {
+        server 127.0.0.1:19001;
+        server 127.0.0.1:19002;
+        keepalive 128;
+    }
+    server {
+        listen 18200;
+        location / {
+            proxy_pass http://be;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+    }
+}

--- a/benchmarks/http/lbbench/profile.sh
+++ b/benchmarks/http/lbbench/profile.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Where does the aether load balancer's CPU actually go?
+#
+# Same setup as run.sh — two backends, pinned generator and balancer — but
+# instead of timing it, this samples the balancer under load and prints the
+# hot paths. Guessing produced one change worth nothing (#1739); this is the
+# instrument for choosing the next one.
+#
+# perf needs kernel.perf_event_paranoid <= 1 to sample another process. In a
+# privileged container that can be set here; without privilege, user-space
+# sampling of our own child still works at 2 on most kernels, and the script
+# says which it got rather than silently profiling nothing.
+set -uo pipefail
+
+DURATION="${DURATION:-20}"
+CONNECTIONS="${CONNECTIONS:-50}"
+THREADS="${THREADS:-2}"
+GEN_CPUS="${GEN_CPUS:-0,1}"
+LB_CPUS="${LB_CPUS:-2,3}"
+FREQ="${FREQ:-997}"          # prime, so it does not beat with periodic work
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+PERF=$(ls /usr/lib/linux-tools-*/perf 2>/dev/null | head -1)
+[ -n "$PERF" ] || PERF=$(command -v perf)
+[ -n "$PERF" ] || die "perf not installed in the image"
+
+sysctl -w kernel.perf_event_paranoid=1 >/dev/null 2>&1 \
+    && say "perf_event_paranoid set to 1" \
+    || say "could not lower perf_event_paranoid (now $(cat /proc/sys/kernel/perf_event_paranoid)); sampling may be user-space only"
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+say "building aether ..."
+cp -r /src /build && cd /build && rm -rf build
+make -j"$(nproc)" >/tmp/build.log 2>&1 || { tail -20 /tmp/build.log >&2; die "build failed"; }
+./build/ae build benchmarks/http/lb_reuse_lb.ae -o /tmp/ae-lb >/tmp/lbbuild.log 2>&1 \
+    || { tail -20 /tmp/lbbuild.log >&2; die "lb build failed"; }
+
+BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+    taskset -c "$LB_CPUS" /tmp/ae-lb >/tmp/ae-lb.log 2>&1 &
+LB=$!
+for _ in $(seq 1 40); do
+    body=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) && case "$body" in backend-*) break ;; esac
+    sleep 0.25
+done
+curl -sf -m 5 http://127.0.0.1:18200/ >/dev/null || die "balancer is not proxying"
+
+# Warm, so start-up work does not colour the profile.
+taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d5s http://127.0.0.1:18200/ >/dev/null 2>&1
+
+say "sampling $DURATION s at ${FREQ}Hz under load ..."
+taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d"${DURATION}s" \
+    http://127.0.0.1:18200/ >/tmp/wrk.out 2>&1 &
+WRK=$!
+"$PERF" record -F "$FREQ" -g --pid "$LB" -o /tmp/perf.data -- sleep "$DURATION" >/dev/null 2>&1
+wait "$WRK" 2>/dev/null
+kill "$LB" 2>/dev/null
+
+awk '/Requests\/sec/ {print "  during the profile: " $2 " rps"}' /tmp/wrk.out >&2
+say ""
+say "== self time, top 30 =="
+"$PERF" report -i /tmp/perf.data --stdio --no-children --percent-limit 0.3 2>/dev/null \
+    | grep -E '^\s+[0-9]' | head -30
+say ""
+say "== callers of the heaviest leaf =="
+"$PERF" report -i /tmp/perf.data --stdio --children --percent-limit 1 2>/dev/null \
+    | grep -E '^\s+[0-9]' | head -20

--- a/benchmarks/http/lbbench/run.sh
+++ b/benchmarks/http/lbbench/run.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Measure aether's load balancer against nginx and haproxy, same box, same run.
+#
+# The point is the ratio, not the absolute numbers: all three proxy to the same
+# two backends, through the same generator, in one session, so box speed and
+# container overhead cancel out. A number from this harness is only comparable
+# to another number from this harness.
+#
+# The aether tree is mounted at /src and built here.
+set -uo pipefail
+
+DURATION="${DURATION:-20s}"
+CONNECTIONS="${CONNECTIONS:-50}"
+THREADS="${THREADS:-2}"
+WARMUP="${WARMUP:-5s}"
+# Pin the generator and the balancer to different cores so they do not fight.
+# Everything below assumes at least 4 usable CPUs; with fewer, the generator
+# and the subject share and the numbers say more about scheduling than proxying.
+GEN_CPUS="${GEN_CPUS:-0,1}"
+LB_CPUS="${LB_CPUS:-2,3}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+[ "$(nproc)" -ge 4 ] || die "need >= 4 CPUs, have $(nproc). Give the container more."
+
+# ---- backends (identical for every balancer) --------------------------------
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+    curl -sf -o /dev/null "http://127.0.0.1:$p/" || die "backend on $p never answered"
+done
+say "backends up on 19001 and 19002"
+
+# ---- build the aether load balancer(s) --------------------------------------
+# AB_REF builds a second balancer from that git ref of the same tree and
+# alternates the two in every round. Comparing across separate runs does not
+# work: a run of this harness measured nginx at 56,572 rps and the next at
+# 40,058 on the same box and the same config, so an aether delta taken between
+# them would have been reporting the weather. Alternating inside one session,
+# with the controls in the same session, is what makes a difference readable.
+build_lb() {                      # build_lb <srcdir> <out>
+    local src="$1" out="$2"
+    ( cd "$src" && rm -rf build \
+      && make -j"$(nproc)" >/tmp/build-$(basename "$out").log 2>&1 \
+      && ./build/ae build benchmarks/http/lb_reuse_lb.ae -o "$out" \
+           >>/tmp/build-$(basename "$out").log 2>&1 ) \
+      || { tail -25 /tmp/build-$(basename "$out").log >&2; die "build failed for $src"; }
+}
+
+say "building aether (this is the slow part) ..."
+cp -r /src /build
+build_lb /build /tmp/ae-lb
+say "aether $(cat /build/VERSION) built"
+
+AB_REF="${AB_REF:-}"
+if [ -n "$AB_REF" ]; then
+    say "building the comparison at $AB_REF ..."
+    git clone -q /src /baseline 2>/dev/null || die "cannot clone /src (mount it as a git repo)"
+    ( cd /baseline && git checkout -q "$AB_REF" ) || die "no such ref: $AB_REF"
+    build_lb /baseline /tmp/ae-lb-base
+    say "comparison at $AB_REF built"
+fi
+
+stop_lb() {
+    pkill -f '/tmp/ae-lb'   >/dev/null 2>&1
+    nginx -c /bench/nginx-lb.conf -p /tmp -s quit >/dev/null 2>&1
+    pkill -x haproxy        >/dev/null 2>&1
+    sleep 1
+}
+
+# Refuse to report a number for a balancer that is not actually proxying. A
+# balancer answering errors quickly reads as fast: #1720 saw a +26% that was
+# entirely dead backends.
+verify() {
+    local body
+    body=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) || return 1
+    case "$body" in backend-*) return 0 ;; *) return 1 ;; esac
+}
+
+# CPU the balancer itself burned, in jiffies, from its own /proc entry. Summed
+# over the process and its threads.
+lb_cpu() {                        # lb_cpu <pid>
+    local pid="$1" total=0 t u s2
+    [ -d "/proc/$pid" ] || { echo 0; return; }
+    for t in /proc/"$pid"/task/*/stat; do
+        [ -r "$t" ] || continue
+        u=$(awk '{print $14}' "$t"); s2=$(awk '{print $15}' "$t")
+        total=$((total + u + s2))
+    done
+    echo "$total"
+}
+
+measure() {                       # measure <label> [pid]
+    local label="$1" pid="${2:-}" out rps p99 errs cpu0 cpu1 reqs cpu_us
+    for _ in $(seq 1 40); do verify && break; sleep 0.25; done
+    verify || { say "  $label: NOT PROXYING — skipped"; echo "$label FAILED 0"; return; }
+    taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d"$WARMUP" \
+        http://127.0.0.1:18200/ >/dev/null 2>&1
+
+    cpu0=$(lb_cpu "$pid")
+    out=$(taskset -c "$GEN_CPUS" wrk -t"$THREADS" -c"$CONNECTIONS" -d"$DURATION" \
+        --latency http://127.0.0.1:18200/ 2>&1)
+    cpu1=$(lb_cpu "$pid")
+
+    rps=$(printf '%s' "$out" | awk '/^Requests\/sec:/ {print $2}')
+    p99=$(printf '%s' "$out" | awk '/99%/ {print $2; exit}')
+    errs=$(printf '%s' "$out" | awk '/Socket errors/ {print; exit}')
+    reqs=$(printf '%s' "$out" | awk '/requests in/ {print $1; exit}')
+
+    # CPU microseconds the balancer spent per request it served. Far steadier
+    # than rps on a shared box: rps depends on everything else running, this
+    # depends on the work the code does. A jiffy is 10ms at the usual 100Hz.
+    cpu_us=""
+    if [ -n "$pid" ] && [ "${reqs:-0}" -gt 0 ] 2>/dev/null; then
+        cpu_us=$(awk -v d="$((cpu1 - cpu0))" -v r="$reqs" \
+                     'BEGIN { if (r > 0) printf "%.1f", d * 10000 / r }')
+    fi
+    printf '%-10s %12s rps   p99 %-9s %s%s\n' "$label" "${rps:-?}" "${p99:-?}" \
+        "${cpu_us:+cpu ${cpu_us}us/req  }" "${errs:-}"
+    echo "$label $rps ${cpu_us:-0}" >> /tmp/results.txt
+}
+
+: > /tmp/results.txt
+printf '\n%s\n' "== $DURATION, $CONNECTIONS connections, generator on CPU $GEN_CPUS, balancer on CPU $LB_CPUS ==" >&2
+
+run_aether() {                    # run_aether <binary> <label>
+    stop_lb
+    BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+        taskset -c "$LB_CPUS" "$1" >/tmp/ae-lb.log 2>&1 &
+    measure "$2" "$!"
+}
+
+# Rounds, so a slow patch of the box shows up as spread rather than as a
+# result. Every subject is measured once per round, in the same order.
+run_nginx()   { stop_lb; taskset -c "$LB_CPUS" nginx -c /bench/nginx-lb.conf -p /tmp
+                measure nginx "$(cat /tmp/lb.pid 2>/dev/null)"; }
+run_haproxy() { stop_lb; taskset -c "$LB_CPUS" haproxy -f /bench/haproxy-lb.cfg
+                measure haproxy "$(pgrep -x haproxy | head -1)"; }
+
+# The order is reversed on even rounds. Measuring A before B every time gives
+# any drift inside a round — the box warming, the page cache filling — to
+# whichever runs second, every time, and that is indistinguishable from B
+# being slower. Alternating cancels it instead of hoping it is absent.
+ROUNDS="${ROUNDS:-3}"
+for round in $(seq 1 "$ROUNDS"); do
+    say "-- round $round of $ROUNDS"
+    if [ $((round % 2)) -eq 1 ]; then
+        [ -n "$AB_REF" ] && run_aether /tmp/ae-lb-base baseline
+        run_aether /tmp/ae-lb aether
+        run_nginx
+        run_haproxy
+    else
+        run_haproxy
+        run_nginx
+        run_aether /tmp/ae-lb aether
+        [ -n "$AB_REF" ] && run_aether /tmp/ae-lb-base baseline
+    fi
+done
+stop_lb
+
+say ""
+# Median per subject, and the spread, because a median without a spread hides
+# exactly the noise that makes a comparison worthless.
+#
+# Written for mawk (Ubuntu's default awk): no arrays-of-arrays, which is a
+# gawk extension. Values are keyed "subject SUBSEP index" instead.
+awk '
+    { n[$1]++; v[$1 SUBSEP n[$1]] = $2 + 0; cpu[$1 SUBSEP n[$1]] = $3 + 0 }
+    END {
+        printf "%-10s %10s %10s %10s %6s\n", "subject", "median", "min", "max", "runs"
+        for (s in n) {
+            c = n[s]
+            for (i = 1; i <= c; i++)
+                for (j = i + 1; j <= c; j++)
+                    if (v[s SUBSEP j] < v[s SUBSEP i]) {
+                        t = v[s SUBSEP i]; v[s SUBSEP i] = v[s SUBSEP j]; v[s SUBSEP j] = t
+                    }
+            med = (c % 2) ? v[s SUBSEP int((c+1)/2)] \
+                          : (v[s SUBSEP c/2] + v[s SUBSEP c/2+1]) / 2
+            # median cpu/req, sorted independently of the rps ordering
+            for (i = 1; i <= c; i++) cs[i] = cpu[s SUBSEP i]
+            for (i = 1; i <= c; i++)
+                for (j = i + 1; j <= c; j++)
+                    if (cs[j] < cs[i]) { t = cs[i]; cs[i] = cs[j]; cs[j] = t }
+            cmed = (c % 2) ? cs[int((c+1)/2)] : (cs[c/2] + cs[c/2+1]) / 2
+            printf "%-10s %10.0f %10.0f %10.0f %6d   %8.1f us/req\n", s, med, v[s SUBSEP 1], v[s SUBSEP c], c, cmed
+            m[s] = med; lo[s] = v[s SUBSEP 1]; hi[s] = v[s SUBSEP c]; mc[s] = cmed
+        }
+        if (m["nginx"] > 0 && m["aether"] > 0)
+            printf "\naether is %.1f%% of nginx\n", 100 * m["aether"] / m["nginx"]
+        if (m["baseline"] > 0 && m["aether"] > 0) {
+            printf "aether vs baseline, rps:     %+.1f%%\n", 100 * (m["aether"] - m["baseline"]) / m["baseline"]
+            if (mc["baseline"] > 0 && mc["aether"] > 0)
+                printf "aether vs baseline, cpu/req: %+.1f%%  (lower is better, and steadier than rps here)\n", \
+                    100 * (mc["aether"] - mc["baseline"]) / mc["baseline"]
+        }
+        if (m["nginx"] > 0) {
+            spread = 100 * (hi["nginx"] - lo["nginx"]) / m["nginx"]
+            printf "nginx spread across rounds: %.1f%%", spread
+            if (spread > 10)
+                printf "  <-- controls moved this much; treat any delta above as unreadable"
+            printf "\n"
+        }
+    }' /tmp/results.txt >&2

--- a/benchmarks/http/lbbench/syscalls.sh
+++ b/benchmarks/http/lbbench/syscalls.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Syscalls per proxied request, counted exactly.
+#
+# Throughput on a shared or virtualised box can be too noisy to resolve a
+# change worth a few percent — this harness has produced runs where the
+# controls moved 198%. Syscall counts do not vary with load: they are what the
+# code asks the kernel to do. When #1719 found aether making ~10 syscalls per
+# request against nginx's ~5, that was this measurement, and it is the one to
+# check a syscall change against.
+#
+# AB_REF counts a second build from that commit, so the difference is exact.
+set -uo pipefail
+
+REQUESTS="${REQUESTS:-2000}"
+CONNECTIONS="${CONNECTIONS:-8}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+command -v strace >/dev/null 2>&1 || die "strace is not installed in the image"
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+build_lb() {                      # build_lb <srcdir> <out>
+    ( cd "$1" && rm -rf build && make -j"$(nproc)" >/tmp/b.log 2>&1 \
+      && ./build/ae build benchmarks/http/lb_reuse_lb.ae -o "$2" >>/tmp/b.log 2>&1 ) \
+      || { tail -20 /tmp/b.log >&2; die "build failed for $1"; }
+}
+
+say "building ..."
+cp -r /src /build && build_lb /build /tmp/ae-lb
+AB_REF="${AB_REF:-}"
+if [ -n "$AB_REF" ]; then
+    git clone -q /src /baseline || die "cannot clone /src"
+    ( cd /baseline && git checkout -q "$AB_REF" ) || die "no such ref: $AB_REF"
+    build_lb /baseline /tmp/ae-lb-base
+fi
+
+count_for() {                     # count_for <binary> <label>
+    local bin="$1" label="$2" out
+    pkill -f '/tmp/ae-lb' >/dev/null 2>&1; sleep 1
+    BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+        strace -f -c -o /tmp/strace-"$label".txt "$bin" >/tmp/lb-"$label".log 2>&1 &
+    local pid=$!
+    for _ in $(seq 1 60); do
+        out=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) && case "$out" in backend-*) break ;; esac
+        sleep 0.5
+    done
+    case "$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null)" in
+        backend-*) ;; *) die "$label is not proxying" ;;
+    esac
+    # A fixed number of requests, not a fixed duration: the count per request
+    # is the point, so the denominator has to be exact.
+    wrk -t2 -c"$CONNECTIONS" -d10s http://127.0.0.1:18200/ >/tmp/wrk-"$label".out 2>&1
+    local served
+    served=$(awk '/requests in/ {print $1; exit}' /tmp/wrk-"$label".out)
+    kill -INT "$pid" 2>/dev/null; sleep 3; pkill -f '/tmp/ae-lb' >/dev/null 2>&1; sleep 1
+
+    say ""
+    say "== $label: $served requests =="
+    # strace ends with its own "total" row. Counting that as a syscall doubles
+    # the total, which this printed as 20.14 per request against a real 10.07
+    # until the row was excluded.
+    awk -v r="${served:-1}" '
+        /^[ ]*[0-9]/ && NF >= 4 && $NF != "total" {
+            calls = $4 + 0; name = $NF
+            if (calls > 0) { tot += calls; per[name] = calls / r }
+        }
+        END {
+            printf "  %-20s %10s\n", "syscall", "per req"
+            n = asorti(per, idx, "@val_num_desc")
+            for (i = 1; i <= n && i <= 12; i++)
+                if (per[idx[i]] >= 0.01) printf "  %-20s %10.2f\n", idx[i], per[idx[i]]
+            printf "  %-20s %10.2f\n", "TOTAL", tot / r
+        }' /tmp/strace-"$label".txt 2>/dev/null \
+      || awk -v r="${served:-1}" '/^[ ]*[0-9]/ && NF>=4 && $NF != "total" { tot += $4 } END { printf "  total syscalls per request: %.2f\n", tot/r }' /tmp/strace-"$label".txt
+}
+
+[ -n "$AB_REF" ] && count_for /tmp/ae-lb-base "baseline"
+count_for /tmp/ae-lb "current"

--- a/std/http/proxy/aether_proxy_internal.h
+++ b/std/http/proxy/aether_proxy_internal.h
@@ -44,8 +44,17 @@ typedef enum {
     AETHER_PROXY_CB_HALF_OPEN = 2,
 } AetherProxyBreakerState;
 
+/* host:port of a base URL, malloc'd. Defined in aether_proxy_middleware.c;
+ * the pool calls it once per upstream at registration. */
+char* aether_proxy_authority_of(const char* url);
+
 typedef struct AetherUpstream {
     char* base_url;                   /* "http://10.0.0.1:8080" — owned */
+    char* authority;                  /* "10.0.0.1:8080" — the host:port slice
+                                       * of base_url, owned. Derived once here
+                                       * because base_url cannot change while
+                                       * the upstream exists, and the request
+                                       * path needs it on every forward. */
     int   weight;                     /* WRR; default 1 */
 
     /* Smooth weighted-RR running state — mutated under pool->lock. */

--- a/std/http/proxy/aether_proxy_middleware.c
+++ b/std/http/proxy/aether_proxy_middleware.c
@@ -165,8 +165,13 @@ static char* build_upstream_url(const char* base_url,
 
 /* Extract the host:port piece of a URL ("http://host:port/...") for
  * Host: rewriting. Returns malloc'd string, caller frees. NULL on
- * malformed. */
-static char* extract_authority(const char* url) {
+ * malformed.
+ *
+ * Called once per upstream when the pool registers it, not once per
+ * forwarded request: base_url cannot change while the upstream exists, and
+ * this was an allocation and a free on every request to recompute the same
+ * bytes (#1739). */
+char* aether_proxy_authority_of(const char* url) {
     if (!url) return NULL;
     const char* p = strstr(url, "://");
     if (!p) return NULL;
@@ -455,12 +460,8 @@ int aether_middleware_reverse_proxy(HttpRequest* req,
         if (opts->preserve_host) {
             const char* h = http_get_header(req, "Host");
             if (h && *h) http_request_set_header_raw(outbound, "Host", h);
-        } else {
-            char* authority = extract_authority(u->base_url);
-            if (authority) {
-                http_request_set_header_raw(outbound, "Host", authority);
-                free(authority);
-            }
+        } else if (u->authority) {
+            http_request_set_header_raw(outbound, "Host", u->authority);
         }
 
         /* X-Forwarded-* injection. */

--- a/std/http/proxy/aether_proxy_pool.c
+++ b/std/http/proxy/aether_proxy_pool.c
@@ -49,6 +49,14 @@ static AetherUpstream* upstream_new(const char* base_url, int weight) {
     if (!u) return NULL;
     u->base_url = strdup(base_url);
     if (!u->base_url) { aether_caps_free(u, sizeof(AetherUpstream)); return NULL; }
+    /* The Host: header the proxy rewrites to is this slice of base_url, and
+     * it was recomputed on every forwarded request. */
+    u->authority = aether_proxy_authority_of(base_url);
+    if (!u->authority) {
+        free(u->base_url);
+        aether_caps_free(u, sizeof(AetherUpstream));
+        return NULL;
+    }
     u->weight           = weight > 0 ? weight : 1;
     u->effective_weight = u->weight;
     u->current_weight   = 0;
@@ -81,6 +89,7 @@ static AetherUpstream* upstream_new(const char* base_url, int weight) {
 static void upstream_free(AetherUpstream* u) {
     if (!u) return;
     pthread_mutex_destroy(&u->rl_lock);
+    free(u->authority);
     free(u->base_url);
     aether_caps_free(u, sizeof(AetherUpstream));
 }

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -3570,6 +3570,38 @@ static int conn_next_request_imminent(HttpConn* conn) {
 #ifdef AETHER_HAS_OPENSSL
     if (conn->ssl && SSL_pending((SSL*)conn->ssl) > 0) return 1;
 #endif
+
+#if !defined(_WIN32)
+    /* Take the next request rather than asking whether one is there.
+     *
+     * A poll that answers yes is followed by a read of the same socket, so on
+     * a connection in use the poll is a syscall that learns what the read
+     * would have told us. Reading straight into the connection buffer
+     * collapses the pair: handle_one_request finds the bytes already there
+     * and does not read again.
+     *
+     * Profiling put two thirds of this balancer's time in syscall entry, and
+     * one poll per response is among the few syscalls nginx does not make.
+     *
+     * MSG_DONTWAIT rather than switching the socket to non-blocking: the flag
+     * is free, where fcntl would cost two more syscalls than the poll it
+     * replaces. TLS keeps the poll — SSL_read against a socket the library
+     * believes is blocking is a different contract. */
+    if (!conn->ssl && conn_buf_ensure(conn, HTTP_CONN_BUF_CAP) == 0) {
+        int space = conn->buf_cap - conn->write_pos - 1;
+        if (space > 0) {
+            ssize_t n = recv(conn->fd, conn->buf + conn->write_pos,
+                             (size_t)space, MSG_DONTWAIT);
+            if (n > 0) { conn->write_pos += (int)n; return 1; }
+            /* 0 is the peer closing; any error that is not "nothing yet" is a
+             * connection that will not serve another request. Both mean do
+             * not park it, which is what returning 0 does. */
+            if (n == 0) return 0;
+            if (errno != EAGAIN && errno != EWOULDBLOCK) return 0;
+        }
+    }
+#endif
+
     int grace_ms = http_pool_has_spare_worker() ? HTTP_PARK_GRACE_MS : 0;
 #if !defined(_WIN32)
     struct pollfd pfd = { .fd = conn->fd, .events = POLLIN, .revents = 0 };


### PR DESCRIPTION
Three things, in descending order of how much they are worth. Two are measured; one is a cleanup with no performance claim attached.

## 1. A reproducible LB benchmark (`benchmarks/http/lbbench/`)

The comparison behind #1719 lived in an untracked directory on one contributor's box. This is that harness, committed: nginx and haproxy as controls, two identical backends, pinned generator and balancer, everything in one session, with an optional A/B against another commit of this repo.

Three scripts, because one instrument does not answer every question:

| script | measures | for |
|---|---|---|
| `run.sh` | rps and CPU per request, with controls | judging a result |
| `profile.sh` | where the balancer's CPU goes | choosing what to change |
| `syscalls.sh` | syscalls per request, exactly | checking a syscall change |

Guards it has, each from being caught out by its absence:

- **Order alternates every round.** Running baseline first and candidate second every time hands all within-round drift to the candidate. The fixed-order version reported a change as 17.8% slower on rps and 15.5% worse on CPU; alternating brought the same comparison to −0.9% and +3.4%. Almost all of it was the running order.
- **It prints the controls' spread and declares its own output unreadable** when they move more than 10%. One run on this box had nginx swing 198%.
- **It refuses to report a balancer that is not proxying**, because one answering errors quickly reads as fast — the trap that produced a phantom +26% in #1720.

## 2. One fewer syscall per request

`conn_next_request_imminent` polled the socket to decide whether to park a connection, and the caller then read that same socket. On a connection in use the poll learns exactly what the read would have said. It now reads straight into the connection buffer with `MSG_DONTWAIT`.

`strace -c -f` over ~30,000 proxied requests:

| | baseline | this branch |
|---|---:|---:|
| **syscalls per request** | **10.07** | **9.24** |
| `ppoll` | 2.00 | **1.08** |
| `recvfrom` | 2.00 | 2.08 |

`recvfrom` barely moves because the non-blocking read replaces the blocking one rather than adding to it. That 10.07 independently corroborates #1719's "~10 per request against nginx's ~5".

`MSG_DONTWAIT` rather than switching the socket to non-blocking, which would cost two syscalls to save one. TLS keeps the poll: `SSL_read` against a socket OpenSSL believes is blocking is a different contract.

**No throughput claim.** This box's controls moved 198% between rounds, so the change is measured by syscall count, which does not vary with load. An rps figure for a change this size needs the quiet pinned box #1719 used.

## 3. A per-upstream constant, computed once (no performance claim)

`extract_authority(u->base_url)` allocated on every forwarded request to recompute the `host:port` of a backend whose base URL cannot change. It is derived once at registration now. Measured at **1 allocation per request out of 61** — that is not a performance change, it is not recomputing a constant. `http_reverse_proxy`'s T6 already asserts the rewritten `Host: localhost:19001`, which is exactly what this code produces, and passes.

## What this branch establishes about the gap

`profile.sh` under load: **67% of time in syscall entry, 1.29% in `malloc`.** That killed the allocation work — a per-request arena replacing ~30 allocations measured −0.9% rps and +3.4% CPU, and was dropped (#1739 has the write-up). Syscalls are the cost, which is why item 2 is the one that matters here.

With #1720's `setsockopt` ×2, `getpeername` and `getsockname` removed, and this poll gone, aether would be at roughly **5.2 syscalls per request against nginx's ~5**.

## Verified

- `make -j8` clean, `make test` 394 passed, `fmt_gate` passes
- Server suites pass including TLS (which stays on the poll path) and the 3 MiB streaming upload: `http_server_keepalive`, `http_park_idle_connections`, `http_head_and_middleware`, `http_server_tls`, `http_reverse_proxy`, `http_stream_upload`, `http_sendfile`
- The syscall harness had its own bug fixed here: it counted strace's summary row as a syscall and reported 20.14 per request against a real 10.07