### PR TITLE
String interpolation checks its operands' kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **String interpolation now checks the kind of each operand.** `"${expr}"`
+  accepted any type — the typechecker walked the operands and discarded the
+  result — so codegen emitted a `%s`-shaped read of whatever bits arrived. The
+  serious case was a bare zero-arg function name: `${cmd}` rendered the
+  function's *address* as a string, and since those bytes are an x86 prologue
+  the result looked like `UH‰åSH‰û…`. It surfaced in the wild only when such a
+  string reached `/bin/sh`, which makes it memory disclosure rather than a
+  formatting wart — and it was silent, where the same mistake in `x = cmd` at
+  least produced a C warning. `${struct}` silently printed the first field.
+
+  Both are now compile errors that name the fix (`${cmd}` →
+  *"Did you mean `${cmd()}`?"*). Interpolation nodes also carry a real source
+  position for the first time: they were created at line 0, so a diagnostic
+  fell back to the operand's own node and pointed at where a function was
+  *declared* rather than the string that misuses it.
+
+  The check is a whitelist of renderable kinds, so a type added to the
+  language later cannot silently join the garbage list. `ptr` and tuple
+  operands are deliberately admitted — 21 in-tree sites interpolate a `ptr`
+  that genuinely holds a `char*`, and a single-bound tuple (`x = f()` where
+  `f` returns a pair) binds the first element correctly while the slot keeps
+  the tuple type. Narrowing either needs its own change: a conversion for
+  `ptr` callers to move to, and an inference fix for the tuple case.
+
 ## [0.614.0]
 
 ### Changed

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -538,6 +538,129 @@ void type_error(const char* message, int line, int column) {
 
 void type_warning(const char* message, int line, int column);
 
+/* ---- string-interpolation operand check -------------------------------
+ *
+ * `"${expr}"` used to accept ANY type: the typechecker walked the operands
+ * and discarded the result, so codegen emitted a `%s`-shaped read of whatever
+ * bits arrived. Three kinds produced garbage instead of a diagnostic:
+ *
+ *   ${zero_arg_fn}  -> the function's ADDRESS read as a string. The bytes are
+ *                      an x86 prologue ("UH\x89\xe5..."), and this was found
+ *                      in the wild only when such a string reached /bin/sh --
+ *                      i.e. it is memory disclosure, not a formatting wart.
+ *   ${struct_value} -> silently printed the first field.
+ *   ${bytes_handle} -> read the handle as a char*, printing nothing.
+ *
+ * The check is a WHITELIST of renderable kinds, not a blocklist of bad ones:
+ * a blocklist lets the next type added to the language silently join the
+ * garbage list, which is how this shipped in the first place.
+ *
+ * TYPE_TUPLE is admitted because the type is often simply WRONG rather than
+ * the value being un-renderable. `x = f()` where f returns `(int, string)`
+ * binds the FIRST element -- verified: it prints 42, not a tuple -- but the
+ * slot keeps the tuple type. Rejecting it flagged a working example in
+ * std/tcp/README.md. Fixing that inference is a separate change; until then a
+ * tuple operand is far more likely to be a correctly-bound scalar than a real
+ * attempt to render a tuple.
+ *
+ * TYPE_PTR is admitted despite being the `${bytes_handle}` case above, and
+ * that is a deliberate scope decision rather than an oversight. Interpolating
+ * a `ptr` is an established idiom here: 21 sites across std/, contrib/,
+ * examples/ and tests/ do it -- including std/spec and every std.map consumer
+ * -- because map/pqueue/schema return `ptr` for values that really are
+ * `char*`, and those render correctly today. Rejecting them would break
+ * working code, and there is no sanctioned replacement to migrate to (a
+ * `ptr`-to-string binding does not currently compile). Narrowing this is its
+ * own change: it needs a conversion for callers to move to, and a sweep of
+ * those 21 sites. Filed rather than smuggled in behind a bug fix.
+ */
+static int interp_kind_is_renderable(TypeKind k) {
+    switch (k) {
+        case TYPE_INT: case TYPE_INT64: case TYPE_UINT64:
+        case TYPE_UINT32: case TYPE_UINT16: case TYPE_UINT8:
+        case TYPE_BYTE: case TYPE_BOOL:
+        case TYPE_FLOAT: case TYPE_FLOAT32: case TYPE_LONGDOUBLE:
+        case TYPE_DURATION:
+        case TYPE_STRING:
+        case TYPE_ENUM:      /* integer-backed; renders as its numeric value */
+        case TYPE_UNKNOWN:   /* inference already failed and reported */
+        case TYPE_PTR:       /* see below -- deliberately admitted */
+        case TYPE_TUPLE:     /* see below -- deliberately admitted */
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+/* Reject an un-renderable operand, naming the fix. The message matters more
+ * than the rejection: each of these has an obvious intended spelling, and
+ * saying it turns a silent wrong answer into a one-line correction.
+ *
+ * fb_line/fb_col are the enclosing interpolation's position. Prefer them: an
+ * identifier inside `${...}` carries the position of the DECLARATION it
+ * resolves to, so reporting the child's own line sent the reader to where the
+ * function was defined rather than to the string that misuses it. */
+static void check_interp_operand(ASTNode* child, SymbolTable* table,
+                                 int fb_line, int fb_col) {
+    if (!child) return;
+    if (child->type == AST_LITERAL) return;   /* the literal text segments */
+
+    int line = fb_line > 0 ? fb_line : child->line;
+    int col  = fb_line > 0 ? fb_col  : child->column;
+
+    /* A bare reference to a function. Caught by NAME before consulting the
+     * inferred type, because a bare function identifier infers as its RETURN
+     * type -- so `${cmd}` looks like a perfectly good string here -- and
+     * "did you mean cmd()?" is the whole value of the diagnostic. */
+    if (child->type == AST_IDENTIFIER && child->value) {
+        Symbol* sym = lookup_symbol(table, child->value);
+        if (sym && sym->is_function) {
+            char msg[320];
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate '%s': it is a function, so `${%s}` renders "
+                "its ADDRESS, not a value. Did you mean `${%s()}`?",
+                child->value, child->value, child->value);
+            type_error(msg, line, col);
+            return;
+        }
+    }
+
+    Type* t = child->node_type;
+    if (!t || interp_kind_is_renderable(t->kind)) return;
+
+    char msg[320];
+    switch (t->kind) {
+        case TYPE_STRUCT:
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate a struct%s%s: interpolate a field instead, "
+                "e.g. `${value.field}`",
+                t->struct_name ? " " : "", t->struct_name ? t->struct_name : "");
+            break;
+        case TYPE_ARRAY:
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate an array: interpolate an element, "
+                "e.g. `${a[0]}`");
+            break;
+        case TYPE_FUNCTION:
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate a function value: `${f}` renders its "
+                "address. Call it (`${f()}`) to interpolate its result");
+            break;
+        case TYPE_VOID:
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate a void value: this expression returns "
+                "nothing to render");
+            break;
+        default:
+            snprintf(msg, sizeof(msg),
+                "cannot interpolate this value: its type has no string "
+                "rendering");
+            break;
+    }
+    type_error(msg, line, col);
+}
+
+
 /* #1140 — can this function signal failure to its caller? True for Aether's
  * Go-style `(value, err)` convention (a tuple whose last element is the error
  * string) and hence for `T!`, which is represented as exactly that tuple with
@@ -6782,9 +6905,16 @@ int typecheck_expression(ASTNode* expr, SymbolTable* table) {
             return 1;
 
         case AST_STRING_INTERP:
-            // Type check all sub-expressions inside the interpolation
+            /* Type check each sub-expression, then check it is a KIND that
+             * can actually be rendered -- see check_interp_operand.
+             *
+             * NB a diagnostic from here prints more than once. That is
+             * pre-existing and general (an unrelated `as *Missing` error
+             * repeats identically), not something this check introduces. */
             for (int i = 0; i < expr->child_count; i++) {
                 typecheck_expression(expr->children[i], table);
+                check_interp_operand(expr->children[i], table,
+                                     expr->line, expr->column);
             }
             set_node_type(expr, create_type(TYPE_STRING));
             return 1;

--- a/compiler/analysis/typechecker.c
+++ b/compiler/analysis/typechecker.c
@@ -625,6 +625,15 @@ static void check_interp_operand(ASTNode* child, SymbolTable* table,
         }
     }
 
+    /* Stay quiet once something else has already failed. A cascading
+     * diagnostic on a broken parse or a failed inference is worse than
+     * silence: tests/integration/tuple_through_fn/bare_fn.ae is a deliberate
+     * negative fixture whose whole point is that a bare `fn` parameter gets
+     * ONE targeted hint and no follow-on noise, and without this guard the
+     * destructured string `e2` there was reported as a function value --
+     * true of its (bogus) inferred type, misleading about the code. */
+    if (error_count > 0) return;
+
     Type* t = child->node_type;
     if (!t || interp_kind_is_renderable(t->kind)) return;
 

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -837,8 +837,12 @@ static Type* parse_type_unsuffixed(Parser* parser) {
 // Returns AST_STRING_INTERP with alternating children:
 //   - AST_LITERAL (TYPE_STRING) for literal text segments
 //   - expression nodes for ${...} parts
-static ASTNode* parse_interp_string_expr(const char* raw) {
-    ASTNode* interp = create_ast_node(AST_STRING_INTERP, NULL, 0, 0);
+static ASTNode* parse_interp_string_expr(const char* raw, int line, int column) {
+    /* Carry the string's own position. It used to be created at 0,0, so any
+     * diagnostic about an interpolated expression pointed at line 0 -- or, if
+     * it fell back to the operand's node, at wherever that identifier was
+     * DECLARED rather than where it was misused. */
+    ASTNode* interp = create_ast_node(AST_STRING_INTERP, NULL, line, column);
 
     const char* p = raw;
     int lit_cap = 256;
@@ -1137,7 +1141,7 @@ ASTNode* parse_primary_expression(Parser* parser) {
 
         case TOKEN_INTERP_STRING: {
             Token* t = advance_token(parser);
-            return parse_interp_string_expr(t->value);
+            return parse_interp_string_expr(t->value, t->line, t->column);
         }
             
         // Type keywords used as namespace names: string.new(), int.parse(), etc.

--- a/tests/integration/string_interp_operand_reject/test_string_interp_operand_reject.sh
+++ b/tests/integration/string_interp_operand_reject/test_string_interp_operand_reject.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+# String interpolation checks the KIND of each operand.
+#
+# `"${expr}"` used to accept any type: the typechecker walked the operands and
+# discarded the result, so codegen emitted a `%s`-shaped read of whatever bits
+# arrived. The worst case was a bare zero-arg function name, which rendered the
+# function's ADDRESS as a string -- "UH\x89\xe5..." is an x86 prologue. That
+# surfaced in the wild only when such a string was handed to /bin/sh, i.e. it
+# is memory disclosure rather than a formatting wart, and it was silent: the
+# same mistake in `x = cmd` at least produced a C warning.
+#
+# The rejections are one half of this test. The other half matters just as
+# much: interpolation is everywhere, so a check that over-rejects breaks the
+# language. The ACCEPT cases below are sentries against exactly that.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+[ -x "$AE" ] || { echo "  [SKIP] string_interp_operand_reject: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP" || :; return 0; }
+trap cleanup EXIT
+
+pass=0
+fail=0
+
+# --- REJECT: a bare zero-arg function name (the reported bug) -------------
+cat > "$TMP/fn.ae" << 'EOF'
+cmd() -> string { return "V" }
+main() {
+    println("value is ${cmd}")
+}
+EOF
+out=$("$AE" build "$TMP/fn.ae" -o "$TMP/fn.bin" 2>&1)
+if echo "$out" | grep -q "it is a function"; then
+    echo "  [PASS] bare function name rejected"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] expected a function-interpolation diagnostic; got:"
+    echo "$out" | head -6 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# The message must name the fix. A diagnostic that says "cannot interpolate"
+# and stops leaves the reader to guess; `${cmd()}` is the whole answer.
+if echo "$out" | grep -q '\${cmd()}'; then
+    echo "  [PASS] diagnostic names the fix"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] diagnostic did not suggest \${cmd()}"
+    fail=$((fail + 1))
+fi
+
+# ...and point at the interpolation, not the declaration. A bare identifier
+# inside ${...} carries the position of the DECLARATION it resolves to, so
+# this reported line 1 (where cmd is defined) for a misuse on line 3 until the
+# parser was fixed to give interpolation nodes a real position.
+if echo "$out" | grep -q "fn.ae:3:"; then
+    echo "  [PASS] diagnostic points at the interpolation site"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] expected the error at fn.ae:3; got:"
+    echo "$out" | grep -oE 'fn\.ae:[0-9]+:[0-9]+' | head -2 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- REJECT: a struct (silently printed its first field) ------------------
+cat > "$TMP/st.ae" << 'EOF'
+struct P { x: int, y: int }
+main() {
+    p = P { x: 1, y: 2 }
+    println("point ${p}")
+}
+EOF
+out=$("$AE" build "$TMP/st.ae" -o "$TMP/st.bin" 2>&1)
+if echo "$out" | grep -q "cannot interpolate a struct"; then
+    echo "  [PASS] struct rejected"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] expected a struct-interpolation diagnostic; got:"
+    echo "$out" | head -6 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- ACCEPT: every renderable kind ----------------------------------------
+# The sentry. Interpolation is used constantly, so over-rejection is a worse
+# failure than the bug being fixed -- and the first version of this check did
+# over-reject, breaking std/pqueue and std/schema.
+cat > "$TMP/ok.ae" << 'EOF'
+cmd() -> string { return "V" }
+main() {
+    n = 42
+    s = "str"
+    f = 1.5
+    b = 1 == 1
+    println("int ${n} str ${s} float ${f} bool ${b} call ${cmd()} expr ${n + 1}")
+}
+EOF
+if out=$("$AE" build "$TMP/ok.ae" -o "$TMP/ok.bin" 2>&1) && "$TMP/ok.bin" >"$TMP/ok.out" 2>&1; then
+    if grep -q "int 42 str str float 1.5 bool true call V expr 43" "$TMP/ok.out"; then
+        echo "  [PASS] all renderable kinds still interpolate"
+        pass=$((pass + 1))
+    else
+        echo "  [FAIL] renderable kinds produced wrong output:"
+        sed 's/^/    /' "$TMP/ok.out"
+        fail=$((fail + 1))
+    fi
+else
+    echo "  [FAIL] a valid interpolation was rejected:"
+    echo "$out" | head -6 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- ACCEPT: a `ptr` --------------------------------------------------------
+# Deliberately allowed. Interpolating a ptr is an established idiom here --
+# map/pqueue/schema return `ptr` for values that really are char*, and 21
+# sites across std/, contrib/, examples/ and tests/ rely on it. Rejecting it
+# broke std/pqueue and std/schema when this check first went in, and there is
+# no sanctioned conversion to migrate those callers to. Narrowing it is its
+# own change; this sentry records the decision.
+cat > "$TMP/ptr.ae" << 'EOF'
+import std.map
+main() {
+    m = map.new()
+    map.put(m, "k", "hello")
+    v, _ = map.get(m, "k")
+    println("value ${v}")
+}
+EOF
+if "$AE" build "$TMP/ptr.ae" -o "$TMP/ptr.bin" >"$TMP/ptr.log" 2>&1; then
+    echo "  [PASS] ptr interpolation still accepted"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] ptr interpolation was rejected; that breaks 21 in-tree sites:"
+    grep -E "^error" "$TMP/ptr.log" | head -3 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- ACCEPT: a bare function name as a callback argument --------------------
+# Passing a function by name is legitimate and must stay so; only rendering
+# one into a string is not.
+cat > "$TMP/cb.ae" << 'EOF'
+handler() -> int { return 7 }
+run(f: fn() -> int) -> int { return f() }
+main() {
+    println("via callback: ${run(handler)}")
+}
+EOF
+if "$AE" build "$TMP/cb.ae" -o "$TMP/cb.bin" >"$TMP/cb.log" 2>&1; then
+    echo "  [PASS] bare function name still valid as a callback argument"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] callback argument was rejected:"
+    grep -E "^error" "$TMP/cb.log" | head -3 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+# --- ACCEPT: a single-bound tuple -------------------------------------------
+# `x = f()` where f returns (int, string) binds the FIRST element -- verified,
+# it yields 42 rather than a tuple -- but the slot keeps the tuple type.
+# Rejecting that flagged a working example in std/tcp/README.md, so the type
+# being wrong is not evidence the value is un-renderable.
+cat > "$TMP/tup.ae" << 'EOF'
+pair() -> (int, string) { return 42, "err" }
+main() {
+    single = pair()
+    println("first element ${single}")
+}
+EOF
+if "$AE" build "$TMP/tup.ae" -o "$TMP/tup.bin" >"$TMP/tup.log" 2>&1; then
+    echo "  [PASS] single-bound tuple still accepted"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] single-bound tuple rejected; that breaks std/tcp's README:"
+    grep -E "^error" "$TMP/tup.log" | head -3 | sed 's/^/    /'
+    fail=$((fail + 1))
+fi
+
+echo ""
+echo "string_interp_operand_reject: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Found by a sibling project on an Aether-using tech: a function pointer was being rendered into a string and handed to `/bin/sh`. The signature was `UH‰åSH‰û…` — an x86 prologue read as text.

## The bug

`"${expr}"` accepted **any** type. The typechecker walked the operands and discarded the result, so codegen emitted a `%s`-shaped read of whatever bits arrived.

| Form | Before |
| --- | --- |
| `${zero_arg_fn}` | the function's **address**, as a string |
| `${struct}` | silently printed the first field |
| `${fn()}`, `${int}`, `${string}`… | correct |

The function case is memory disclosure rather than a formatting wart — it only surfaced because the string reached `/bin/sh` — and it was **silent**, where the same mistake in `x = cmd` at least produced a C warning.

One correction to the original diagnosis: the sibling attributed it to *a local or param shadowing a same-named function*. I tested both shadowing forms and they work correctly. The actual trigger is a bare zero-arg function name with no shadowing involved — worth knowing, because looking for a shadowing local will find nothing.

## The fix

Both cases are now compile errors that name the fix:

```
error: cannot interpolate 'cmd': it is a function, so `${cmd}` renders its
       ADDRESS, not a value. Did you mean `${cmd()}`?
error: cannot interpolate a struct P: interpolate a field instead,
       e.g. `${value.field}`
```

Interpolation nodes also carry a real source position for the first time. `parse_interp_string_expr` created them at `0,0`, so a diagnostic fell back to the operand's node — and a bare identifier inside `${...}` holds the position of the **declaration** it resolves to, so the error pointed at where `cmd` was *defined* rather than the string misusing it.

It's a **whitelist** of renderable kinds, not a blocklist: a blocklist lets the next type added to the language silently join the garbage list, which is how this shipped.

## Two kinds deliberately admitted

Both decided on measurement, after a first version rejected them and broke the tree:

- **`ptr`** — 21 sites across `std/`, `contrib/`, `examples/` and `tests/` interpolate a `ptr` that genuinely holds a `char*`, because `map`/`pqueue`/`schema` return `ptr` for string values. Rejecting it broke `std/pqueue` and `std/schema`, and there's no sanctioned conversion to migrate to (`s: string = v` doesn't compile).
- **tuple** — the type is often simply *wrong* rather than the value being un-renderable. `x = f()` where `f` returns `(int, string)` binds the **first element** — verified, it yields `42` — while the slot keeps the tuple type. Rejecting it flagged a working example in `std/tcp/README.md`.

Narrowing either is its own change; both are documented in the source so they aren't mistaken for oversights.

## Testing

`tests/integration/string_interp_operand_reject/` — 8 assertions, half of them **sentries against over-rejection**, since interpolation is everywhere and breaking it is worse than the bug.

Four mutants all fail it: removing the function check, removing the whole check, admitting structs to the whitelist, and reverting the parser position fix.

Gates: `make test` 403/403, `ae fmt`, `check-docs`, gcc and clang clean under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)