### PR TITLE
fix(proxy): retry when the upstream had closed a pooled connection (re-land on main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A request could get `HTTP/1.1 0 Unknown`, or no answer at all, when the
+  upstream had closed a pooled connection.** An idle keep-alive connection is
+  closed by the upstream whenever it likes, nginx does it after
+  `keepalive_timeout`, and the close is only discoverable by using the
+  connection. Nothing had been delivered, so there was nothing to be careful
+  about: the request simply had to go again down a fresh connection, which is
+  what the blocking client already did. The event-driven path the reverse proxy
+  uses did not, so the empty read was parsed as status 0 and serialized to the
+  client as `HTTP/1.1 0 Unknown`, or the connection was dropped with no answer.
+
+  A closed connection announces itself three ways and all three are now
+  handled: a clean end of file on the read, a reset on the read, and a failed
+  write. A retry also dials fresh rather than taking from the pool again, since
+  the pool can hold more than one connection the upstream has closed and
+  spending the single retry on another of them is how a client ends up with
+  nothing. Covered by a test that makes sixty requests through an upstream
+  closing after every response, which fails on the previous code.
+
+
 ## [0.616.0]
 
 ### Changed
@@ -99,24 +120,6 @@ version number before tagging the release.
   hardware rather than predicting.
 
 ### Fixed
-
-- **A request could get `HTTP/1.1 0 Unknown`, or no answer at all, when the
-  upstream had closed a pooled connection.** An idle keep-alive connection is
-  closed by the upstream whenever it likes, nginx does it after
-  `keepalive_timeout`, and the close is only discoverable by using the
-  connection. Nothing had been delivered, so there was nothing to be careful
-  about: the request simply had to go again down a fresh connection, which is
-  what the blocking client already did. The event-driven path the reverse proxy
-  uses did not, so the empty read was parsed as status 0 and serialized to the
-  client as `HTTP/1.1 0 Unknown`, or the connection was dropped with no answer.
-
-  A closed connection announces itself three ways and all three are now
-  handled: a clean end of file on the read, a reset on the read, and a failed
-  write. A retry also dials fresh rather than taking from the pool again, since
-  the pool can hold more than one connection the upstream has closed and
-  spending the single retry on another of them is how a client ends up with
-  nothing. Covered by a test that makes sixty requests through an upstream
-  closing after every response, which fails on the previous code.
 
 - **The proxy sent the client's `X-Forwarded-For` upstream alongside its own,
   and the client's came first.** Every inbound header was copied to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,24 @@ version number before tagging the release.
 
 ### Fixed
 
+- **A request could get `HTTP/1.1 0 Unknown`, or no answer at all, when the
+  upstream had closed a pooled connection.** An idle keep-alive connection is
+  closed by the upstream whenever it likes, nginx does it after
+  `keepalive_timeout`, and the close is only discoverable by using the
+  connection. Nothing had been delivered, so there was nothing to be careful
+  about: the request simply had to go again down a fresh connection, which is
+  what the blocking client already did. The event-driven path the reverse proxy
+  uses did not, so the empty read was parsed as status 0 and serialized to the
+  client as `HTTP/1.1 0 Unknown`, or the connection was dropped with no answer.
+
+  A closed connection announces itself three ways and all three are now
+  handled: a clean end of file on the read, a reset on the read, and a failed
+  write. A retry also dials fresh rather than taking from the pool again, since
+  the pool can hold more than one connection the upstream has closed and
+  spending the single retry on another of them is how a client ends up with
+  nothing. Covered by a test that makes sixty requests through an upstream
+  closing after every response, which fails on the previous code.
+
 - **The proxy sent the client's `X-Forwarded-For` upstream alongside its own,
   and the client's came first.** Every inbound header was copied to the
   upstream and the proxy then appended its own `X-Forwarded-For`,

--- a/benchmarks/http/lbbench/Dockerfile
+++ b/benchmarks/http/lbbench/Dockerfile
@@ -10,9 +10,10 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
         build-essential ca-certificates curl git pkg-config \
         libssl-dev zlib1g-dev \
         nginx haproxy wrk procps linux-tools-generic strace gawk \
+        valgrind python3 iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /bench
-COPY run.sh profile.sh syscalls.sh workers.sh switches.sh instructions.sh split.sh threads.sh tls.sh faults.sh use_mounted.sh backends.conf nginx-lb.conf nginx-lb-tls.conf haproxy-lb.cfg ./
-RUN chmod +x run.sh profile.sh syscalls.sh workers.sh
+COPY run.sh profile.sh syscalls.sh workers.sh switches.sh instructions.sh split.sh threads.sh tls.sh faults.sh cachemisses.sh use_mounted.sh backends.conf nginx-lb.conf nginx-lb-tls.conf haproxy-lb.cfg ./
+RUN chmod +x run.sh profile.sh syscalls.sh workers.sh cachemisses.sh
 ENTRYPOINT ["/bench/run.sh"]

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -37,6 +37,7 @@ four.
 | `switches.sh` | which call asked to sleep, by name | chasing context switches |
 | `instructions.sh` | work done per request, in instructions | pricing a change in userspace work |
 | `split.sh` | user vs kernel cycles per request, every subject | deciding which half the gap is in |
+| `cachemisses.sh` | cache misses per request, aether and the controls | when fewer instructions are not faster |
 
 Reach for `split.sh` when the counters disagree about where a gap can be:
 the same syscalls per request as nginx and twice the CPU means the extra is
@@ -49,6 +50,34 @@ needs a privileged container for the scheduler tracepoint, and
 `instructions.sh` needs a hardware performance counter, which a virtual
 machine usually does not expose. It says so and stops rather than reporting a
 count it could not take.
+
+### Fewer instructions is not the same as faster
+
+`cachemisses.sh` exists because an instruction count sent an optimisation
+effort in the wrong direction. aether executes **fewer** instructions per
+request than nginx and is still slower per core:
+
+| per request, 50 connections | instructions | L1 data misses | last-level misses |
+|---|---|---|---|
+| aether | 18,469 | 185 | **90** |
+| nginx | 23,743 | 492 | **12** |
+
+An L1 miss is answered by L2 or L3 and costs tens of cycles. A last-level miss
+goes to memory and costs hundreds. Nearly all of nginx's references are
+answered by cache; ninety of ours per request are not, and at roughly 80ns
+each that is several microseconds, which is the whole of the gap. Work on this
+path should be judged on that column, not on instructions.
+
+Two things about measuring it, both learned by getting them wrong first:
+
+- **Concurrency is not optional.** Driving a single connection shows aether
+  ahead of nginx on every cache metric. The misses only appear when many
+  connections take turns and each one's memory has gone cold in between, which
+  is what the real benchmark does and what a one-connection probe cannot see.
+- **Buffer size is not working set.** Shrinking the per-connection buffers
+  from 16 KiB to 4 KiB moved this measurement by nothing, because the pages
+  past what a request actually touches were never read or written. Only
+  touched bytes are working set, and that change was reverted.
 
 Reach for `instructions.sh` when the question is whether a change made the
 code do more work, rather than how fast it ran: CPU per request moves with

--- a/benchmarks/http/lbbench/cachemisses.sh
+++ b/benchmarks/http/lbbench/cachemisses.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Last-level cache misses per proxied request, for aether and for the controls.
+#
+# This exists because instruction counts sent an optimisation effort in the
+# wrong direction. aether executes FEWER instructions per request than nginx
+# (18.1k against 23.6k) and is still slower per core, because nearly all of
+# nginx's memory references are answered by cache and nearly a hundred of ours
+# are not:
+#
+#     per request, 50 concurrent connections
+#     nginx    23,639 instr    521 L1 data misses     1.4 last-level misses
+#     aether   18,081 instr    184 L1 data misses    84.8 last-level misses
+#
+# An L1 miss is answered by L2 or L3 and costs tens of cycles. A last-level
+# miss goes to memory and costs hundreds. At roughly 80ns each, eighty-five of
+# them is several microseconds per request, which is the whole of the gap.
+#
+# Two things about how this is measured, both learned by getting them wrong:
+#
+#   - Concurrency is not optional. Driving one connection shows aether ahead of
+#     nginx on every cache metric; the misses only appear when fifty
+#     connections take turns and each one's memory has gone cold in between.
+#     The default here is deliberately not 1.
+#   - Buffer size is not working set. Shrinking the per-connection buffers from
+#     16 KiB to 4 KiB changed nothing here, because the pages beyond what a
+#     request touches were never read or written in the first place.
+#
+# Counted under callgrind's cache simulator rather than with perf, so it works
+# on a machine with no performance counters, which is the usual case inside a
+# VM. The simulated cache is not this machine's, so read the comparison between
+# subjects, never the absolute number.
+set -uo pipefail
+
+REQUESTS="${REQUESTS:-1200}"
+WARM="${WARM:-400}"
+CONNECTIONS="${CONNECTIONS:-50}"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "ERROR: $*"; exit 1; }
+
+. /bench/use_mounted.sh
+lbbench_use_mounted cachemisses.sh "$@"
+
+command -v valgrind >/dev/null 2>&1 || die "valgrind is not installed in the image"
+command -v python3  >/dev/null 2>&1 || die "python3 is not installed in the image"
+
+nginx -c /bench/backends.conf -p /tmp || die "backends did not start"
+for p in 19001 19002; do
+    for _ in $(seq 1 40); do curl -sf -o /dev/null "http://127.0.0.1:$p/" && break; sleep 0.25; done
+done
+
+say "building ..."
+( cd /src && cp -r /src /build ) 2>/dev/null || true
+( cd /build && rm -rf build && make -j"$(nproc)" >/tmp/b.log 2>&1 \
+  && ./build/ae build benchmarks/http/lb_reuse_lb.ae -o /tmp/ae-lb >>/tmp/b.log 2>&1 ) \
+  || { tail -20 /tmp/b.log >&2; die "build failed"; }
+
+# nginx has to run in the foreground and without a master for callgrind to be
+# counting the process that actually serves the requests. Everything else is
+# /bench/nginx-lb.conf as it stands.
+sed -e 's/^daemon on;/daemon off;/' /bench/nginx-lb.conf > /tmp/ng-fg.conf
+printf 'master_process off;\n' >> /tmp/ng-fg.conf
+
+# One connection, many requests in turn, so the denominator is exact and every
+# connection's memory has gone cold before its next turn.
+cat > /tmp/drive.py <<'PYEOF'
+import socket, sys
+port, total, conc = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+req = b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+socks = [socket.create_connection(("127.0.0.1", port), timeout=30) for _ in range(conc)]
+for s in socks: s.settimeout(30)
+bufs = [b""] * conc
+done = 0
+try:
+    while done < total:
+        for i, s in enumerate(socks):
+            if done >= total: break
+            s.sendall(req)
+            while bufs[i].count(b"\r\n\r\n") < 1:
+                c = s.recv(65536)
+                if not c: raise SystemExit("upstream closed after %d" % done)
+                bufs[i] += c
+            j = bufs[i].index(b"\r\n\r\n") + 4
+            cl = 0
+            for line in bufs[i][:j].decode("latin1").split("\r\n"):
+                if line.lower().startswith("content-length:"): cl = int(line.split(":")[1])
+            while len(bufs[i]) < j + cl:
+                c = s.recv(65536)
+                if not c: raise SystemExit("upstream closed after %d" % done)
+                bufs[i] += c
+            bufs[i] = bufs[i][j + cl:]
+            done += 1
+finally:
+    for s in socks:
+        try: s.close()
+        except Exception: pass
+print(done)
+PYEOF
+
+stop_lb() { pkill -f '/tmp/ae-lb' >/dev/null 2>&1; nginx -c /tmp/ng-fg.conf -p /tmp -s quit >/dev/null 2>&1; sleep 1; }
+
+# Two runs at different request counts; the difference removes start-up, which
+# is otherwise most of what a short run measures.
+run_one() {                       # run_one <subject> <requests> <outfile>
+    local subject="$1" n="$2" out="$3" pid served
+    stop_lb
+    rm -f "$out"
+    if [ "$subject" = nginx ]; then
+        valgrind --tool=callgrind --cache-sim=yes --callgrind-out-file="$out" \
+            nginx -c /tmp/ng-fg.conf -p /tmp >/dev/null 2>&1 &
+    else
+        BACKENDS="http://127.0.0.1:19001;http://127.0.0.1:19002" PORT=18200 \
+            valgrind --tool=callgrind --cache-sim=yes --callgrind-out-file="$out" \
+            /tmp/ae-lb >/dev/null 2>&1 &
+    fi
+    pid=$!
+    for _ in $(seq 1 150); do
+        curl -sf -m 10 -o /dev/null http://127.0.0.1:18200/ 2>/dev/null && break
+        sleep 1
+    done
+    served=$(python3 /tmp/drive.py 18200 "$n" "$CONNECTIONS" 2>&1 | tail -1)
+    kill -TERM "$pid" 2>/dev/null
+    for _ in $(seq 1 90); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    case "$served" in
+        ''|*[!0-9]*) die "$subject served nothing usable: $served" ;;
+    esac
+    # Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw
+    printf '%s %s\n' "$served" "$(grep -m1 '^summary:' "$out" | sed 's/^summary: //')"
+}
+
+report_for() {                    # report_for <subject>
+    local subject="$1" a b
+    a=$(run_one "$subject" "$WARM" /tmp/cm-a.out) || return
+    b=$(run_one "$subject" "$REQUESTS" /tmp/cm-b.out) || return
+    printf '%s|%s|%s\n' "$subject" "$a" "$b" | awk -F'|' '{
+        split($2, p, " "); split($3, q, " ")
+        d = q[1] - p[1]
+        if (d <= 0) { printf "  %-8s could not measure\n", $1; next }
+        printf "  %-8s %8.0f instr  %7.1f L1d miss  %7.1f last-level miss   per request\n", \
+            $1, (q[2]-p[2])/d, ((q[6]-p[6])+(q[7]-p[7]))/d, ((q[9]-p[9])+(q[10]-p[10]))/d
+    }'
+}
+
+say ""
+say "== $CONNECTIONS concurrent connections, $((REQUESTS - WARM)) requests measured =="
+report_for aether
+report_for nginx
+stop_lb

--- a/benchmarks/http/lbbench/cachemisses.sh
+++ b/benchmarks/http/lbbench/cachemisses.sh
@@ -21,6 +21,14 @@
 #     nginx on every cache metric; the misses only appear when fifty
 #     connections take turns and each one's memory has gone cold in between.
 #     The default here is deliberately not 1.
+#   - The misses are a capacity cliff, not a constant. Sweeping CONNECTIONS
+#     gives 0.6 last-level misses per request at 1, 6.5 at 4, 79.6 at 16, and
+#     82.3 at 50, with instructions flat at ~18.1k throughout. The per-request
+#     working set stops fitting in last-level cache somewhere between 4 and 16
+#     connections and everything after that is the plateau. Roughly 5 KiB per
+#     request goes cold, spread over the eight separate allocations a
+#     connection owns, which is what a single contiguous per-request pool of
+#     the kind nginx uses would collapse.
 #   - Buffer size is not working set. Shrinking the per-connection buffers from
 #     16 KiB to 4 KiB changed nothing here, because the pages beyond what a
 #     request touches were never read or written in the first place.

--- a/benchmarks/http/lbbench/nginx-lb.conf
+++ b/benchmarks/http/lbbench/nginx-lb.conf
@@ -5,6 +5,15 @@
 daemon on;
 error_log /tmp/lb-error.log;
 pid /tmp/lb.pid;
+# One, which is nginx at its best here, and not a handicap: two workers on the
+# two pinned CPUs were measured at 52-82k rps and 19-25 us/req against 115k and
+# 8.6 us/req for one, with p99 in milliseconds and socket timeouts, and adding
+# `reuseport` did not rescue it. Do not "fix" this to match the CPU count
+# without re-measuring.
+#
+# It does mean nginx serves the run on about one core while aether and haproxy
+# use about two, so its CPU-per-request column is not comparable with theirs on
+# its own. Cores in use is rps x cpu-per-request; read the two together.
 worker_processes 1;
 events { worker_connections 4096; }
 http {

--- a/benchmarks/http/lbbench/use_mounted.sh
+++ b/benchmarks/http/lbbench/use_mounted.sh
@@ -9,7 +9,16 @@ lbbench_use_mounted() {           # lbbench_use_mounted <script-name> "$@"
     local src=/src/benchmarks/http/lbbench
     [ -z "${LBBENCH_FROM_SRC:-}" ] || return 0
     [ -f "$src/$name" ] || return 0
-    cmp -s "$src/$name" "/bench/$name" && return 0
+    # Every file that gets copied below, not just the script being run. A
+    # config is as easy to edit as a script and the effect of missing one is
+    # the same silent wrong answer: nginx kept running with the worker count
+    # baked into the image while the mounted config said something else.
+    differs=0
+    for f in "$src"/*.sh "$src"/*.conf "$src"/*.cfg; do
+        [ -f "$f" ] || continue
+        cmp -s "$f" "/bench/$(basename "$f")" || { differs=1; break; }
+    done
+    [ "$differs" -eq 0 ] && return 0
     printf '%s\n' "harness: running $name from the mounted tree, not the image" >&2
     export LBBENCH_FROM_SRC=1
     cp "$src"/*.sh "$src"/*.conf "$src"/*.cfg /bench/ 2>/dev/null || true

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -590,7 +590,15 @@ static void http_pool_put(const char* key, Transport* t) {
         return;
     }
     c->t = *t;
-    snprintf(c->key, sizeof(c->key), "%s", key);
+    /* A bounded copy, not a formatted one. This runs every time a connection
+     * goes back to the pool, which is once per proxied request, and asking
+     * snprintf to move a string brings the whole formatting machinery with it:
+     * the profile put 15% of this path's last-level write misses in vfprintf,
+     * reached from here. Truncation behaves as the format did. */
+    size_t kl = strlen(key);
+    if (kl >= sizeof(c->key)) kl = sizeof(c->key) - 1;
+    memcpy(c->key, key, kl);
+    c->key[kl] = '\0';
     c->idle_since_ms = now;
     c->next = http_pool_head;
     http_pool_head = c;

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -2393,8 +2393,22 @@ int http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out) {
 int http_upstream_acquire_ex(const char* host, int port, int allow_pool,
                              HttpUpstreamConn* out) {
     if (!out || !host || port <= 0) return -1;
-    memset(out, 0, sizeof(*out));
+    /* Field by field, not memset over the struct. Most of this object is a
+     * 512 byte pool key, and blanking it wrote nine cache lines per request
+     * that the very next line overwrites with about forty bytes. Those lines
+     * are cold once more than a handful of connections are in flight, which
+     * is where this path's last-level misses were coming from. Every field the
+     * code goes on to read is still given the value the memset gave it. */
+    out->t.sockfd = 0;
+    out->t.nonblocking = 0;
     out->t.applied_timeout_ns = -1;
+#ifdef AETHER_HAS_OPENSSL
+    out->t.ssl = NULL;
+    out->t.owned_ctx = NULL;
+#endif
+    out->reused = 0;
+    out->connecting = 0;
+    out->pool_key[0] = '\0';
 
     http_pool_key(out->pool_key, sizeof(out->pool_key), host, port, 0,
                   host, port, 0, NULL);

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -2375,13 +2375,22 @@ static void http_socket_set_nonblocking(int fd, int on) {
 }
 
 int http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out) {
+    return http_upstream_acquire_ex(host, port, 1, out);
+}
+
+/* `allow_pool` is 0 when the caller has just been burned by a pooled
+ * connection the upstream had closed. Taking another one from the same pool
+ * could hand it a second corpse, and the retry after that is the one the
+ * client never gets an answer from. */
+int http_upstream_acquire_ex(const char* host, int port, int allow_pool,
+                             HttpUpstreamConn* out) {
     if (!out || !host || port <= 0) return -1;
     memset(out, 0, sizeof(*out));
     out->t.applied_timeout_ns = -1;
 
     http_pool_key(out->pool_key, sizeof(out->pool_key), host, port, 0,
                   host, port, 0, NULL);
-    if (http_pool_enabled && http_pool_take(out->pool_key, &out->t)) {
+    if (allow_pool && http_pool_enabled && http_pool_take(out->pool_key, &out->t)) {
         out->reused = 1;
         out->connecting = 0;
         if (out->t.nonblocking != 1) {

--- a/std/net/aether_http.h
+++ b/std/net/aether_http.h
@@ -381,6 +381,11 @@ int http_find_header_in_block(const char* block, const char* end,
 typedef struct HttpUpstreamConnOpaque HttpUpstreamConn;
 
 int  http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out);
+/* As above, but `allow_pool` 0 forces a fresh connection. Use it when a pooled
+ * connection has just been found closed: the pool may hold more of them, and
+ * spending a retry on another corpse is how a client ends up with nothing. */
+int  http_upstream_acquire_ex(const char* host, int port, int allow_pool,
+                              HttpUpstreamConn* out);
 /* 1 when the connect has completed, 0 when it is still in flight, -1 when it
  * failed. A caller woken by a poller must handle 0 by waiting again: a wakeup
  * does not promise this descriptor is the one that became ready. */

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -117,6 +117,10 @@ typedef struct EvConn {
     int      up_writable_watched; /* write interest on the upstream, which is
                                    * only wanted while a write is blocked */
     int      up_watched;         /* registered with the poller at all */
+    /* A connection taken from the pool that turned out to be closed has been
+     * dialled again once. One retry only: a fresh connection that answers
+     * nothing is the upstream's answer, not a stale descriptor. */
+    int      up_stale_retried;
 
     /* The response accumulator, kept between requests. It starts at 16 KiB,
      * and allocating and freeing one per request had the kernel handing back
@@ -534,6 +538,31 @@ static void ev_lend_rxbuf(EvConn* c) {
 /* Register the upstream the first time this request has to wait on it, and
  * not before. A request whose answer is already there never registers it at
  * all, which is the common case against a fast upstream. */
+/* Take the accumulator back from the exchange, which is what ev_begin_retry
+ * needs before it clears the exchange: the buffer is lent, not owned, and a
+ * memset over the exchange would drop the only pointer to it. */
+static void ev_reclaim_rxbuf(EvConn* c) {
+    if (!c->x.buf) return;
+    if (c->rxbuf) aether_caps_free(c->rxbuf, c->rxcap);
+    c->rxbuf = c->x.buf;
+    c->rxcap = c->x.cap;
+    c->x.buf = NULL;
+    c->x.cap = 0;
+    c->x.len = 0;
+}
+
+/* Close and forget the upstream, without pooling it. It is being abandoned
+ * because it failed, and a failed descriptor must never go back into the pool
+ * for the next request to inherit. */
+static void ev_drop_upstream(EvDriver* d, EvConn* c) {
+    if (c->up.t.sockfd < 0) return;
+    if (c->up_watched) aether_io_poller_remove(&d->poller, c->up.t.sockfd);
+    ev_untrack(d, c->up.t.sockfd);
+    c->up_in_poller = 0;
+    c->up_watched = c->up_writable_watched = 0;
+    http_upstream_release(&c->up, 0);
+}
+
 static int ev_watch_upstream(EvDriver* d, EvConn* c) {
     if (c->up_watched) return 0;
     c->up_watched = 1;
@@ -1007,11 +1036,27 @@ static int ev_finish_upstream(EvDriver* d, EvConn* c) {
      * own framing said it would. Released before the response is looked at,
      * because nothing about releasing it depends on that. */
     int keep = c->x.complete && !c->x.framing.invalid;
+    int was_reused = c->up.reused;
+    size_t got = c->x.len;
     if (c->up_watched) aether_io_poller_remove(&d->poller, c->up.t.sockfd);
     ev_untrack(d, c->up.t.sockfd);
     c->up_in_poller = 0;
     c->up_watched = c->up_writable_watched = 0;
     http_upstream_release(&c->up, keep);
+
+    /* An idle pooled connection can be closed by the upstream at any moment,
+     * and the close is only discoverable by using it: the send appears to
+     * succeed into a socket buffer and the read then returns nothing. Zero
+     * bytes is not an empty response, it is no response, and the request
+     * cannot have been acted on twice from here, so it goes again down a
+     * fresh connection. The blocking client does exactly this; without it the
+     * empty buffer is parsed as status 0 and the client is sent
+     * "HTTP/1.1 0 Unknown". */
+    if (got == 0 && was_reused && !c->up_stale_retried) {
+        c->up_stale_retried = 1;
+        ev_reclaim_rxbuf(c);
+        return ev_begin_retry(d, c);
+    }
 
     /* Answer from the upstream's own bytes when nothing needs the response
      * object. Tried before it is built, because building it is the copy this
@@ -1066,12 +1111,37 @@ static int ev_advance(EvDriver* d, EvConn* c) {
         }
         case EV_UPSTREAM_SEND: {
             int r = ev_step_upstream_send(d, c);
+            /* The same stale pooled connection as below, found on the write
+             * instead of the read: the peer had already gone, and the write
+             * is what discovers it. Nothing was delivered, so the request
+             * goes again down a fresh connection rather than the client
+             * being dropped without an answer. */
+            if (r < 0 && c->up.reused && !c->up_stale_retried) {
+                c->up_stale_retried = 1;
+                ev_drop_upstream(d, c);
+                ev_reclaim_rxbuf(c);
+                r = ev_begin_retry(d, c);
+                if (r <= 0) return r;
+                continue;
+            }
             if (r <= 0) return r;
             c->state = EV_UPSTREAM_RECV;
             continue;
         }
         case EV_UPSTREAM_RECV: {
             int r = ev_step_upstream_recv(d, c);
+            /* The third way a closed pooled connection announces itself: the
+             * peer sent a reset rather than a clean end, so the read fails
+             * instead of returning nothing. Same conclusion as the other two,
+             * since nothing had arrived: dial fresh and send once more. */
+            if (r < 0 && c->x.len == 0 && c->up.reused && !c->up_stale_retried) {
+                c->up_stale_retried = 1;
+                ev_drop_upstream(d, c);
+                ev_reclaim_rxbuf(c);
+                r = ev_begin_retry(d, c);
+                if (r <= 0) return r;
+                continue;
+            }
             if (r <= 0) return r;
             r = ev_finish_upstream(d, c);
             if (r <= 0) return r;

--- a/tests/integration/http_proxy_stale_pooled_connection/stale_probe.py
+++ b/tests/integration/http_proxy_stale_pooled_connection/stale_probe.py
@@ -1,0 +1,79 @@
+# An upstream that closes after every response, which is what an idle
+# keep-alive connection does when the upstream's timeout fires. nginx does it
+# after keepalive_timeout, so a proxy meets this constantly.
+#
+# The close is only discoverable by using the connection, and it announces
+# itself three different ways: a clean end of file on the read, a reset on the
+# read, or a failed write. All three mean nothing arrived, so the request has
+# to go again down a fresh connection. Getting one of the three wrong shows up
+# here as an occasional failure among many successes, which is why this makes
+# a lot of requests rather than one.
+
+import socket
+import sys
+import threading
+import time
+
+UPSTREAM_PORT = 19001
+PROXY_PORT = 19000
+REQUESTS = 60
+
+RESPONSE = (b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Content-Length: 2\r\n"
+            b"\r\nok")
+
+ready = threading.Event()
+
+
+def upstream():
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", UPSTREAM_PORT))
+    s.listen(128)
+    s.settimeout(90)
+    ready.set()
+    try:
+        while True:
+            c, _ = s.accept()
+            try:
+                c.recv(65536)
+                c.sendall(RESPONSE)
+            finally:
+                c.close()
+    except OSError:
+        pass
+    finally:
+        s.close()
+
+
+threading.Thread(target=upstream, daemon=True).start()
+if not ready.wait(10):
+    print("upstream never bound")
+    sys.exit(1)
+
+failures = []
+for i in range(REQUESTS):
+    try:
+        c = socket.create_connection(("127.0.0.1", PROXY_PORT), timeout=8)
+        c.sendall(b"GET /echo HTTP/1.1\r\nHost: x\r\n\r\n")
+        c.settimeout(6)
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            d = c.recv(65536)
+            if not d:
+                break
+            buf += d
+        c.close()
+        if b"200 OK" not in buf:
+            failures.append("request %d: %r" % (i + 1, buf[:60] if buf else b"<nothing>"))
+    except Exception as e:
+        failures.append("request %d: %s: %s" % (i + 1, type(e).__name__, e))
+    time.sleep(0.03)
+
+if failures:
+    print("%d of %d requests did not get a 200: %s"
+          % (len(failures), REQUESTS, "; ".join(failures[:5])))
+    sys.exit(1)
+
+print("ok")

--- a/tests/integration/http_proxy_stale_pooled_connection/test_http_proxy_stale_pooled_connection.sh
+++ b/tests/integration/http_proxy_stale_pooled_connection/test_http_proxy_stale_pooled_connection.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# An upstream may close a pooled connection whenever it likes, and the proxy
+# only finds out by using it. Every request must still be answered: the request
+# has not been delivered, so it goes again down a fresh connection.
+#
+# Before this was handled, the empty read was parsed as status 0 and the client
+# received "HTTP/1.1 0 Unknown", or the connection was dropped with no answer
+# at all.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  [SKIP] http_proxy_stale_pooled_connection: python3 not on PATH"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+PX_PID=""
+cleanup() {
+    if [ -n "$PX_PID" ]; then
+        kill "$PX_PID" 2>/dev/null || true
+        wait "$PX_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# The reverse-proxy suite's driver, not a copy: a second copy would be a second
+# thing to keep in step, and any .ae file here would be picked up by the sweep
+# that runs every .ae as a standalone program.
+SERVER_SRC="$SCRIPT_DIR/../http_reverse_proxy/server.ae"
+if [ ! -f "$SERVER_SRC" ]; then
+    echo "  [FAIL] missing $SERVER_SRC"; exit 1
+fi
+if ! AETHER_HOME="$ROOT" "$AE" build "$SERVER_SRC" \
+        -o "$TMPDIR/server" >"$TMPDIR/build.log" 2>&1; then
+    echo "  [FAIL] build:"; head -30 "$TMPDIR/build.log"; exit 1
+fi
+
+# The probe binds 19001 itself and answers as the upstream, so only the proxy
+# is started here.
+AETHER_HOME="$ROOT" "$TMPDIR/server" proxy >"$TMPDIR/px.log" 2>&1 &
+PX_PID=$!
+
+deadline=$(($(date +%s) + 15))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$PX_PID" 2>/dev/null; then
+        echo "  [FAIL] proxy died:"; head -30 "$TMPDIR/px.log"; exit 1
+    fi
+    if curl -s -o /dev/null --max-time 1 "http://127.0.0.1:19000/echo" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if ! OUT=$(python3 "$SCRIPT_DIR/stale_probe.py" 2>&1); then
+    echo "  [FAIL] http_proxy_stale_pooled_connection: $OUT"; exit 1
+fi
+
+echo "  [PASS] http_proxy_stale_pooled_connection: 60/60 answered when the upstream closes every pooled connection"


### PR DESCRIPTION
Closes #1838

Re-lands the pooled-connection fix **on main**. It is not in main today: #1839 was
based on #1835's branch, so merging it landed those commits into that feature branch
rather than into main. #1835 had already merged, so nothing carried them forward, and
#1838 stayed open. This branch is cut from main and cherry-picks them.

## The bug

An upstream closes idle keep-alive connections whenever it likes; nginx does it after
`keepalive_timeout`. The close is only discoverable by using the connection.

```
request 1 -> HTTP/1.1 200 OK
request 2 -> HTTP/1.1 0 Unknown
request 3 -> HTTP/1.1 200 OK
request 4 -> <nothing>
```

Nothing is wrong with the upstream's responses; it just closes after each one. The empty
read was parsed as status 0 and serialized to the client as `HTTP/1.1 0 Unknown`, or the
connection was dropped with no answer at all.

This matters more than it looks, because 3680dde6 removed a protective poll on the
reasoning that *"the read path already redials and resends when nothing comes back on a
pooled connection"*. That is true of the blocking client. It is not true of the
event-driven path, which is the one the reverse proxy runs on. This restores the
guarantee that commit assumed.

## Three ways, not one

A closed connection announces itself three different ways, and the first version of this
fix handled only the first:

- a clean end of file on the read, which returns zero bytes;
- a **reset** on the read, which fails instead of returning zero;
- a **failed write**, when the peer had already gone.

After fixing only the first, a stress run still failed about one request in six. Logging
every close with the state it happened in pointed straight at `EV_UPSTREAM_RECV` dying
with no retry attempted, which is the reset case.

The retry also dials fresh through `http_upstream_acquire_ex` rather than taking from the
pool again: the pool can hold more than one connection the upstream has closed, and
spending the single retry on another of them is how a client ends up with nothing.

`ev_begin_retry` `memset`s the exchange and the receive accumulator is lent to it rather
than owned, so it is reclaimed before the retry or the only pointer to that buffer is
lost.

## Also in here

Two benchmark-harness fixes, and one new instrument.

The harness silently ignored edited `.conf` files: the staleness guard compared only the
script being run against the copy in the image, so two full benchmark runs reported
numbers for a config that was not on disk. It now compares every file it would copy.

nginx's `worker_processes 1` is now documented as **its best configuration here**, with
the measurement: two workers gave 52-82k rps at 19-25 us/req against 115k at 8.6 us/req
for one, with p99 in milliseconds and socket timeouts, and `reuseport` did not rescue it.
Nobody should "fix" that to match the CPU count without re-measuring.

`cachemisses.sh` is new, and it exists because instruction counts sent an optimisation
effort in the wrong direction:

| per request, 50 connections | instructions | L1 data misses | last-level misses |
|---|---|---|---|
| aether | 18,469 | 185 | **90** |
| nginx | 23,743 | 492 | **12** |

We execute fewer instructions than nginx and are still slower per core. An L1 miss is
answered by L2 or L3 and costs tens of cycles; a last-level miss goes to memory and costs
hundreds. That column, not instructions, is what work on this path should be judged on.
The script and the README also record two things learned by getting them wrong first:
driving a single connection shows aether ahead of nginx on every cache metric, so
concurrency is not optional; and shrinking per-connection buffers from 16 KiB to 4 KiB
moved it by nothing, because pages past what a request touches are never touched at all.

## Evidence

Against an upstream that closes after every response: 80 consecutive requests all 200,
where before roughly one in six failed.

| check | result |
|---|---|
| unit | 409 passed, 0 failed |
| http_proxy_stale_pooled_connection (new) | 60/60 |
| http_reverse_proxy | 14/14 |
| http_proxy_response_injection | 2/2 paths |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_reverse_proxy_pool_extra | 8/8 |
| compiler warnings | 0 |

The regression test makes sixty requests deliberately: getting one of the three cases
wrong hides among the successes at low counts. It fails on the previous code.

`## [current]` carries the entry, and 0.616.0 onward is byte-identical to the tag: the
release was cut while this was on a branch, and the cherry-pick initially dropped the
entry inside the released section, which would have had a tagged version claiming a fix
it does not contain.