### PR TITLE
perf(http): grow the worker pool when every worker is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Changed
+
+- **The HTTP worker pool grows when its workers are all blocked.** A worker
+  owns its connection for the whole of a request, so a handler that *waits* —
+  a reverse proxy waiting on an upstream is the ordinary case — holds a thread
+  without using a core. Sizing the pool at `cores * 2` then caps requests in
+  flight at twice the core count however idle those threads are, which looks
+  like a slow server rather than an idle one.
+
+  Measured on a 2-core-pinned proxy against two backends, with the pool fixed
+  at each size: 8 workers 18,621 rps, 16 workers 38,866, 32 workers 42,798.
+  Nothing was CPU-bound at any of those points; it was waiting.
+
+  The pool now adds one worker when every worker is busy and work is still
+  queued, up to the ceiling it already had. Re-running the same sweep with
+  growth on, the starting size stops mattering: 35,486 / 35,857 / 36,778 /
+  39,215 for the same 8 / 16 / 32 / 64 starts, a spread of 1.1x where fixed
+  sizing spread 2.3x. `AETHER_HTTP_WORKERS` sets the starting size for anyone
+  who wants to pin it.
+
+  This raises a ceiling rather than removing it: a thread per in-flight
+  request is still a thread per in-flight request, and the proxy path blocks
+  on its upstream. Not blocking is the larger change, and this is not it.
+
 ## [0.585.0]
 
 ### Added

--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh profile.sh syscalls.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
-RUN chmod +x run.sh profile.sh syscalls.sh
+COPY run.sh profile.sh syscalls.sh workers.sh backends.conf nginx-lb.conf haproxy-lb.cfg ./
+RUN chmod +x run.sh profile.sh syscalls.sh workers.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/workers.sh
+++ b/benchmarks/http/lbbench/workers.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Does throughput scale with the worker count?
+#
+# A worker owns its connection for the whole of a request, and a proxy's
+# handler blocks for an upstream round trip, so in-flight requests cannot
+# exceed the worker count. If that is the bound, throughput rises with workers
+# and flattens when something else takes over. If it is flat from the start,
+# the bound is elsewhere and the thread model is not what to change.
+#
+# This is a diagnosis, not a benchmark: it says which wall we are against.
+set -uo pipefail
+
+DURATION="${DURATION:-10s}"
+CONNECTIONS="${CONNECTIONS:-50}"
+SWEEP="${SWEEP:-8 16 32 64}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+say "building ..."
+cp -r /src /build && cd /build && rm -rf build
+make -j"$(nproc)" >/tmp/build.log 2>&1 || { tail -20 /tmp/build.log >&2; die "build failed"; }
+./build/ae build benchmarks/http/lb_reuse_lb.ae -o /tmp/ae-lb >/tmp/lb.log 2>&1 || die "lb build failed"
+
+say ""
+printf '%8s %12s %10s\n' "workers" "rps" "p99" >&2
+for w in $SWEEP; do
+    pkill -f '/tmp/ae-lb' >/dev/null 2>&1; sleep 1
+    AETHER_HTTP_WORKERS="$w" BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+        taskset -c 2,3 /tmp/ae-lb >/tmp/ae-lb.log 2>&1 &
+    ok=0
+    for _ in $(seq 1 40); do
+        case "$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null)" in backend-*) ok=1; break ;; esac
+        sleep 0.25
+    done
+    [ "$ok" = 1 ] || { printf '%8s %12s\n' "$w" "NOT PROXYING" >&2; continue; }
+    taskset -c 0,1 wrk -t2 -c"$CONNECTIONS" -d4s http://127.0.0.1:18200/ >/dev/null 2>&1
+    out=$(taskset -c 0,1 wrk -t2 -c"$CONNECTIONS" -d"$DURATION" --latency http://127.0.0.1:18200/ 2>&1)
+    printf '%8s %12s %10s\n' "$w" \
+        "$(printf '%s' "$out" | awk '/^Requests\/sec:/ {print $2}')" \
+        "$(printf '%s' "$out" | awk '/99%/ {print $2; exit}')" >&2
+done
+pkill -f '/tmp/ae-lb' >/dev/null 2>&1
+
+# nginx, once, for scale.
+nginx -c /bench/nginx-lb.conf -p /tmp
+taskset -c 0,1 wrk -t2 -c"$CONNECTIONS" -d4s http://127.0.0.1:18200/ >/dev/null 2>&1
+out=$(taskset -c 0,1 wrk -t2 -c"$CONNECTIONS" -d"$DURATION" --latency http://127.0.0.1:18200/ 2>&1)
+printf '%8s %12s %10s\n' "nginx" \
+    "$(printf '%s' "$out" | awk '/^Requests\/sec:/ {print $2}')" \
+    "$(printf '%s' "$out" | awk '/99%/ {print $2; exit}')" >&2

--- a/std/net/aether_http_pool.c
+++ b/std/net/aether_http_pool.c
@@ -89,6 +89,24 @@ static int http_pool_worker_count(void) {
     if (cores < 1) cores = 1;
 
     long want = cores * 2;
+
+    /* Overridable, because cores * 2 is the right shape for handlers that
+     * compute and the wrong one for handlers that wait. A worker owns its
+     * connection for the whole of a request, so a reverse proxy — whose
+     * handler blocks for an upstream round trip — can have no more requests
+     * in flight than it has workers, however idle those threads are. Sizing
+     * that by core count bounds throughput at workers/latency and looks like
+     * a slow server rather than an idle one.
+     *
+     * The default is unchanged. This exists so the bound can be measured and
+     * so a proxy deployment can raise it without a rebuild. */
+    const char* env = getenv("AETHER_HTTP_WORKERS");
+    if (env && *env) {
+        char* end = NULL;
+        long from_env = strtol(env, &end, 10);
+        if (end && *end == '\0' && from_env > 0) want = from_env;
+    }
+
     if (want < HTTP_POOL_MIN_WORKERS) want = HTTP_POOL_MIN_WORKERS;
     if (want > HTTP_POOL_MAX_WORKERS) want = HTTP_POOL_MAX_WORKERS;
     return (int)want;
@@ -151,6 +169,48 @@ HttpConnectionPool* http_pool_create(HttpServer* server) {
     return pool;
 }
 
+/* Add one worker, if the pool is still short of its ceiling.
+ *
+ * A worker owns its connection for the whole of a request, so a handler that
+ * waits — a reverse proxy waiting on an upstream is the ordinary case — holds
+ * a thread without using a core. Sizing the pool at cores * 2 then caps
+ * requests in flight at twice the core count however idle those threads are.
+ * Measured on a 2-core-pinned proxy against two backends: 8 workers gave
+ * 18,621 rps, 16 gave 38,866, 32 gave 42,798 with p99 falling from 96ms to
+ * 11ms. The work was not CPU-bound at any of those points; it was waiting.
+ *
+ * Growing one at a time rather than in batches: each new worker changes the
+ * condition that asked for it, and a proxy that briefly queues two items does
+ * not need sixteen more threads.
+ *
+ * The ceiling stays HTTP_POOL_MAX_WORKERS. Past the point where waiting stops
+ * being the constraint, more threads cost more than they carry — the same
+ * measurement had 64 workers slower than 32. */
+static void http_pool_grow(HttpConnectionPool* pool) {
+    pthread_mutex_lock(&pool->lock);
+    if (pool->shutdown || pool->worker_count >= HTTP_POOL_MAX_WORKERS) {
+        pthread_mutex_unlock(&pool->lock);
+        return;
+    }
+    int slot = pool->worker_count;
+    /* Claimed before the thread exists so two submitters cannot take the same
+     * slot; rolled back below if the thread does not start. */
+    pool->worker_count++;
+    pthread_mutex_unlock(&pool->lock);
+
+    if (pthread_create(&pool->workers[slot], NULL, http_pool_worker, pool) != 0) {
+        pthread_mutex_lock(&pool->lock);
+        /* Only safe to give the slot back if nobody has claimed one after it;
+         * otherwise leave the count alone and let the gap stay unused rather
+         * than have http_pool_destroy join a pthread_t that was never
+         * initialised. */
+        if (pool->worker_count == slot + 1) pool->worker_count--;
+        pthread_mutex_unlock(&pool->lock);
+        return;
+    }
+    atomic_fetch_add(&http_pool_total_workers, 1);
+}
+
 static void http_pool_submit_item(HttpConnectionPool* pool, HttpPoolItem item) {
     pthread_mutex_lock(&pool->lock);
     while (pool->count >= HTTP_POOL_QUEUE_CAP && !pool->shutdown) {
@@ -166,8 +226,17 @@ static void http_pool_submit_item(HttpConnectionPool* pool, HttpPoolItem item) {
     pool->queue[pool->tail] = item;
     pool->tail = (pool->tail + 1) % HTTP_POOL_QUEUE_CAP;
     pool->count++;
+    /* Every worker busy and work still arriving means the pool is the
+     * bottleneck, not the machine. Decided under the lock, acted on outside
+     * it: pthread_create takes long enough that holding the queue lock across
+     * it would stall the submitters this is meant to unblock. */
+    int grow = (pool->worker_count < HTTP_POOL_MAX_WORKERS)
+            && (atomic_load(&http_pool_busy_workers) >= pool->worker_count)
+            && (pool->count > 1);
     pthread_cond_signal(&pool->not_empty);
     pthread_mutex_unlock(&pool->lock);
+
+    if (grow) http_pool_grow(pool);
 }
 
 void http_pool_submit(HttpConnectionPool* pool, int client_fd) {


### PR DESCRIPTION
The reverse proxy was bounded by its worker count, not by the machine.

A worker owns its connection for the whole of a request, and a proxy's handler blocks for an upstream round trip. So requests in flight cannot exceed the worker count, and `cores * 2` — right for handlers that compute — caps a proxy at twice the core count however idle those threads are. The server looks slow while the machine is idle.

## The measurement that found it

2 cores pinned, two backends, pool fixed at each size:

| workers | rps | p99 |
|---:|---:|---:|
| 8 | 18,621 | 96.4 ms |
| 16 *(the shipped default here)* | 38,866 | 22.1 ms |
| 32 | 42,798 | 11.4 ms |
| 64 | 39,222 | 13.9 ms |

Throughput more than doubles from 8 to 16 and keeps climbing to 32, then falls back at 64 as the threads oversubscribe two cores. Nothing is CPU-bound at any of those points — it is waiting.

## The change

The pool adds one worker when every worker is busy and work is still queued, up to the ceiling it already had. One at a time, because each new worker changes the condition that asked for it. `AETHER_HTTP_WORKERS` sets the starting size for anyone who wants to pin it; the default is unchanged.

Same sweep with growth on:

| start | fixed | with growth |
|---:|---:|---:|
| 8 | 18,621 | **35,486** |
| 16 | 38,866 | 35,857 |
| 32 | 42,798 | 36,778 |
| 64 | 39,222 | 39,215 |

**Spread across starting sizes falls from 2.3x to 1.1x.** The pool finds its own size instead of depending on someone picking the right number.

## What is not claimed

**No cross-run comparison.** nginx measured 46,104 rps in the first sweep and 58,907 in the second — this box moved 28% between them, so it cannot referee a small difference. The evidence here is the *shape* of the sweep, whose steps are 2x and therefore far above that noise.

**A correction to something I wrote earlier in this work:** I described aether as "4.4x better than nginx on p99", from a run measuring 11.4 ms against nginx's 50.5 ms. In the second run nginx's p99 was 3.51 ms against our 7.61 ms — better than ours. That advantage was a property of one run, not of the system, and I should not have stated it as a result.

**This raises a ceiling rather than removing it.** A thread per in-flight request is still a thread per in-flight request. nginx and haproxy hold thousands in flight on one thread because nothing blocks; the proxy path here blocks on its upstream. Async upstream I/O is the change that removes the bound, and this is not that change.

## Concurrency details worth reviewing

- The thread is created **outside** the queue lock: `pthread_create` is slow enough that holding it there would stall the submitters growth is meant to unblock.
- The slot is claimed before the thread exists, so two submitters cannot take the same one.
- On `pthread_create` failure the slot is given back **only** if no later slot has been claimed — otherwise the count stays, because `http_pool_destroy` must never join a `pthread_t` that was never initialised.

## Verified

- `make -j8` clean, `make test` 394 passed, `fmt_gate` passes
- `http_server_keepalive`, `http_park_idle_connections`, `http_server_actor_dispatch`, `http_reverse_proxy`, `http_reverse_proxy_pool` all pass
- Adds `workers.sh` to the bench harness, which produced both sweeps