### PR TITLE
fix(proxy): retry when the upstream had closed a pooled connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,24 @@ version number before tagging the release.
 
 ### Fixed
 
+- **A request could get `HTTP/1.1 0 Unknown`, or no answer at all, when the
+  upstream had closed a pooled connection.** An idle keep-alive connection is
+  closed by the upstream whenever it likes, nginx does it after
+  `keepalive_timeout`, and the close is only discoverable by using the
+  connection. Nothing had been delivered, so there was nothing to be careful
+  about: the request simply had to go again down a fresh connection, which is
+  what the blocking client already did. The event-driven path the reverse proxy
+  uses did not, so the empty read was parsed as status 0 and serialized to the
+  client as `HTTP/1.1 0 Unknown`, or the connection was dropped with no answer.
+
+  A closed connection announces itself three ways and all three are now
+  handled: a clean end of file on the read, a reset on the read, and a failed
+  write. A retry also dials fresh rather than taking from the pool again, since
+  the pool can hold more than one connection the upstream has closed and
+  spending the single retry on another of them is how a client ends up with
+  nothing. Covered by a test that makes sixty requests through an upstream
+  closing after every response, which fails on the previous code.
+
 - **The proxy sent the client's `X-Forwarded-For` upstream alongside its own,
   and the client's came first.** Every inbound header was copied to the
   upstream and the proxy then appended its own `X-Forwarded-For`,

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -2375,13 +2375,22 @@ static void http_socket_set_nonblocking(int fd, int on) {
 }
 
 int http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out) {
+    return http_upstream_acquire_ex(host, port, 1, out);
+}
+
+/* `allow_pool` is 0 when the caller has just been burned by a pooled
+ * connection the upstream had closed. Taking another one from the same pool
+ * could hand it a second corpse, and the retry after that is the one the
+ * client never gets an answer from. */
+int http_upstream_acquire_ex(const char* host, int port, int allow_pool,
+                             HttpUpstreamConn* out) {
     if (!out || !host || port <= 0) return -1;
     memset(out, 0, sizeof(*out));
     out->t.applied_timeout_ns = -1;
 
     http_pool_key(out->pool_key, sizeof(out->pool_key), host, port, 0,
                   host, port, 0, NULL);
-    if (http_pool_enabled && http_pool_take(out->pool_key, &out->t)) {
+    if (allow_pool && http_pool_enabled && http_pool_take(out->pool_key, &out->t)) {
         out->reused = 1;
         out->connecting = 0;
         if (out->t.nonblocking != 1) {

--- a/std/net/aether_http.h
+++ b/std/net/aether_http.h
@@ -381,6 +381,11 @@ int http_find_header_in_block(const char* block, const char* end,
 typedef struct HttpUpstreamConnOpaque HttpUpstreamConn;
 
 int  http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out);
+/* As above, but `allow_pool` 0 forces a fresh connection. Use it when a pooled
+ * connection has just been found closed: the pool may hold more of them, and
+ * spending a retry on another corpse is how a client ends up with nothing. */
+int  http_upstream_acquire_ex(const char* host, int port, int allow_pool,
+                              HttpUpstreamConn* out);
 /* 1 when the connect has completed, 0 when it is still in flight, -1 when it
  * failed. A caller woken by a poller must handle 0 by waiting again: a wakeup
  * does not promise this descriptor is the one that became ready. */

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -117,6 +117,10 @@ typedef struct EvConn {
     int      up_writable_watched; /* write interest on the upstream, which is
                                    * only wanted while a write is blocked */
     int      up_watched;         /* registered with the poller at all */
+    /* A connection taken from the pool that turned out to be closed has been
+     * dialled again once. One retry only: a fresh connection that answers
+     * nothing is the upstream's answer, not a stale descriptor. */
+    int      up_stale_retried;
 
     /* The response accumulator, kept between requests. It starts at 16 KiB,
      * and allocating and freeing one per request had the kernel handing back
@@ -534,6 +538,31 @@ static void ev_lend_rxbuf(EvConn* c) {
 /* Register the upstream the first time this request has to wait on it, and
  * not before. A request whose answer is already there never registers it at
  * all, which is the common case against a fast upstream. */
+/* Take the accumulator back from the exchange, which is what ev_begin_retry
+ * needs before it clears the exchange: the buffer is lent, not owned, and a
+ * memset over the exchange would drop the only pointer to it. */
+static void ev_reclaim_rxbuf(EvConn* c) {
+    if (!c->x.buf) return;
+    if (c->rxbuf) aether_caps_free(c->rxbuf, c->rxcap);
+    c->rxbuf = c->x.buf;
+    c->rxcap = c->x.cap;
+    c->x.buf = NULL;
+    c->x.cap = 0;
+    c->x.len = 0;
+}
+
+/* Close and forget the upstream, without pooling it. It is being abandoned
+ * because it failed, and a failed descriptor must never go back into the pool
+ * for the next request to inherit. */
+static void ev_drop_upstream(EvDriver* d, EvConn* c) {
+    if (c->up.t.sockfd < 0) return;
+    if (c->up_watched) aether_io_poller_remove(&d->poller, c->up.t.sockfd);
+    ev_untrack(d, c->up.t.sockfd);
+    c->up_in_poller = 0;
+    c->up_watched = c->up_writable_watched = 0;
+    http_upstream_release(&c->up, 0);
+}
+
 static int ev_watch_upstream(EvDriver* d, EvConn* c) {
     if (c->up_watched) return 0;
     c->up_watched = 1;
@@ -1007,11 +1036,27 @@ static int ev_finish_upstream(EvDriver* d, EvConn* c) {
      * own framing said it would. Released before the response is looked at,
      * because nothing about releasing it depends on that. */
     int keep = c->x.complete && !c->x.framing.invalid;
+    int was_reused = c->up.reused;
+    size_t got = c->x.len;
     if (c->up_watched) aether_io_poller_remove(&d->poller, c->up.t.sockfd);
     ev_untrack(d, c->up.t.sockfd);
     c->up_in_poller = 0;
     c->up_watched = c->up_writable_watched = 0;
     http_upstream_release(&c->up, keep);
+
+    /* An idle pooled connection can be closed by the upstream at any moment,
+     * and the close is only discoverable by using it: the send appears to
+     * succeed into a socket buffer and the read then returns nothing. Zero
+     * bytes is not an empty response, it is no response, and the request
+     * cannot have been acted on twice from here, so it goes again down a
+     * fresh connection. The blocking client does exactly this; without it the
+     * empty buffer is parsed as status 0 and the client is sent
+     * "HTTP/1.1 0 Unknown". */
+    if (got == 0 && was_reused && !c->up_stale_retried) {
+        c->up_stale_retried = 1;
+        ev_reclaim_rxbuf(c);
+        return ev_begin_retry(d, c);
+    }
 
     /* Answer from the upstream's own bytes when nothing needs the response
      * object. Tried before it is built, because building it is the copy this
@@ -1066,12 +1111,37 @@ static int ev_advance(EvDriver* d, EvConn* c) {
         }
         case EV_UPSTREAM_SEND: {
             int r = ev_step_upstream_send(d, c);
+            /* The same stale pooled connection as below, found on the write
+             * instead of the read: the peer had already gone, and the write
+             * is what discovers it. Nothing was delivered, so the request
+             * goes again down a fresh connection rather than the client
+             * being dropped without an answer. */
+            if (r < 0 && c->up.reused && !c->up_stale_retried) {
+                c->up_stale_retried = 1;
+                ev_drop_upstream(d, c);
+                ev_reclaim_rxbuf(c);
+                r = ev_begin_retry(d, c);
+                if (r <= 0) return r;
+                continue;
+            }
             if (r <= 0) return r;
             c->state = EV_UPSTREAM_RECV;
             continue;
         }
         case EV_UPSTREAM_RECV: {
             int r = ev_step_upstream_recv(d, c);
+            /* The third way a closed pooled connection announces itself: the
+             * peer sent a reset rather than a clean end, so the read fails
+             * instead of returning nothing. Same conclusion as the other two,
+             * since nothing had arrived: dial fresh and send once more. */
+            if (r < 0 && c->x.len == 0 && c->up.reused && !c->up_stale_retried) {
+                c->up_stale_retried = 1;
+                ev_drop_upstream(d, c);
+                ev_reclaim_rxbuf(c);
+                r = ev_begin_retry(d, c);
+                if (r <= 0) return r;
+                continue;
+            }
             if (r <= 0) return r;
             r = ev_finish_upstream(d, c);
             if (r <= 0) return r;

--- a/tests/integration/http_proxy_stale_pooled_connection/stale_probe.py
+++ b/tests/integration/http_proxy_stale_pooled_connection/stale_probe.py
@@ -1,0 +1,79 @@
+# An upstream that closes after every response, which is what an idle
+# keep-alive connection does when the upstream's timeout fires. nginx does it
+# after keepalive_timeout, so a proxy meets this constantly.
+#
+# The close is only discoverable by using the connection, and it announces
+# itself three different ways: a clean end of file on the read, a reset on the
+# read, or a failed write. All three mean nothing arrived, so the request has
+# to go again down a fresh connection. Getting one of the three wrong shows up
+# here as an occasional failure among many successes, which is why this makes
+# a lot of requests rather than one.
+
+import socket
+import sys
+import threading
+import time
+
+UPSTREAM_PORT = 19001
+PROXY_PORT = 19000
+REQUESTS = 60
+
+RESPONSE = (b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Content-Length: 2\r\n"
+            b"\r\nok")
+
+ready = threading.Event()
+
+
+def upstream():
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", UPSTREAM_PORT))
+    s.listen(128)
+    s.settimeout(90)
+    ready.set()
+    try:
+        while True:
+            c, _ = s.accept()
+            try:
+                c.recv(65536)
+                c.sendall(RESPONSE)
+            finally:
+                c.close()
+    except OSError:
+        pass
+    finally:
+        s.close()
+
+
+threading.Thread(target=upstream, daemon=True).start()
+if not ready.wait(10):
+    print("upstream never bound")
+    sys.exit(1)
+
+failures = []
+for i in range(REQUESTS):
+    try:
+        c = socket.create_connection(("127.0.0.1", PROXY_PORT), timeout=8)
+        c.sendall(b"GET /echo HTTP/1.1\r\nHost: x\r\n\r\n")
+        c.settimeout(6)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            d = c.recv(65536)
+            if not d:
+                break
+            buf += d
+        c.close()
+        if b"200 OK" not in buf:
+            failures.append("request %d: %r" % (i + 1, buf[:60] if buf else b"<nothing>"))
+    except Exception as e:
+        failures.append("request %d: %s: %s" % (i + 1, type(e).__name__, e))
+    time.sleep(0.03)
+
+if failures:
+    print("%d of %d requests did not get a 200: %s"
+          % (len(failures), REQUESTS, "; ".join(failures[:5])))
+    sys.exit(1)
+
+print("ok")

--- a/tests/integration/http_proxy_stale_pooled_connection/test_http_proxy_stale_pooled_connection.sh
+++ b/tests/integration/http_proxy_stale_pooled_connection/test_http_proxy_stale_pooled_connection.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# An upstream may close a pooled connection whenever it likes, and the proxy
+# only finds out by using it. Every request must still be answered: the request
+# has not been delivered, so it goes again down a fresh connection.
+#
+# Before this was handled, the empty read was parsed as status 0 and the client
+# received "HTTP/1.1 0 Unknown", or the connection was dropped with no answer
+# at all.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  [SKIP] http_proxy_stale_pooled_connection: python3 not on PATH"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+PX_PID=""
+cleanup() {
+    if [ -n "$PX_PID" ]; then
+        kill "$PX_PID" 2>/dev/null || true
+        wait "$PX_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# The reverse-proxy suite's driver, not a copy: a second copy would be a second
+# thing to keep in step, and any .ae file here would be picked up by the sweep
+# that runs every .ae as a standalone program.
+SERVER_SRC="$SCRIPT_DIR/../http_reverse_proxy/server.ae"
+if [ ! -f "$SERVER_SRC" ]; then
+    echo "  [FAIL] missing $SERVER_SRC"; exit 1
+fi
+if ! AETHER_HOME="$ROOT" "$AE" build "$SERVER_SRC" \
+        -o "$TMPDIR/server" >"$TMPDIR/build.log" 2>&1; then
+    echo "  [FAIL] build:"; head -30 "$TMPDIR/build.log"; exit 1
+fi
+
+# The probe binds 19001 itself and answers as the upstream, so only the proxy
+# is started here.
+AETHER_HOME="$ROOT" "$TMPDIR/server" proxy >"$TMPDIR/px.log" 2>&1 &
+PX_PID=$!
+
+deadline=$(($(date +%s) + 15))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$PX_PID" 2>/dev/null; then
+        echo "  [FAIL] proxy died:"; head -30 "$TMPDIR/px.log"; exit 1
+    fi
+    if curl -s -o /dev/null --max-time 1 "http://127.0.0.1:19000/echo" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if ! OUT=$(python3 "$SCRIPT_DIR/stale_probe.py" 2>&1); then
+    echo "  [FAIL] http_proxy_stale_pooled_connection: $OUT"; exit 1
+fi
+
+echo "  [PASS] http_proxy_stale_pooled_connection: 60/60 answered when the upstream closes every pooled connection"


### PR DESCRIPTION
Closes #1838

Stacked on #1835, so this shows only the commit that is not already in it. GitHub
retargets this to `main` when #1835 merges.

## The bug

An upstream closes idle keep-alive connections whenever it likes; nginx does it after
`keepalive_timeout`. The close is only discoverable by using the connection, so a pool
has to be ready to dial again. The blocking client already was. The event-driven path
the reverse proxy runs on was not:

```
request 1 -> HTTP/1.1 200 OK
request 2 -> HTTP/1.1 0 Unknown
request 3 -> HTTP/1.1 200 OK
request 4 -> <nothing>
```

Nothing is wrong with the upstream's responses. The empty read was parsed as status 0
and serialized to the client as `HTTP/1.1 0 Unknown`; on the other path the connection
was dropped with no answer at all. Nothing had been delivered in either case, so the
request cannot have been acted on twice from this hop and going again is safe.

## Three ways, not one

A closed connection announces itself three different ways, and the first version of this
fix handled only the first:

- a clean end of file on the read, which returns zero bytes;
- a **reset** on the read, which fails instead of returning zero;
- a **failed write**, when the peer had already gone.

After fixing only the first, a stress run still failed about one request in six. Rather
than guess again I logged every close with the state it happened in, which pointed
straight at `EV_UPSTREAM_RECV` dying with no retry attempted: the reset case.

There was a second-order bug in the fix itself. The retry took another connection from
the pool, which can also be stale, so the one retry got spent on a second corpse.
Retries now dial fresh through `http_upstream_acquire_ex`; `http_upstream_acquire` keeps
its old meaning.

One trap worth naming for whoever touches this next: `ev_begin_retry` `memset`s the
exchange, and the receive accumulator is *lent* to it rather than owned. It has to be
reclaimed first or the retry drops the only pointer to that buffer.

## Evidence

Against an upstream that closes after every response:

```
before   200 / 0 Unknown / 200 / <nothing>     roughly 1 in 6 failing
after    80 consecutive requests, all 200
```

| check | result |
| --- | --- |
| unit | 409 passed, 0 failed |
| http_proxy_stale_pooled_connection (new) | 60/60 |
| http_reverse_proxy | 14/14 |
| http_reverse_proxy_pool / _extra | 9/9, 8/8 |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_proxy_response_injection | 2/2 paths |
| http_client_disconnect, _tls, _dechunk, _stream_chunked | pass |
| macOS `leaks(1)` gate | 305 programs, 0 over budget |
| compiler warnings | 0 |
| Windows cross-compile, networking-disabled build | clean |

The regression test makes sixty requests deliberately: getting one of the three cases
wrong hides among the successes at low counts. It fails on the previous code.

It builds the reverse-proxy suite's driver rather than copying it, so this directory
contributes no `.ae` file to the sweep that runs every `.ae` as a standalone program.
Checked with the sweep's own command.