### PR TITLE
ci(release): skip the release when nothing shippable changed, do not fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,11 +242,56 @@ jobs:
         elif [ "$SKIP_CHANGELOG" = "1" ]; then
           echo "No [current] section, and the trigger commit says [skip changelog]."
         else
-          echo "::error::No '## [current]' section in CHANGELOG.md, so ${VERSION}"
-          echo "would ship with nothing recorded. Add the entry under a"
-          echo "'## [current]' heading, or put [skip changelog] in the"
-          echo "release-trigger commit if this release is genuinely empty."
-          exit 1
+          # Nothing recorded under [current]. Whether that is a mistake depends
+          # on what has actually changed since the last release.
+          #
+          # A release leaves [current] empty behind it, so the very next merge
+          # to main arrives with nothing under the heading. When that merge is
+          # a chore, a docs change or a test, there is no release to cut and
+          # nothing is wrong: failing there turns every such merge into a red
+          # run and stops releases being generated until someone happens to
+          # merge a change that adds an entry. That is what happened after
+          # 0.616.0, where merging a chore PR failed this job.
+          #
+          # A merge that touches shipping code with nothing recorded is still
+          # the error it always was: that is how 0.506.0 through 0.509.0 went
+          # out with their work recorded nowhere, and silence stays unavailable
+          # for those.
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$LAST_TAG" ]; then
+            CHANGED=$(git diff --name-only "${LAST_TAG}..HEAD")
+          else
+            CHANGED=$(git diff --name-only HEAD~1..HEAD 2>/dev/null || true)
+          fi
+          # Everything that is not shipped to a user of the language: docs,
+          # tests, benchmarks, CI, and the changelog itself.
+          SHIPPING=$(printf '%s\n' "$CHANGED" \
+                     | grep -vE '^(docs/|tests/|benchmarks/|examples/|\.github/)' \
+                     | grep -vE '(^|/)[^/]*\.md$' \
+                     | grep -vE '^$' | head -1)
+
+          if [ -n "$SHIPPING" ]; then
+            echo "::error::No '## [current]' section in CHANGELOG.md, so ${VERSION}"
+            echo "would ship with nothing recorded, and shipping code changed"
+            echo "since ${LAST_TAG:-the last release} (for example ${SHIPPING})."
+            echo "Add the entry under a '## [current]' heading, or put"
+            echo "[skip changelog] in the release-trigger commit if this"
+            echo "release is genuinely empty."
+            exit 1
+          fi
+
+          echo "::notice::Nothing under [current], and nothing outside docs,"
+          echo "tests, benchmarks and CI has changed since ${LAST_TAG:-the last"
+          echo "release}. There is no release to cut, so this run stops here"
+          echo "rather than failing."
+          {
+            echo "### No release cut"
+            echo ""
+            echo "\`## [current]\` is empty and only non-shipping paths changed"
+            echo "since \`${LAST_TAG:-the last release}\`, so there is nothing to"
+            echo "release. The next merge that records an entry will cut one."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
         fi
 
         # Only commit if there are staged changes


### PR DESCRIPTION
Fixes the release job going red on merges that have nothing to release.

## What broke

A release leaves an empty `## [current]` behind it, so the very next merge to main
arrives with nothing under that heading. This job treated that as an error:

```
##[error]No '## [current]' section in CHANGELOG.md, so 0.617.0
```

That run was triggered by merging #1836, a chore PR that changed six files under
`asks/` and nothing else. There was no release to cut and nothing was wrong, but the
job failed and the pipeline stayed red until a PR happened to merge that added an
entry.

## What this does not change

The guard exists because 0.506.0 through 0.509.0 shipped with their work recorded
nowhere, and a release that ships in silence has to stay impossible. That property is
kept, and skipping serves it better than failing did: no release is cut either way,
and the pipeline is not left red in the meantime.

## What it does

An empty `[current]` now asks what actually changed since the last tag.

- Anything outside `docs/`, `tests/`, `benchmarks/`, `examples/`, `.github/` and
  markdown has changed: still an error, and the message names the file that made it
  one.
- Only those paths changed: the job writes a step summary saying why no release is
  being cut, and stops cleanly.

## Checked, not reasoned about

The decision logic was lifted out and driven against fixtures:

| case | result |
|---|---|
| empty `[current]`, only docs/tests/CI/bench/markdown changed | no release cut, exit 0 |
| empty `[current]`, `std/net/aether_http.c` changed | error, names the file, exit 1 |
| empty `[current]`, `std/http/proxy/aether_proxy_lb.c` changed | error, names the file, exit 1 |
| `[current]` has an entry | cuts the release |
| `[current]` has only a `### Fixed` subheading, no entry | counts as empty, no release cut |

And against the real failure: the six `asks/*.md` files from #1836 classify as
non-shipping, so the run that broke would now stop cleanly instead of failing.

## Not the cause, for the record

While tracing this I checked two things that looked like failures and were not.
`release/v0.617.0` shows all three workflows red with zero jobs; those runs were
cancelled when the PR merged ninety seconds later, and a run cancelled during startup
reports as a failure with no jobs. v0.617.0 is tagged and its publish run was still
queued at the time of writing, so it was in flight rather than stuck.