### PR TITLE
docs(lbbench): make the harness README documentation, not a findings log

### DIFF
--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -1,7 +1,7 @@
 # Load-balancer comparison bench
 
-Measures `std.http.server.lb` against nginx and haproxy, on one box, in one
-run, with an optional A/B against another commit of this repo.
+Measures `std.http.server.lb` against nginx and haproxy on one box, in one run,
+with an optional A/B against another commit of this repo.
 
 ```sh
 docker build -t aether-lbbench benchmarks/http/lbbench
@@ -13,48 +13,14 @@ docker run --rm --cpus=8 -e AB_REF=origin/main -e ROUNDS=6 \
 ```
 
 `DURATION`, `WARMUP`, `CONNECTIONS`, `THREADS`, `ROUNDS`, `GEN_CPUS`, `LB_CPUS`
-and `AB_REF` are all environment variables.
+and `AB_REF` are environment variables.
 
-## What it reports, and why
+The point is the ratio, not the absolute numbers. All three balancers proxy to
+the same backends through the same generator in one session, so box speed and
+container overhead cancel. A number from this harness is comparable only to
+another number from the same run.
 
-**rps**, and **CPU microseconds the balancer burned per request it served**,
-read from the process's own `/proc` task stats. On a shared machine rps
-measures everything running; CPU per request measures the work the code does,
-and it is far steadier. Use it to judge a change, and rps to judge the result.
-
-**Context switches per request**, from the same source. A thread-per-request
-server pays these where an event loop does not, so this is the number that
-prices the thread model. All three figures sum the balancer's whole process
-tree: nginx forks workers and does its work there, so following the master
-alone reported 0 CPU and 0 context switches for it, a flattering number that
-said nothing.
-
-## Three things it does deliberately
-
-**It measures nginx and haproxy in the same run.** A number from a run whose
-controls moved is not a result. The summary prints nginx's spread across
-rounds and says outright when a delta should not be read.
-
-**It alternates the order every round.** Measuring A before B every time hands
-any drift inside a round (the box warming, the page cache filling) to
-whichever runs second, every time. The first version of this harness did that
-and reported the subject as 17.8% slower; alternating the order brought the
-same comparison to 0.9%. Almost all of the "regression" was the running order.
-
-**It refuses to report a balancer that is not proxying.** A balancer answering
-errors quickly reads as fast. A run against dead backends once showed +26%.
-
-**It refuses to report a figure it could not measure.** A CPU or context
-switch figure it cannot read is printed as `cpu UNMEASURED`, never as 0.
-Zero is the most flattering number in the table and is never true of a
-process that served requests. nginx daemonizes, so its master pid comes from
-a pid file that is not written yet when the launcher returns; reading it
-straight away got the previous round's dead pid and reported 0 for the whole
-nginx column. Only nginx was affected, because aether runs in the foreground
-and haproxy is found by pgrep, so findings that compare aether against a
-baseline were never touched by it.
-
-## Three instruments, and when to use which
+## The instruments
 
 | script | measures | use it when |
 |---|---|---|
@@ -63,28 +29,48 @@ baseline were never touched by it.
 | `syscalls.sh` | syscalls per request, exactly | checking a syscall change |
 | `switches.sh` | which call asked to sleep, by name | chasing context switches |
 
-Throughput can be unresolvable on a shared or virtualised box: a run here has
-had its controls move 198% between rounds. Syscall counts do not care: they
-are what the code asks the kernel to do. When a change is about syscalls,
-count them and say so, rather than quoting a throughput delta the box cannot
-support.
+`profile.sh` and `switches.sh` need `perf`, and `switches.sh` needs a
+privileged container for the scheduler tracepoint.
 
-## What it has established
+## What `run.sh` reports
 
-**Allocation count is not what limits this path.** Replacing the ~30
-per-request allocations of request parsing with a bump arena moved throughput
-by −0.9% and CPU per request by +3.4%: no benefit. `profile.sh` says the same
-thing from the other side: `malloc` is 1.29% of self time, while syscall
-entry is 67%. The arena was written, measured and dropped. See #1739.
+**rps**, and **CPU microseconds the balancer burned per request it served**,
+read from the process's own `/proc` entry and summed over its whole process
+tree. On a shared machine rps measures everything running; CPU per request
+measures the work the code does, and it is far steadier.
 
-**The sleeps are voluntary, and two of them per request.** `switches.sh`
-attributes them: `transport_recv` 0.91 per request and `conn_serve` 0.65,
-against 0.06 for the whole parking lot and 0.05 involuntary. Both sleepers
-have one cause, a worker owning a single connection with nothing else to run.
-Two cheaper fixes were measured and dropped: shrinking the worker pool (there
-is no involuntary cost to recover) and removing the park grace poll (worse by
-0.57 switches and about 30% CPU per request, every round). See #1758.
+**Context switches per request**, split into voluntary and involuntary.
+Voluntary means the code asked to sleep. Involuntary means the scheduler took
+the CPU away, which is threads oversubscribing the cores. The two call for
+opposite fixes, so they are never summed into one figure.
 
-**Syscalls are where the cost is.** Baseline measured 10.07 per proxied
-request, against the ~5 that #1719 measured for nginx. Removing the poll that
-preceded a read on a kept-alive connection took that to 9.24.
+## Guarantees it makes about its own numbers
+
+**Both controls are measured in the same run.** A number from a run whose
+controls moved is not a result, so the summary prints nginx's spread across
+rounds and says outright when a delta should not be read.
+
+**The order alternates every round.** Measuring A before B every time hands any
+drift inside a round, the box warming or the page cache filling, to whichever
+runs second.
+
+**A balancer that is not proxying is not reported.** One answering errors
+quickly reads as fast, so every subject is verified to return a backend
+response before it is measured.
+
+**A figure it could not measure is reported as `cpu UNMEASURED`, never as 0.**
+Zero is the most flattering number in the table and is never true of a process
+that served requests, so it is never printed as one. Rounds that could not be
+measured keep their rps and are excluded from the CPU median, and the count of
+skipped rounds is shown.
+
+**Editing an instrument takes effect without rebuilding the image.** The
+scripts are baked in, so each re-execs from the mounted tree when it differs,
+and says so, rather than silently measuring with the version in the image.
+
+Throughput can be unresolvable on a shared or virtualised box, where controls
+have moved over 100% between rounds. Syscall and context-switch counts do not
+care, so when a change is about either, count them and say so rather than
+quoting a throughput delta the box cannot support.
+
+Results and findings live in the issue tracker, not here.

--- a/benchmarks/http/lbbench/run.sh
+++ b/benchmarks/http/lbbench/run.sh
@@ -74,10 +74,9 @@ stop_lb() {
 }
 
 # nginx daemonizes, so the pid of the process the shell started is not the
-# master's: the master's is in the pid file, and it is not written yet when
-# the launcher returns. Reading it straight away got the previous round's
-# stale pid, whose /proc entry is gone, and every per-request figure derived
-# from it came out 0.
+# master's. The master's is in the pid file and is not written yet when the
+# launcher returns, so it has to be waited for; a stale pid from the previous
+# round names a dead process and every figure derived from it reads 0.
 wait_pid_file() {                 # wait_pid_file <file>
     local f="$1" i pid
     for i in $(seq 1 60); do
@@ -112,11 +111,10 @@ lb_pids() {                       # lb_pids <pid>
     for k in $kids; do lb_pids "$k"; done
 }
 
-# Voluntary and involuntary switches are two different findings and are
-# counted separately. Voluntary means the code asked to sleep, which for this
-# path is the upstream call blocking a worker. Involuntary means the scheduler
-# took the CPU away, which is threads oversubscribing the cores. A single
-# summed figure cannot tell those apart, and they call for opposite fixes.
+# Voluntary and involuntary switches are counted separately. Voluntary means
+# the code asked to sleep; involuntary means the scheduler took the CPU away,
+# which is threads oversubscribing the cores. A summed figure cannot tell them
+# apart and they call for opposite fixes.
 lb_ctxt() {                       # lb_ctxt <pid> <voluntary|involuntary>
     local pid="$1" which="$2" total=0 t v p key
     case "$which" in
@@ -173,9 +171,8 @@ measure() {                       # measure <label> [pid]
     # than rps on a shared box: rps depends on everything else running, this
     # depends on the work the code does. A jiffy is 10ms at the usual 100Hz.
     # A CPU figure this could not measure is reported as unmeasured, never as
-    # zero. A zero here reads as "burned no CPU", which is the most flattering
-    # number in the table and is never true of a process that served requests:
-    # it means the pid was wrong, and it once hid nginx's real cost entirely.
+    # zero. Zero reads as "burned no CPU", which is never true of a process
+    # that served requests, and it silently hides the subject's real cost.
     cpu_us=""; ctx_per=""; vol_per=""; inv_per=""; note=""
     if [ -z "$pid" ] || [ ! -d "/proc/$pid" ]; then
         note="cpu UNMEASURED (no live pid)  "
@@ -194,9 +191,8 @@ measure() {                       # measure <label> [pid]
         fi
     fi
     # stderr, like every other line this prints. A result on stdout and the
-    # round header on stderr interleave once the output is piped, and a row
-    # then appears under the wrong round: one run showed a subject missing
-    # from round 2 and listed twice in round 3.
+    # round header on stderr interleave once the output is piped, which files
+    # a row under the wrong round.
     printf '%-10s %12s rps   p99 %-9s %s%s%s%s\n' "$label" "${rps:-?}" "${p99:-?}" \
         "$note" "${cpu_us:+cpu ${cpu_us}us/req  }" \
         "${ctx_per:+ctxsw ${ctx_per}/req (vol ${vol_per} inv ${inv_per})  }" \

--- a/benchmarks/http/lbbench/switches.sh
+++ b/benchmarks/http/lbbench/switches.sh
@@ -3,9 +3,8 @@
 #
 # run.sh counts context switches and splits voluntary from involuntary, which
 # says how many and of what kind but not where. This records the scheduler
-# tracepoint with stacks, so each sleep is attributed to the call that asked
-# for it. #1758 turns on removing two voluntary sleeps per request, and this
-# is what says which two they are rather than which two look likely.
+# tracepoint with stacks and attributes each sleep to the call that asked for
+# it, so a fix can target a call site rather than a likely-looking one.
 #
 # Voluntary only: a task leaving the CPU in state S (interruptible sleep) went
 # to sleep because the code asked. A task leaving in state R was preempted and

--- a/benchmarks/http/lbbench/use_mounted.sh
+++ b/benchmarks/http/lbbench/use_mounted.sh
@@ -1,10 +1,9 @@
 # Sourced by every instrument in this directory, first thing.
 #
-# The scripts are baked into the image, so editing one does nothing until the
-# image is rebuilt. That failure is silent and it is the worst kind: the run
-# succeeds and reports numbers from the instrument you thought you had just
-# fixed, which is how a fix to the pid handling below got believed once before
-# it was running. When the tree is mounted and differs, re-exec from the mount.
+# The scripts are baked into the image, so editing one has no effect until the
+# image is rebuilt. That failure is silent: the run succeeds and reports
+# numbers from the version in the image, not the edited one. When the tree is
+# mounted and differs, re-exec from the mount and say so.
 lbbench_use_mounted() {           # lbbench_use_mounted <script-name> "$@"
     local name="$1"; shift
     local src=/src/benchmarks/http/lbbench


### PR DESCRIPTION
The harness README had become a findings log: what past experiments
established, and how the instrument's own bugs were found. That is tracker
content, and a README is documentation.

Rewritten to what a reader actually needs: what the harness measures, how to
run it, which of the four instruments answers which question, and what its
numbers can be trusted to mean. The guarantees it makes about its own output
stay, because those tell you how to read a result; the incidents that produced
each guard are gone.

Same edit to the comments in the scripts.

The measurements themselves are not lost, they are on #1758.

This re-lands a commit that missed #1761: the merge took that PR at its
previous head, so the README rewrite never reached main.

No production code, no CHANGELOG change (the entry it touched has since
shipped in 0.587.0 and released sections stay as tagged).

Refs #1758