### PR TITLE
perf(http): scan the client's headers with memchr, and copy URLs without printf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **The client's request headers are scanned with `memchr`, and URLs are copied
+  without `printf`.** Two remaining instances of patterns already fixed
+  elsewhere on this path. `ev_request_complete` looked for the header
+  terminator with `strstr`, where the response side had already been converted;
+  it now takes a length rather than trusting the buffer to be NUL-terminated.
+  `parse_url` used `snprintf(dst, n, "%s", src)` three times to copy strings,
+  and it runs once per proxied request.
+
+  This is **not a speedup and is not recorded as one**. It takes last-level
+  cache misses from about 71 to about 58 per request and instructions from
+  ~17.9k to ~17.4k, and moves a paired eight-round A/B by +0.0% on the
+  least-contended round. It is here because replacing `strstr` on a four byte
+  needle and `printf` on a string copy is better code either way. The
+  benchmark README now records what that cost to learn: neither instruction
+  counts nor simulated cache misses predict wall clock on this path, and only
+  a paired A/B decides.
+
 ## [0.617.0]
 
 ### Fixed

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -68,6 +68,20 @@ answered by cache; ninety of ours per request are not, and at roughly 80ns
 each that is several microseconds, which is the whole of the gap. Work on this
 path should be judged on that column, not on instructions.
 
+**And it does not predict wall clock either.** Removing the client-side
+`strstr` and the `snprintf`-to-copy-a-string in `parse_url` took last-level
+misses from ~71 to ~58 per request and instructions from ~17.9k to ~17.4k, and
+moved a paired eight-round A/B by +0.0% on the least-contended round. The
+memset change earlier in the same effort moved misses by a similar amount and
+was worth -12% CPU per request. So misses removed off the critical path, which
+the hardware was already absorbing through prefetch and out-of-order execution,
+look identical here to misses that mattered.
+
+The order to trust, then: a paired A/B in `run.sh` decides whether a change is
+worth having. `cachemisses.sh` and `instructions.sh` say what a change did to
+the work done, which is useful for understanding and useless as a verdict.
+Three separate rounds of this effort optimised a counter and bought nothing.
+
 Two things about measuring it, both learned by getting them wrong first:
 
 - **Concurrency is not optional.** Driving a single connection shows aether

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -101,6 +101,17 @@ static void http_init(void) {
 //   https://foo.example/bar  →  host="foo.example" port=443 path="/bar" use_tls=1
 //   http://foo:8080/         →  host="foo"         port=8080 path="/"   use_tls=0
 // Returns 1 on success, 0 on malformed input.
+/* A bounded string copy. snprintf(dst, n, "%s", src) does the same thing and
+ * brings the whole formatting machinery with it, which parse_url paid for
+ * three times on a path that runs once per proxied request. */
+static void url_copy(char* dst, size_t cap, const char* src) {
+    if (!cap) return;
+    size_t n = strlen(src);
+    if (n >= cap) n = cap - 1;
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
 int parse_url(const char* url, char* host, size_t host_size,
                      int* port, char* path, size_t path_size, int* use_tls) {
     if (!url || !host || !port || !path || !use_tls ||
@@ -131,19 +142,19 @@ int parse_url(const char* url, char* host, size_t host_size,
         host[host_len] = '\0';
         *port = atoi(colon + 1);
         if (slash) {
-            snprintf(path, path_size, "%s", slash);
+            url_copy(path, path_size, slash);
         } else {
-            snprintf(path, path_size, "/");
+            url_copy(path, path_size, "/");
         }
     } else if (slash) {
         size_t host_len = slash - start;
         if (host_len >= host_size) host_len = host_size - 1;
         memcpy(host, start, host_len);
         host[host_len] = '\0';
-        snprintf(path, path_size, "%s", slash);
+        url_copy(path, path_size, slash);
     } else {
-        snprintf(host, host_size, "%s", start);
-        snprintf(path, path_size, "/");
+        url_copy(host, host_size, start);
+        url_copy(path, path_size, "/");
     }
 
     return 1;

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -344,7 +344,11 @@ static int ev_request_complete(EvConn* c, size_t* out_total) {
      * the terminator. */
     if (!c->in_hdr_end) {
         size_t from = c->in_scanned > 3 ? c->in_scanned - 3 : 0;
-        char* found = strstr(c->in + from, "\r\n\r\n");
+        /* memchr for the CR, like the response side already does: strstr pays
+         * a two-way-algorithm setup before it looks at a byte, which is a poor
+         * trade for a four byte needle, and this runs on every request the
+         * client sends. Length-bounded rather than trusting the NUL. */
+        const char* found = http_find_header_end(c->in + from, c->in_len - from);
         c->in_scanned = c->in_len;
         if (!found) return 0;
         c->in_hdr_end = (size_t)((found + 4) - c->in);


### PR DESCRIPTION
Two remaining instances of patterns already fixed elsewhere on this path, in the two
places that were missed.

`ev_request_complete` scanned the **client's** request for the header terminator with
`strstr`. The response side was converted to a `memchr` scan earlier in this effort;
this is the request side. It now takes a length rather than trusting the buffer to be
NUL-terminated, so it is binary-safe by construction.

`parse_url` used `snprintf(dst, n, "%s", src)` three times to copy strings, and it runs
once per proxied request to split the upstream URL. glibc brings the whole formatting
machinery along for that.

## What it bought, and what it did not

```
last-level misses per request   ~71   -> ~58     (-18%, two runs)
instructions per request        ~17.9k -> ~17.4k (-3%)
wall clock, paired 8 rounds     -0.6% rps, +0.5% CPU/req, +0.0% least-contended round
```

The counters moved and the clock did not. **This is not a speedup and is not recorded
as one.** It is here because replacing `strstr` on a four-byte needle and `printf` on a
string copy is better code either way, and because the scan becomes length-bounded
instead of NUL-dependent.

## The reason that matters more than the change

The `memset` change earlier in this effort moved cache misses by a similar amount and
was worth **-12% CPU per request**. This one moved them the same and was worth nothing.
Misses that the hardware already absorbs through prefetch and out-of-order execution
look identical in that counter to misses that actually cost time.

So neither instruction counts nor simulated cache misses predict wall clock on this
path. The README now says so, with both examples, and states the order to trust: a
paired A/B in `run.sh` decides whether a change is worth having; `cachemisses.sh` and
`instructions.sh` explain what a change did to the work done and are useless as a
verdict. Three rounds of this effort optimised a counter and bought nothing, which is
what that note exists to stop happening again.

## Evidence

| check | result |
|---|---|
| unit | 409 passed, 0 failed |
| http_reverse_proxy | 14/14 |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_reverse_proxy_pool_extra | 8/8 |
| http_proxy_stale_pooled_connection | 60/60 |
| http_client_forward_proxy | pass |
| compiler warnings | 0 |

The direct pass-through still emits bytes identical to the copying path across all five
shapes, which is what holds a change to the request scan honest.