### PR TITLE
test(actors): wait for the message instead of sleeping a fixed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `main`, the release pipeline automatically replaces `[current]` with the next
 version number before tagging the release.
 
+## [current]
+
+### Fixed
+
+- **The actor registry test waits for its answer instead of sleeping a fixed
+  time.** It synchronised with three `sleep(50)` calls, which is a guess about
+  how quickly the scheduler will deliver a message, and a loaded machine loses
+  that guess: it failed on a Windows CI runner while passing everywhere else,
+  blocking a pull request that touched neither actors nor the registry. It now
+  polls for the value with a deadline, so it passes as soon as the message
+  arrives and still fails if one genuinely goes nowhere.
+
 ## [0.593.0]
 
 ### Changed

--- a/std/actors/test_actors_registry.ae
+++ b/std/actors/test_actors_registry.ae
@@ -71,13 +71,26 @@ fn count_via_spy(target: actor_ref, n: int) -> int {
     for (i = 0; i < n; i = i + 1) {
         target ! Bump {}
     }
-    sleep(50)
     spy = spawn(Spy())
     target ! Ask { from: spy }
-    sleep(50)
+
+    // Wait for the answer rather than assuming how long it takes to
+    // arrive. A mailbox is FIFO, so the bumps are counted before the Ask
+    // is answered; what is not fixed is how soon the scheduler reaches
+    // them, and a fixed sleep is a guess that a loaded machine loses.
+    // This failed on a Windows CI runner while passing everywhere else.
+    //
+    // Draining is idempotent, so asking again costs nothing, and -1 means
+    // the spy has not been told yet. A send that genuinely goes nowhere
+    // still fails, one second later than before.
     cell = ref(-1)
-    spy ! Drain { sink: cell }
-    sleep(50)
+    for (waited = 0; waited < 1000; waited = waited + 5) {
+        spy ! Drain { sink: cell }
+        if ref_get(cell) != -1 {
+            return ref_get(cell)
+        }
+        sleep(5)
+    }
     return ref_get(cell)
 }
 


### PR DESCRIPTION
`std_actors_test_actors_registry` failed on a Windows CI runner and is
blocking #1779, which changes only `std/deque` and `std/set`. This test imports
neither. It is not that PR's fault: the test is flaky by construction.

It synchronised with three `sleep(50)` calls, which is a guess about how
quickly the scheduler delivers a message. On a loaded runner the guess loses,
the spy has recorded nothing, and the assertion sees `-1`.

It polls for the value now, with a one second deadline:

- A mailbox is FIFO (confirmed in `aether_send_message.c`), so the bumps are
  counted before the `Ask` is answered and the count cannot come back short.
  What was never fixed is how soon the scheduler gets to them.
- Draining the spy is idempotent, so asking again costs nothing.
- A send that genuinely goes nowhere still fails, one second later than before.

It is also faster in the normal case, returning as soon as the answer arrives
rather than always spending 150ms.

Verified five consecutive runs under a load average of 12.9, which is the
condition the fixed sleeps lose under, and by reading the send path rather than
assuming the ordering the count depends on.

Sent separately from the proxy work: a flaky test blocks everyone, and it
should not wait behind a feature branch.