### PR TITLE
perf(http): reuse the request head, pin the loop clock, and make the benchmark fair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **A proxied request's head is built into a buffer the connection keeps.** It
+  was allocated through the memory cap and released again for every request.
+  A `perf -e page-faults` trace put **89% of the faults this path still takes**
+  on that one allocation, which is the last load-independent difference against
+  nginx: 0.05 faults per request against its 0.00.
+
+  Every head on a connection is about the same size, so after the first there
+  is nothing to allocate. Moving the buffer's lifetime from a request to a
+  connection means the cap's accounting follows it, or a long-lived connection
+  drifts upward until the cap refuses allocations the machine has memory for.
+
+  This landed once before and was lost in a merge; the trace found it again by
+  naming the allocation rather than by anyone noticing the code had gone.
+
+### Testing
+
+- The benchmark's controls now add the same four forwarded headers the aether
+  balancer does. It adds `X-Forwarded-For`, `X-Forwarded-Proto`,
+  `X-Forwarded-Host` and `Via` to every request and the controls added none of
+  them, so every CPU-per-request figure taken before this compared one side
+  building four headers with two forwarding as-is. That is the configuration
+  being measured, not the code.
+
+
 ## [0.613.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ version number before tagging the release.
   them, so every CPU-per-request figure taken before this compared one side
   building four headers with two forwarding as-is. That is the configuration
   being measured, not the code.
+- **A driver pins the clock for one pass of its event loop.** It reads the
+  clock several times per request -- arming a deadline, computing the next
+  timeout, expiring idle pooled connections, recording when an upstream was
+  picked -- and each read is a counter the kernel serialises. On a single core
+  `arch_counter_get_cntvct` was **4.9% of this path's profile**, the largest
+  entry that is not TCP receive processing.
+
+  Within one pass those readers do not need different answers: the pass takes
+  microseconds and every deadline they compare against is milliseconds or
+  seconds away. The clock is pinned after the wait and released before the
+  next one, so a poll that blocks for its timeout cannot leave the pass reading
+  a time from before it.
+
+  **CPU per request 14.2 to 12.7 microseconds** on a single core, better in
+  seven of eight rank-matched rounds.
+
+  This was written once, measured at exactly zero on a two-core configuration,
+  and reverted. The profile said 4.9% and the profile was right: with two
+  driver threads the reads overlap other work, and on one core they are on the
+  critical path. The lesson is about where a change is measured, not whether
+  it was worth making.
 
 
 ## [0.613.0]

--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh profile.sh syscalls.sh workers.sh switches.sh instructions.sh split.sh threads.sh tls.sh use_mounted.sh backends.conf nginx-lb.conf nginx-lb-tls.conf haproxy-lb.cfg ./
+COPY run.sh profile.sh syscalls.sh workers.sh switches.sh instructions.sh split.sh threads.sh tls.sh faults.sh use_mounted.sh backends.conf nginx-lb.conf nginx-lb-tls.conf haproxy-lb.cfg ./
 RUN chmod +x run.sh profile.sh syscalls.sh workers.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -22,6 +22,13 @@ another number from the same run.
 
 ## The instruments
 
+All three balancers are configured to do the same job, which took a correction:
+the aether one adds `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`
+and `Via` to every forwarded request and the controls originally added none of
+them. A comparison where one side builds four headers and the others forward
+as-is measures the configuration, not the code. The controls now add the same
+four.
+
 | script | measures | use it when |
 |---|---|---|
 | `run.sh` | rps and CPU per request, with controls | judging a result |

--- a/benchmarks/http/lbbench/faults.sh
+++ b/benchmarks/http/lbbench/faults.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Which allocations still fault a page in.
+#
+# Page faults per request are the last load-independent difference left
+# against nginx: 0.05 against its 0.00, with the kernel zeroing those pages
+# costing about 4% of the profile. A fault is not slow because a malloc is
+# slow; it is the kernel handing back a page and taking it again. This says
+# which allocation is doing that, the same way the trace that found the
+# request arena did.
+set -uo pipefail
+
+. /bench/use_mounted.sh
+lbbench_use_mounted faults.sh "$@"
+
+DURATION="${DURATION:-15}"
+CONNECTIONS="${CONNECTIONS:-50}"
+GEN_CPUS="${GEN_CPUS:-0,1}"
+LB_CPUS="${LB_CPUS:-2,3}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+PERF=$(ls /usr/lib/linux-tools-*/perf 2>/dev/null | head -1)
+[ -n "$PERF" ] || PERF=$(command -v perf)
+[ -n "$PERF" ] || die "perf not installed in the image"
+sysctl -w kernel.perf_event_paranoid=1 >/dev/null 2>&1 || true
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+say "building aether ..."
+cp -r /src /build && cd /build && rm -rf build
+make -j"$(nproc)" >/tmp/build.log 2>&1 || { tail -20 /tmp/build.log >&2; die "build failed"; }
+./build/ae build benchmarks/http/lb_reuse_lb.ae -o /tmp/ae-lb >/tmp/lbbuild.log 2>&1 \
+    || { tail -20 /tmp/lbbuild.log >&2; die "lb build failed"; }
+
+BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+    taskset -c "$LB_CPUS" /tmp/ae-lb >/tmp/ae-lb.log 2>&1 &
+LB=$!
+for _ in $(seq 1 40); do
+    body=$(curl -sf -m 5 http://127.0.0.1:18200/ 2>/dev/null) && case "$body" in backend-*) break ;; esac
+    sleep 0.25
+done
+curl -sf -m 5 http://127.0.0.1:18200/ >/dev/null || die "balancer is not proxying"
+
+# Warm first: start-up faults are not the ones being looked for.
+taskset -c "$GEN_CPUS" wrk -t2 -c"$CONNECTIONS" -d10s http://127.0.0.1:18200/ >/dev/null 2>&1
+
+taskset -c "$GEN_CPUS" wrk -t2 -c"$CONNECTIONS" -d"${DURATION}s" \
+    http://127.0.0.1:18200/ >/tmp/wrk.out 2>&1 &
+WRK=$!
+"$PERF" record -e page-faults -g --pid "$LB" -o /tmp/pf.data -- sleep "$DURATION" >/dev/null 2>&1
+wait "$WRK" 2>/dev/null
+kill "$LB" 2>/dev/null
+
+awk '/Requests\/sec/ {print "  during the trace: " $2 " rps"}' /tmp/wrk.out >&2
+say ""
+say "== page faults, by the balancer's own frames =="
+# The leaf is almost always inside libc and often has no symbol, which says
+# nothing: what matters is which of our allocations led to it. --children
+# attributes a fault to every frame on the way down, so our own function names
+# appear even when the page was taken by memset inside malloc.
+"$PERF" report -i /tmp/pf.data --stdio --children --percent-limit 1 --comms=ae-lb 2>/dev/null \
+    | grep -E '^\s+[0-9]+\.[0-9]+%' | grep -E 'ae-lb\s+ae-lb|\[\.\] [a-z_]+' | head -20
+say ""
+say "== and the raw leaves, for completeness =="
+"$PERF" report -i /tmp/pf.data --stdio --no-children --percent-limit 1 2>/dev/null \
+    | grep -E '^\s+[0-9]+\.[0-9]+%' | head -8

--- a/benchmarks/http/lbbench/haproxy-lb.cfg
+++ b/benchmarks/http/lbbench/haproxy-lb.cfg
@@ -15,5 +15,13 @@ frontend fe
     default_backend be
 backend be
     balance roundrobin
+    # Same four headers the aether balancer adds to every forwarded request,
+    # for the same reason they were added to the nginx config: otherwise the
+    # comparison is between one side building headers and another forwarding
+    # as-is, which measures the configuration rather than the code.
+    option forwardfor
+    http-request set-header X-Forwarded-Proto http
+    http-request set-header X-Forwarded-Host %[req.hdr(Host)]
+    http-request set-header Via "1.1 haproxy"
     server b1 127.0.0.1:19001
     server b2 127.0.0.1:19002

--- a/benchmarks/http/lbbench/nginx-lb-tls.conf
+++ b/benchmarks/http/lbbench/nginx-lb-tls.conf
@@ -23,6 +23,14 @@ http {
             proxy_pass http://be;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
+            # The aether balancer adds these to every forwarded request, and
+            # a comparison where one side builds four headers and the other
+            # forwards as-is measures the configuration, not the code. This is
+            # also what a real nginx in front of a service is set up to do.
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Via               "1.1 nginx";
         }
     }
 }

--- a/benchmarks/http/lbbench/nginx-lb.conf
+++ b/benchmarks/http/lbbench/nginx-lb.conf
@@ -20,6 +20,14 @@ http {
             proxy_pass http://be;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
+            # The aether balancer adds these to every forwarded request, and
+            # a comparison where one side builds four headers and the other
+            # forwards as-is measures the configuration, not the code. This is
+            # also what a real nginx in front of a service is set up to do.
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Via               "1.1 nginx";
         }
     }
 }

--- a/std/http/proxy/aether_proxy_pool.c
+++ b/std/http/proxy/aether_proxy_pool.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <time.h>
 #include "../../../runtime/utils/aether_thread.h"
+#include "../../net/aether_http.h"
 
 /* ----- helpers exposed to other proxy .c files ----- */
 
@@ -27,7 +28,7 @@ long aether_proxy_now_ms(void) {
     /* Only differences matter here (health-check and breaker timings).
      * Delegates to the shared monotonic clock so Windows uses the
      * overflow-free QueryPerformanceCounter split in one place. */
-    return (long)(aether_now_ns() / 1000000ULL);
+    return (long)http_clock_ms();
 }
 
 /* ----- LB algo string mapping ----- */

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -1953,12 +1953,34 @@ static int http_response_is_complete(HttpRespFraming* f, char* buf, size_t len,
 
 char* http_build_request_head(const HttpReqHead* p,
                                      size_t* out_len, size_t* out_cap) {
-    size_t hdr_cap = 1024;
-    /* #461: gate the request-header build buffer through the cap. Self-
-     * contained — alloc, grow, and free all live in this function with
-     * hdr_cap tracking the live size, so accounting balances exactly. */
-    char* hdr = (char*)aether_caps_malloc(hdr_cap);
-    if (!hdr) return NULL;
+    char*  buf = NULL;
+    size_t cap = 0;
+    char*  r = http_build_request_head_into(p, &buf, &cap, out_len);
+    if (out_cap) *out_cap = cap;
+    return r;
+}
+
+/* The same builder, over a buffer the caller keeps.
+ *
+ * A connection serving many requests built this head into a fresh allocation
+ * every time and released it a moment later. The head of one request is the
+ * same size as the head of the next, so after the first there is nothing to
+ * allocate: the buffer is reused at whatever size it reached.
+ *
+ * `*buf` is NULL on the first call and the caller's afterwards, released with
+ * aether_caps_free and `*cap` when the connection ends -- through the cap,
+ * because that is how it was taken. */
+char* http_build_request_head_into(const HttpReqHead* p,
+                                     char** io_buf, size_t* io_cap,
+                                     size_t* out_len) {
+    size_t hdr_cap = *io_cap;
+    char*  hdr     = *io_buf;
+    if (!hdr) {
+        hdr_cap = 1024;
+        /* #461: gate the request-header build buffer through the cap. */
+        hdr = (char*)aether_caps_malloc(hdr_cap);
+        if (!hdr) return NULL;
+    }
     size_t hdr_len = 0;
 
     /* Helper: append a NUL-terminated string into hdr, growing as
@@ -1969,7 +1991,8 @@ char* http_build_request_head(const HttpReqHead* p,
             size_t _nc = hdr_cap; \
             while (_nc < hdr_len + _slen + 1) _nc *= 2; \
             char* _nh = (char*)aether_caps_realloc(hdr, hdr_cap, _nc); \
-            if (!_nh) { aether_caps_free(hdr, hdr_cap); return NULL; } \
+            if (!_nh) { aether_caps_free(hdr, hdr_cap); \
+                        *io_buf = NULL; *io_cap = 0; return NULL; } \
             hdr = _nh; hdr_cap = _nc; \
         } \
         memcpy(hdr + hdr_len, s, _slen); \
@@ -2051,7 +2074,10 @@ char* http_build_request_head(const HttpReqHead* p,
     #undef HDR_APPEND_STR
 
     *out_len = hdr_len;
-    *out_cap = hdr_cap;
+    /* The buffer goes back to the caller at whatever size it reached, so the
+     * next request on this connection builds into it without allocating. */
+    *io_buf = hdr;
+    *io_cap = hdr_cap;
     return hdr;
 }
 

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -45,6 +45,7 @@ const char* http_response_read_chunk_raw(HttpResponse* r, int max) { (void)r; (v
 #include <stdatomic.h>
 #include <time.h>
 #include "../../runtime/utils/aether_thread.h"
+#include "../../runtime/utils/aether_compiler.h"
 #include <limits.h>
 #if !defined(_WIN32)
 #include <sys/resource.h>
@@ -420,14 +421,39 @@ static int64_t         http_pool_idle_ms = 15000;
  * never a missed expiry. */
 static int64_t         http_pool_next_expiry_ms = INT64_MAX;
 
-static int64_t http_now_ms(void) {
-    struct timespec ts;
-#if defined(CLOCK_MONOTONIC)
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
-        return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-#endif
-    return (int64_t)time(NULL) * 1000;
+/* A millisecond clock pinned for one pass of an event loop.
+ *
+ * A driver reads the clock several times per request: arming a deadline,
+ * computing the next timeout, expiring idle pooled connections, recording when
+ * an upstream was picked. Each read is a counter the kernel serialises, and on
+ * a single core arch_counter_get_cntvct is 4.9% of this path's profile -- the
+ * largest entry that is not TCP receive processing.
+ *
+ * Within one pass those readers do not need different answers: the pass takes
+ * microseconds and every deadline they compare against is milliseconds or
+ * seconds away. So the driver pins one value for the pass and they share it.
+ *
+ * Defined here rather than in a header because a static thread-local in a
+ * header is a separate variable per translation unit, and the thread that pins
+ * it is not in the file that reads it. A thread that never pins reads the real
+ * clock, which is every thread but a driver. */
+AETHER_TLS_SHARED uint64_t aether_http_pinned_ms = 0;
+
+void http_clock_pin(void) {
+    uint64_t ms = aether_now_ns() / 1000000ULL;
+    /* Zero means "not pinned", so a clock reading exactly zero pins a
+     * millisecond later rather than not at all. */
+    aether_http_pinned_ms = ms ? ms : 1;
 }
+
+void http_clock_unpin(void) { aether_http_pinned_ms = 0; }
+
+uint64_t http_clock_ms(void) {
+    return aether_http_pinned_ms ? aether_http_pinned_ms
+                                 : (aether_now_ns() / 1000000ULL);
+}
+
+static int64_t http_now_ms(void) { return (int64_t)http_clock_ms(); }
 
 /* Everything that makes two connections non-interchangeable: the origin, the
  * endpoint actually dialled (proxy or origin), TLS, and the verification the

--- a/std/net/aether_http.h
+++ b/std/net/aether_http.h
@@ -83,6 +83,14 @@ void http_response_free(HttpResponse* response);
  * connections are held for the length of a request and returned, not kept for
  * a handful of hosts. Sized from the descriptor budget; only ever raises, so
  * a deliberate configuration is preserved. */
+/* A millisecond clock a driver may pin for one pass of its event loop, so the
+ * several readers in a request share one counter access. Pin AFTER waiting: a
+ * poll that blocks for its timeout would otherwise leave the pass looking at a
+ * time from before it. A thread that never pins reads the real clock. */
+void     http_clock_pin(void);
+void     http_clock_unpin(void);
+uint64_t http_clock_ms(void);
+
 void http_client_pool_size_for_proxy(void);
 
 /* The pool's current caps. */

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -1142,6 +1142,12 @@ static void* ev_driver_main(void* arg) {
          * visible. */
         int n = aether_io_poller_poll(&d->poller, events, 64,
                                       ev_next_timeout_ms(d, 200));
+
+        /* Pin the clock for this pass, after the wait and not before: the poll
+         * above can block for its whole timeout. Everything below then shares
+         * one counter access rather than taking one to arm each deadline,
+         * expire each idle pooled connection and record each upstream pick. */
+        http_clock_pin();
         for (int i = 0; i < n; i++) {
             int fd = events[i].fd;
             if (fd == d->wake_r) { ev_take_submissions(d); continue; }
@@ -1158,6 +1164,10 @@ static void* ev_driver_main(void* arg) {
             if (r < 0) { ev_conn_close(d, c); continue; }
             if (ev_advance(d, c) < 0) ev_conn_close(d, c);
         }
+
+        /* Released before waiting again, so the next wait's timeout is
+         * computed from the real clock rather than from this pass's. */
+        http_clock_unpin();
     }
 
     /* Shutting down: the connections this driver owns are its to close. */

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -226,9 +226,10 @@ static void ev_conn_reset_request(EvConn* c) {
     c->in_scanned = 0;
     c->in_hdr_end = 0;
 
-    if (c->head) aether_caps_free(c->head, c->head_cap);
-    c->head = NULL;
-    c->head_len = c->head_cap = 0;
+    /* The head buffer stays with the connection and is only grown. Every
+     * request on it builds a head of about the same size, so after the first
+     * there is nothing to allocate. */
+    c->head_len = 0;
 
     /* Keep the accumulator rather than returning it; the next request on this
      * connection reuses it at whatever size it has grown to. */
@@ -304,6 +305,7 @@ static void ev_conn_close(EvDriver* d, EvConn* c) {
         c->ssl = NULL;
     }
 #endif
+    if (c->head) aether_caps_free(c->head, c->head_cap);
     free(c->out);
     free(c->in);
     free(c);
@@ -747,21 +749,18 @@ static int ev_begin_retry(EvDriver* d, EvConn* c) {
 
     int body_len = 0;
     const char* body = http_request_body_of(c->px.outbound, &body_len);
-    /* Freed through the cap, because it was allocated through it. A plain
-     * free() returns the memory but leaves the accounting counter believing
-     * the bytes are still live, and this is the retry path: it runs when an
-     * upstream is failing, so the drift accumulates fastest exactly when the
-     * proxy is already under strain, until the cap refuses allocations that
-     * the machine has memory for. */
-    aether_caps_free(c->head, c->head_cap);
-    c->head = NULL;
-    c->head_len = c->head_cap = 0;
+    /* Rebuilt in place rather than released and taken again. The buffer
+     * belongs to the connection now, and is returned through the cap when the
+     * connection ends -- which is what the accounting requires, and what a
+     * plain free() here used to get wrong. */
+    c->head_len = 0;
     HttpReqHead head_params = {
         c->px.outbound, http_request_method_of(c->px.outbound), path,
         host, port, 0, 0, body, body_len,
         http_request_content_type_of(c->px.outbound), 1
     };
-    c->head = http_build_request_head(&head_params, &c->head_len, &c->head_cap);
+    c->head = http_build_request_head_into(&head_params, &c->head, &c->head_cap,
+                                           &c->head_len);
     if (!c->head) return -1;
 
     memset(&c->x, 0, sizeof(c->x));
@@ -915,7 +914,8 @@ static int ev_begin_upstream(EvDriver* d, EvConn* c) {
         host, port, 0, 0, body, body_len,
         http_request_content_type_of(c->px.outbound), 1
     };
-    c->head = http_build_request_head(&head_params, &c->head_len, &c->head_cap);
+    c->head = http_build_request_head_into(&head_params, &c->head, &c->head_cap,
+                                           &c->head_len);
     if (!c->head) return -1;
 
     http_exchange_init(&c->x, &c->up.t, c->head, c->head_len, body, body_len,

--- a/std/net/aether_http_internal.h
+++ b/std/net/aether_http_internal.h
@@ -135,6 +135,13 @@ typedef struct {
 
 char* http_build_request_head(const HttpReqHead* p, size_t* out_len, size_t* out_cap);
 
+/* The same builder over a buffer the caller keeps, so a connection serving
+ * many requests allocates one head and reuses it. `*buf` is NULL on the first
+ * call and the caller's afterwards; release it with aether_caps_free and
+ * `*cap` when the connection ends, because that is how it was taken. */
+char* http_build_request_head_into(const HttpReqHead* p,
+                                   char** buf, size_t* cap, size_t* out_len);
+
 
 /* A bump allocator for building one outbound request.
  *

--- a/tests/runtime/test_runtime_http.c
+++ b/tests/runtime/test_runtime_http.c
@@ -418,3 +418,40 @@ TEST_CATEGORY(http_request_head_reuse_is_accounted, TEST_CATEGORY_NETWORK) {
     http_request_free_raw(req);
 }
 #endif  /* !_WIN32 */
+
+#if !defined(_WIN32)
+/* A driver pins the clock for one pass of its loop so the several readers in a
+ * request share one counter access. The contract is narrow and worth stating:
+ * pinned, everyone sees the same millisecond; unpinned, everyone sees the real
+ * clock; and pinning again takes a fresh reading. Getting the last one wrong
+ * would freeze every deadline in the process. */
+TEST_CATEGORY(http_clock_pin_contract, TEST_CATEGORY_NETWORK) {
+    http_clock_unpin();
+
+    struct timespec nap = { 0, 3 * 1000 * 1000 };   /* 3ms, clear of a tick */
+
+    /* Unpinned, it moves. */
+    uint64_t a = http_clock_ms();
+    nanosleep(&nap, NULL);
+    uint64_t b = http_clock_ms();
+    ASSERT_TRUE(b > a);
+
+    /* Pinned, it does not, however long the pass takes. */
+    http_clock_pin();
+    uint64_t p1 = http_clock_ms();
+    nanosleep(&nap, NULL);
+    ASSERT_EQ(p1, http_clock_ms());
+    ASSERT_TRUE(p1 >= b);
+
+    /* Pinning again reads afresh: a loop that never advanced its pinned clock
+     * would never time anything out. */
+    http_clock_pin();
+    ASSERT_TRUE(http_clock_ms() > p1);
+
+    /* And releasing it goes back to the real clock. */
+    http_clock_unpin();
+    uint64_t c = http_clock_ms();
+    nanosleep(&nap, NULL);
+    ASSERT_TRUE(http_clock_ms() > c);
+}
+#endif  /* !_WIN32 */

--- a/tests/runtime/test_runtime_http.c
+++ b/tests/runtime/test_runtime_http.c
@@ -373,3 +373,48 @@ TEST_CATEGORY(http_proxy_direct_head_bytes, TEST_CATEGORY_NETWORK) {
     free(h);
 }
 #endif  /* !_WIN32 */
+
+#if !defined(_WIN32)
+/* A connection builds a request head per request. It used to take a fresh
+ * allocation each time and release it a moment later; it now reuses one
+ * buffer, released when the connection ends.
+ *
+ * That moves the buffer's lifetime from a request to a connection, and the
+ * cap's accounting has to follow: a build that reused the buffer must not
+ * account for it again, or a long-lived connection drifts upward until the
+ * cap refuses allocations the machine has memory for. */
+TEST_CATEGORY(http_request_head_reuse_is_accounted, TEST_CATEGORY_NETWORK) {
+    HttpClientRequest* req = http_request_raw("GET", "http://127.0.0.1:1/x");
+    ASSERT_NOT_NULL(req);
+
+    uint64_t base = aether_caps_used_bytes();
+
+    char*  buf = NULL;
+    size_t cap = 0, len = 0;
+    HttpReqHead p = { req, "GET", "/x", "127.0.0.1", 80, 0, 0, NULL, 0, NULL, 1 };
+
+    ASSERT_NOT_NULL(http_build_request_head_into(&p, &buf, &cap, &len));
+    uint64_t after_first = aether_caps_used_bytes();
+    ASSERT_TRUE(after_first > base);
+    char*  first_buf = buf;
+    size_t first_cap = cap;
+    size_t first_len = len;
+
+    /* Many more builds into the same buffer: same pointer, same capacity,
+     * same accounted total. Nothing new is taken. */
+    for (int i = 0; i < 64; i++) {
+        ASSERT_NOT_NULL(http_build_request_head_into(&p, &buf, &cap, &len));
+        ASSERT_TRUE(buf == first_buf);
+        ASSERT_EQ((int)first_cap, (int)cap);
+        ASSERT_EQ((int)first_len, (int)len);   /* and it rebuilds, not appends */
+    }
+    ASSERT_EQ(after_first, aether_caps_used_bytes());
+
+    /* One release, with the capacity the buffer actually reached, returns the
+     * counter exactly. */
+    aether_caps_free(buf, cap);
+    ASSERT_EQ(base, aether_caps_used_bytes());
+
+    http_request_free_raw(req);
+}
+#endif  /* !_WIN32 */


### PR DESCRIPTION
Two things, both found by measurement rather than by reading code.

## The benchmark was not comparing like with like

The aether balancer adds `X-Forwarded-For` (including a lookup of any prior
value), `X-Forwarded-Proto`, `X-Forwarded-Host` and `Via` to every forwarded
request. The nginx and haproxy configs added **none of them**.

So every CPU-per-request figure taken before this compared one side building
four headers against two forwarding as-is. That measures the configuration, not
the code. Both controls now do the same job, which is also how they are
configured in front of a real service.

With that corrected, on ten rounds:

| | CPU/req | rps |
|---|---:|---:|
| nginx | 8.3 us | 115,520 |
| haproxy | 13.5 us | 144,707 |
| **aether** | **13.9 us** | **142,685** |

**3% behind haproxy on CPU and 1% on throughput** — where the same comparison
before the correction read 8%.

## 89% of the remaining page faults were one allocation

Page faults per request are the last load-independent difference against nginx:
0.05 against its 0.00, with the kernel zeroing those pages costing about 4% of
the profile. A `perf -e page-faults` trace attributed **89.13%** of them to
`http_build_request_head` → `aether_caps_malloc`: a fresh allocation for every
request.

Every head on a connection is about the same size, so after the first there is
nothing to allocate. The buffer now belongs to the connection and is only
grown.

Moving its lifetime from a request to a connection means the cap's accounting
has to follow, or a long-lived connection drifts upward until the cap refuses
allocations the machine has memory for — the failure #1810 fixed on the retry
path. The test asserts it: sixty-four builds into one buffer give the same
pointer, capacity and accounted total, and one release returns the counter
exactly. It fails against a build that never reuses, and against one that
appends instead of rebuilding.

**This landed once before and was lost in a merge.** The trace found it again
by naming the allocation, not because anyone noticed the code had gone — which
is a reasonable argument for tracing over remembering.

## Checks

- 402 unit tests
- reverse-proxy 12/12, pool 9/9, pool_extra 8/8, equivalence 5/5, TLS proxy
  4/4, client-disconnect
- zero warnings

Refs #1758


---

## Also here: the clock is pinned for one pass of the event loop

A driver reads the clock several times per request -- arming a deadline,
computing the next timeout, expiring idle pooled connections, recording when an
upstream was picked -- and each read is a counter the kernel serialises. On a
single core `arch_counter_get_cntvct` was **4.9% of this path's profile**, the
largest entry that is not TCP receive processing.

| single core | main | this PR |
|---|---:|---:|
| CPU/req, least-contended | 14.2 us | **12.7 us** |

Better in seven of eight rank-matched rounds.

**I wrote this once before, measured it at exactly zero, and reverted it.** That
A/B ran on two cores, where the reads overlap other work; on one core they are
on the critical path. The profile was right and the configuration I measured in
was wrong, which is worth recording because the change itself never changed.

The clock is pinned *after* the wait and released before the next one, so a
poll that blocks for its whole timeout cannot leave the pass reading a time from
before it. It lives in a translation unit rather than a header, because a
static thread-local in a header is a separate variable per translation unit and
the thread that pins it is not in the file that reads it.

Pinned by a test: pinned, every reader sees the same millisecond; pinning again
reads afresh, because a loop that never advanced its pinned clock would never
time anything out; unpinned, the real clock. It fails against a pin that does
not refresh.

## Where this leaves it, on one core each

    nginx     9.5 us/req
    haproxy  10.1 us/req
    aether   12.7 us/req     (13.6 before these two changes)

The single-core comparison is the honest one: haproxy's threading costs it
(13.5 to 10.1 going from two threads to one) while this path's cost is the same
either way, so the two-thread comparison flattered us.
