### PR TITLE
fix(release): ship the public headers, so a fetched release can cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,6 +489,20 @@ jobs:
         # from source at all.
         cp -r runtime release/share/aether/
         cp -r std     release/share/aether/
+        # The public headers that sit at the top of include/, libaether.h
+        # among them. The loop above only mirrors the runtime/ and std/
+        # SUBTREES, so anything directly in include/ was dropped.
+        #
+        # That matters because include/aether/ is itself an -I directory for
+        # an installed tree, and runtime/libaether_caps.c -- shipped in
+        # share/aether/runtime/ above -- does `#include "libaether.h"`. The
+        # release therefore carried the .c that needs the header and not the
+        # header, so a fetched release could cross-compile hello.ae (which
+        # pulls no runtime .c) and failed on anything that linked the runtime
+        # with `fatal error: 'libaether.h' file not found`. A local install
+        # was fine: the Makefile's own staging has copied these since #1420,
+        # and this workflow reimplements that staging without the line.
+        cp include/*.h release/include/aether/ 2>/dev/null || true
         cp build/MANIFEST release/share/aether/
         cp LICENSE README.md VERSION release/
         cd release && tar -czf ../aether-${VERSION}-${{ matrix.target }}.tar.gz *
@@ -520,6 +534,20 @@ jobs:
         # from source at all.
         cp -r runtime release/share/aether/
         cp -r std     release/share/aether/
+        # The public headers that sit at the top of include/, libaether.h
+        # among them. The loop above only mirrors the runtime/ and std/
+        # SUBTREES, so anything directly in include/ was dropped.
+        #
+        # That matters because include/aether/ is itself an -I directory for
+        # an installed tree, and runtime/libaether_caps.c -- shipped in
+        # share/aether/runtime/ above -- does `#include "libaether.h"`. The
+        # release therefore carried the .c that needs the header and not the
+        # header, so a fetched release could cross-compile hello.ae (which
+        # pulls no runtime .c) and failed on anything that linked the runtime
+        # with `fatal error: 'libaether.h' file not found`. A local install
+        # was fine: the Makefile's own staging has copied these since #1420,
+        # and this workflow reimplements that staging without the line.
+        cp include/*.h release/include/aether/ 2>/dev/null || true
         cp build/MANIFEST release/share/aether/
         cp LICENSE README.md VERSION release/
         cd release && zip -r ../aether-${VERSION}-${{ matrix.target }}.zip *
@@ -639,6 +667,20 @@ jobs:
         done
         cp -r runtime release/share/aether/
         cp -r std     release/share/aether/
+        # The public headers that sit at the top of include/, libaether.h
+        # among them. The loop above only mirrors the runtime/ and std/
+        # SUBTREES, so anything directly in include/ was dropped.
+        #
+        # That matters because include/aether/ is itself an -I directory for
+        # an installed tree, and runtime/libaether_caps.c -- shipped in
+        # share/aether/runtime/ above -- does `#include "libaether.h"`. The
+        # release therefore carried the .c that needs the header and not the
+        # header, so a fetched release could cross-compile hello.ae (which
+        # pulls no runtime .c) and failed on anything that linked the runtime
+        # with `fatal error: 'libaether.h' file not found`. A local install
+        # was fine: the Makefile's own staging has copied these since #1420,
+        # and this workflow reimplements that staging without the line.
+        cp include/*.h release/include/aether/ 2>/dev/null || true
         cp build/MANIFEST release/share/aether/
         cp LICENSE README.md VERSION release/
         # Note the cross-build in the archive so downstream users know it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A fetched release can cross-compile a program that links the runtime.**
+  The release shipped `share/aether/runtime/libaether_caps.c`, which does
+  `#include "libaether.h"`, but not the header — so a downstream that fetched
+  a release and cross-compiled anything beyond a trivial program died on
+  `fatal error: 'libaether.h' file not found`. `hello.ae` dodged it only
+  because it pulls no runtime `.c` at all, which is what made this look like
+  cross-compilation working.
+
+  A local install was always fine, and that is what hid it: the Makefile's
+  staging has copied the top-level headers since #1420, and the release
+  workflow reimplements that staging without the line. Its loop mirrors the
+  `runtime/` and `std/` subtrees of `include/`, so anything sitting directly
+  in `include/` was dropped. All three packaging paths — Unix, Windows and the
+  FreeBSD cross-build — now stage them, and a test asserts every packaging
+  block does, so a new target cannot omit it silently.
+
+
 ## [0.598.0]
 
 ### Added

--- a/tests/integration/release_ships_public_headers/test_release_ships_public_headers.sh
+++ b/tests/integration/release_ships_public_headers/test_release_ships_public_headers.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# The release must ship every header at the top of include/, not just the
+# runtime/ and std/ subtrees.
+#
+# include/aether/ is itself an -I directory for an installed tree, and
+# share/aether/runtime/libaether_caps.c -- which the release also ships --
+# does `#include "libaether.h"`. A release carrying that .c without the
+# header cross-compiles hello.ae fine, because a trivial program pulls no
+# runtime .c, and fails on anything that links the runtime:
+#
+#   libaether_caps.c:18:10: fatal error: 'libaether.h' file not found
+#
+# That shipped in 0.597.0. A local install was unaffected, which is what made
+# it easy to miss: the Makefile's staging copies these (since #1420) and the
+# release workflow reimplements that staging without the line.
+#
+# This asserts the CONTRACT rather than one filename: every .h directly in
+# include/ has to be staged, so a new public header cannot go missing the
+# same way.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+WF="$ROOT/.github/workflows/release.yml"
+
+[ -f "$WF" ] || { echo "  [SKIP] release.yml not found"; exit 0; }
+[ -d "$ROOT/include" ] || { echo "  [SKIP] no include/ in the tree"; exit 0; }
+
+# Every packaging block that stages the runtime source must also stage the
+# top-level headers. Counting both means a NEW packaging block (a new target)
+# cannot quietly omit it.
+n_pkg=$(grep -c 'cp -r runtime release/share/aether/' "$WF" || true)
+n_hdr=$(grep -c 'cp include/\*\.h release/include/aether/' "$WF" || true)
+
+[ "$n_pkg" -gt 0 ] || { echo "  [FAIL] no packaging block found in release.yml"; exit 1; }
+if [ "$n_hdr" != "$n_pkg" ]; then
+    echo "  [FAIL] $n_pkg packaging block(s) ship the runtime source but only"
+    echo "         $n_hdr stage include/*.h into include/aether/."
+    echo "         A release that ships runtime/libaether_caps.c without"
+    echo "         libaether.h cannot cross-compile a runtime-linking program."
+    exit 1
+fi
+
+# And the header the runtime actually needs must exist to be staged.
+[ -f "$ROOT/include/libaether.h" ] || {
+    echo "  [FAIL] include/libaether.h is missing from the tree"
+    exit 1
+}
+
+# The include is by bare name, so it must resolve from an -I of include/aether
+# rather than a relative path. If that ever changes to a relative form, the
+# staging above stops being the right fix and this should be revisited.
+CAPS="$ROOT/runtime/libaether_caps.c"
+if [ -f "$CAPS" ]; then
+    grep -q '#include "libaether\.h"' "$CAPS" || {
+        echo "  [FAIL] runtime/libaether_caps.c no longer includes libaether.h by"
+        echo "         bare name; the release staging assumption needs rechecking."
+        exit 1
+    }
+fi
+
+echo "  [PASS] release_ships_public_headers: $n_pkg packaging block(s) stage include/*.h"


### PR DESCRIPTION
Closes `asks/release-tarball-omits-libaether-h-breaks-runtime-cross.md` — the last of the four cross-build asks.

**Reproduced against the real 0.597.0 tarball:**

```
$ find <release> -name libaether.h        # nothing
$ ae build --target=x86_64-linux real.ae
share/aether/runtime/libaether_caps.c:18:10: fatal error: 'libaether.h' file not found
```

The release ships the `.c` that needs the header and not the header. `hello.ae` dodges it **only** because a trivial program pulls no runtime `.c` at all — which is exactly what made cross-compilation look healthy.

## The placement is not interchangeable

The ask says to ship it "wherever the cross-compile's `-I` points — `include/` or `include/aether/`". Those are **not** the same, and picking the wrong one looks like a fix while changing nothing.

I staged it at `share/aether/include/` first, on the strength of a Makefile comment naming that path — and **the build failed identically**. The cross path uses `tc.include_flags` exclusively, and for an installed tree that list contains `include/aether` (`tools/ae.c:1473`, the #1420 fix). So `include/aether/libaether.h` is the only placement that works.

A local install has it exactly there, which is why local builds were always fine and this was easy to miss.

## Where it went wrong

`release.yml` reimplements the Makefile's staging. Its loop mirrors the `runtime/` and `std/` **subtrees** of `include/`, so anything sitting *directly* in `include/` was dropped. The Makefile has had `cp include/*.h "$reldir/include/aether/"` since #1420; the workflow never gained it.

Fixed in **all three** packaging paths — Unix, Windows, and the FreeBSD cross-build. (There were three, not the two I first assumed.)

## Verified on the actual artifact

| | Result |
| --- | --- |
| pristine 0.597.0 release | `fatal error: 'libaether.h' file not found` |
| same release + only that one line | **builds a working ELF** |

## The test asserts the contract, not a filename

Every packaging block that ships the runtime source must also stage `include/*.h`, so a **new target** cannot omit it silently — and a new public header cannot go missing the same way.

**Proven to fail**: dropping the line from one of the three blocks reddens it with the 3-vs-2 count.

Also: `make test` 394/0, `check-docs` clean.

With this, all four cross-build asks from the aeb line are closed — win-arm64 lzf, FreeBSD sysroot, linux-musl, and now the release bundle blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)