### PR TITLE
ci(release): install the websocket peer the release tests require

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,7 +332,21 @@ jobs:
     # -- Linux ---
     - name: Setup (Linux)
       if: matrix.os == 'ubuntu-22.04'
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+      run: |
+        sudo apt-get update && sudo apt-get install -y gcc make bc python3-pip
+        # The websocket suites check our RFC 6455 implementation against an
+        # independent one, and they fail rather than skip on a Linux CI runner
+        # because a silent skip would hide the only thing they exist for.
+        # This job runs them, so it has to provide the peer, and it did not:
+        # the release failed on a dependency the tests legitimately require
+        # while ci.yml had been installing it in its matrix all along.
+        #
+        # Same line ci.yml uses. Not the distribution package: this leg runs on
+        # 22.04 for glibc reasons (see the matrix above), and 22.04 ships
+        # websockets 9.1, which the probe rejects for good reason -- it passes
+        # asyncio's removed loop= argument and dies mid-handshake on Python
+        # 3.10+. pip gets a current one.
+        pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
     # -- Windows -- MinGW-w64 via MSYS2 ---
     - name: Setup (Windows)


### PR DESCRIPTION
The release job has been failing on Linux since the websocket suites landed:

    [FAIL] python websockets is missing on a Linux CI runner.
    [FAIL] no usable python websockets on a Linux CI runner (probe=2).

**The tests are right.** They check our RFC 6455 implementation against an
independent one, and on a Linux CI runner they fail rather than skip because a
silent skip would hide the only thing they exist for.

**The job never provided the peer.** It runs `make test-ae`, which runs those
suites, while installing nothing but gcc, make and bc. `ci.yml` has been
installing `websockets` in every Linux matrix entry all along, so the two
workflows ran the same tests under different assumptions and only one of them
was right. That is why this reached a release rather than a pull request.

**Not the distribution package.** This leg pins ubuntu-22.04 for glibc
portability (see the matrix comment), and 22.04 ships websockets 9.1, which the
probe rejects for a good reason: 9.1 passes asyncio's removed `loop=` argument
and dies mid-handshake on Python 3.10+, which from the client side is
indistinguishable from a fault in our own client. So this uses the same pip
line `ci.yml` uses.

One file, one step. Sent on its own rather than inside the proxy work it was
reported against, because a broken release should not wait for an unfinished
feature.

Reported from the failing run on main: actions/runs/33098797174