### PR TITLE
ci: do not run the full matrix on a release bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,24 @@
 name: Aether CI
 
+# A change that touches only VERSION and CHANGELOG.md is a release bump, and
+# that tree was already built and tested on main before the release was cut.
+# Running the full matrix on it again gains nothing and costs twice over: the
+# runs queue behind main's, and the release PR is merged before they are given
+# a runner, so every release leaves abandoned runs recorded as failures. Every
+# release branch from v0.614.0 onward shows three of them, while the releases
+# themselves published fine.
+#
+# Skipping also frees the runners the Release workflow queues behind, which is
+# what left v0.617.0 unpublished for a quarter of an hour after its tag
+# existed. paths-ignore skips only when every changed file matches, so a commit
+# that touches code and the changelog together still runs in full.
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   pull_request:
     branches: [ main, develop ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -1,10 +1,24 @@
 name: Memory Leak Detection
 
+# A change that touches only VERSION and CHANGELOG.md is a release bump, and
+# that tree was already built and tested on main before the release was cut.
+# Running the full matrix on it again gains nothing and costs twice over: the
+# runs queue behind main's, and the release PR is merged before they are given
+# a runner, so every release leaves abandoned runs recorded as failures. Every
+# release branch from v0.614.0 onward shows three of them, while the releases
+# themselves published fine.
+#
+# Skipping also frees the runners the Release workflow queues behind, which is
+# what left v0.617.0 unpublished for a quarter of an hour after its tag
+# existed. paths-ignore skips only when every changed file matches, so a commit
+# that touches code and the changelog together still runs in full.
 on:
   push:
     branches: [ main, master, develop ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   pull_request:
     branches: [ main, master, develop ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,12 +1,26 @@
 name: Windows Build
 
+# A change that touches only VERSION and CHANGELOG.md is a release bump, and
+# that tree was already built and tested on main before the release was cut.
+# Running the full matrix on it again gains nothing and costs twice over: the
+# runs queue behind main's, and the release PR is merged before they are given
+# a runner, so every release leaves abandoned runs recorded as failures. Every
+# release branch from v0.614.0 onward shows three of them, while the releases
+# themselves published fine.
+#
+# Skipping also frees the runners the Release workflow queues behind, which is
+# what left v0.617.0 unpublished for a quarter of an hour after its tag
+# existed. paths-ignore skips only when every changed file matches, so a commit
+# that touches code and the changelog together still runs in full.
 on:
   # push to main also runs so the merge build can FILL the miniaudio object
   # cache (PR runs only read it; see the Restore/Save split below).
   push:
     branches: [ main ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   pull_request:
     branches: [ main, develop ]
+    paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   workflow_dispatch:
 
 # Build the Aether compiler and ae CLI on Windows using MinGW (GCC).


### PR DESCRIPTION
Every release branch since v0.614.0 shows all three heavy workflows failed:

| branch | Aether CI | Windows Build | Memory Leak |
|---|---|---|---|
| release/v0.614.0 | failure | failure | failure |
| release/v0.615.0 | failure | failure | failure |
| release/v0.616.0 | failure | failure | failure |
| release/v0.617.0 | failure | failure | failure |

Every one of those releases published fine, with six assets each. **These are not test
failures.** The runs have zero jobs and no logs (the logs endpoint 404s), and each one
lives exactly as long as its pull request:

```
release/v0.617.0   run created 03:22:13   PR merged 03:23:47   run updated 03:23:49
release/v0.616.0   run created 22:38:18   PR merged 22:47:10   run updated 22:47:11
```

A release PR changes only `VERSION` and `CHANGELOG.md`. Its runs queue behind main's,
the PR is merged about ninety seconds later, and the runs are terminated before ever
getting a runner. GitHub records that as a failure.

## The fix

`paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]` on the push and pull_request triggers of
`ci.yml`, `windows.yml` and `memory-check.yml`. The tree in a release PR was already
built and tested on main before the release was cut, so there is nothing in it to test.

`paths-ignore` skips only when **every** changed file matches, so this is narrower than
it looks. Checked against four shapes:

| PR shape | skipped |
|---|---|
| `VERSION` + `CHANGELOG.md` (a release bump) | yes |
| `std/net/aether_http.c` + `CHANGELOG.md` | no |
| `docs/x.md` | no |
| `tests/integration/a.sh` | no |

## The second reason

Skipping frees the runners the Release workflow queues behind. v0.617.0 sat unpublished
for a quarter of an hour after its tag existed, waiting for a runner while three
matrices it did not need ran ahead of it. That is the "releases are not being generated"
symptom, and it has the same cause as the red X's.

## Safety

main has no branch protection and no required status checks (the protection endpoint
404s), so nothing depends on these runs reporting in order for a release PR to merge.