### PR TITLE
perf(proxy): do not start eight idle worker threads when the driver owns traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **A reverse proxy no longer starts eight worker threads that cannot receive
+  work.** It ran 12 threads on two cores where nginx runs 2 and haproxy 3.
+  Eight were connection-pool workers, and the event driver serves every proxied
+  request on a driver thread, so none of them could ever be handed one; the
+  pool exists for the path where a worker is held for a whole upstream round
+  trip, and `HTTP_POOL_MIN_WORKERS` is 8 so that floor applied even on two
+  cores. The pool is now sized knowing whether the driver is running, and still
+  serves the hand-back path. **12 threads to 6.**
+
+  This is not recorded as a wall-clock win: two paired A/B runs had the controls
+  moving 37.6% and 103.9% between rounds, which the harness says makes any delta
+  unreadable. What it provably does is stop creating eight threads that cannot
+  serve a proxied request. The reason to look here is `split.sh`, which puts the
+  whole of the gap against nginx and haproxy in kernel time while our user time
+  is the lowest of the three and we make the fewest syscalls.
+
 ## [0.618.0]
 
 ### Changed

--- a/benchmarks/http/lbbench/README.md
+++ b/benchmarks/http/lbbench/README.md
@@ -51,6 +51,35 @@ needs a privileged container for the scheduler tracepoint, and
 machine usually does not expose. It says so and stops rather than reporting a
 count it could not take.
 
+### The gap is in the kernel, and our user space is already the fastest
+
+Run `split.sh` before optimising anything on this path. At 50 connections:
+
+| | total | user | kernel |
+|---|---|---|---|
+| aether | 18.5 us/req | **4.9 (26.6%)** | **13.5 (73.4%)** |
+| nginx | 16.5 us/req | 5.7 (34.4%) | 10.8 (65.6%) |
+| haproxy | 16.6 us/req | 7.0 (42.0%) | 9.6 (58.0%) |
+
+We have the **lowest user time of the three** and the highest kernel time. We also
+make the **fewest syscalls**: 4.58 per request against nginx's 5.14 and haproxy's
+6.29. So the whole of the gap is kernel time at fewer calls, meaning our calls cost
+more, not that we make too many.
+
+That is why a long run of user-space optimisation moved counters and not the clock:
+it was tuning the half we were already winning. Two further things are known about
+it:
+
+- It is concurrency-dependent. At 2 connections all three sit within 5% of each
+  other on kernel time (38.9, 37.0, 38.6) and aether is fastest overall. The gap
+  only appears at 50.
+- It is not buffer size. Shrinking the per-connection buffers by 4x left the split
+  at 26.7/73.3, unchanged, and left the ratio to nginx's kernel time at 1.26.
+
+What has not been established is why the calls cost more. `perf` cannot run on the
+usual dev box (no PMU, and it is broken against the linuxkit kernel), and that is
+the instrument this needs.
+
 ### Fewer instructions is not the same as faster
 
 `cachemisses.sh` exists because an instruction count sent an optimisation

--- a/std/net/aether_http_pool.c
+++ b/std/net/aether_http_pool.c
@@ -76,10 +76,25 @@ struct HttpConnectionPool {
 
 /* Connection handlers block on socket I/O rather than burning CPU, so the
  * pool is sized above the core count. */
-static int http_pool_worker_count(void) {
+/* `evloop_owns` is true when the event driver is running, which means every
+ * proxied request is served on a driver thread and never occupies a worker
+ * here. The sizing below exists for the opposite case, where a worker is held
+ * for a whole upstream round trip, so with the driver present it buys nothing
+ * and costs a thread apiece. A pure reverse proxy was starting eight idle
+ * workers on two cores, which is where most of its thread count came from. */
+static int http_pool_worker_count(int evloop_owns) {
     long cores = aether_cpu_available();
 
     long want = cores * 2;
+    long floor = HTTP_POOL_MIN_WORKERS;
+    if (evloop_owns) {
+        /* Enough to keep the hand-back path moving: a request the proxy
+         * declines, a health or admin route on the same server, a drained
+         * connection. None of those is the hot path when a driver is running,
+         * and the queue in front of these absorbs a burst. */
+        want = 2;
+        floor = 2;
+    }
 
     /* Overridable, because cores * 2 is the right shape for handlers that
      * compute and the wrong one for handlers that wait. A worker owns its
@@ -98,7 +113,7 @@ static int http_pool_worker_count(void) {
         if (end && *end == '\0' && from_env > 0) want = from_env;
     }
 
-    if (want < HTTP_POOL_MIN_WORKERS) want = HTTP_POOL_MIN_WORKERS;
+    if (want < floor) want = floor;
     if (want > HTTP_POOL_MAX_WORKERS) want = HTTP_POOL_MAX_WORKERS;
     return (int)want;
 }
@@ -137,7 +152,7 @@ HttpConnectionPool* http_pool_create(HttpServer* server) {
     pthread_cond_init(&pool->not_empty, NULL);
     pthread_cond_init(&pool->not_full, NULL);
 
-    int want = http_pool_worker_count();
+    int want = http_pool_worker_count(server->evloop != NULL);
     for (int i = 0; i < want; i++) {
         /* CRITICAL: only count threads that actually started. Joining an
          * uninitialised pthread_t in http_pool_destroy is undefined

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -5297,6 +5297,21 @@ int http_server_start_raw(HttpServer* server) {
         }
 
 #if AETHER_HAS_THREADS
+        /* The proxy driver, when this server proxies and its connections are
+         * plain HTTP. One driver per core is the shape that removes the cost:
+         * more threads than cores would put the sleeping back, and fewer would
+         * leave cores idle. It returns NULL when there is no proxy mounted or
+         * the platform has no poller, and then nothing below changes.
+         *
+         * Started before the pool, not after, so the pool can be sized knowing
+         * whether proxied connections will ever reach it. It reads only the
+         * mounted proxy options at this point and nothing the pool owns. */
+        if (!server->h2_enabled) {
+            int cores = aether_cpu_available();
+            if (cores > 8) cores = 8;
+            server->evloop = http_evloop_start(server, cores);
+        }
+
         HttpConnectionPool* pool = http_pool_create(server);
         server->conn_pool = pool;
         /* The lot resubmits woken connections into the same pool. Capacity is
@@ -5304,17 +5319,6 @@ int http_server_start_raw(HttpServer* server) {
          * idle keep-alive clients cost a table slot each. */
         if (pool) {
             server->park_lot = http_park_create(server, http_park_resume, 4096);
-        }
-
-        /* The proxy driver, when this server proxies and its connections are
-         * plain HTTP. One driver per core is the shape that removes the cost:
-         * more threads than cores would put the sleeping back, and fewer would
-         * leave cores idle. It returns NULL when there is no proxy mounted or
-         * the platform has no poller, and then nothing below changes. */
-        if (!server->h2_enabled) {
-            int cores = aether_cpu_available();
-            if (cores > 8) cores = 8;
-            server->evloop = http_evloop_start(server, cores);
         }
 #endif
 


### PR DESCRIPTION
A reverse proxy ran **12 threads on two cores**. nginx runs 2, haproxy 3.

Eight of them were connection-pool workers that **could never receive work**. The event
driver serves every proxied request on a driver thread; the pool exists for the opposite
case, where a worker is held for a whole upstream round trip. `HTTP_POOL_MIN_WORKERS` is
8, so that floor applied even on two cores.

```
threads under load, two cores:   12 -> 6      (nginx 2, haproxy 3)
```

The pool is now sized knowing whether the driver is running. It still serves the
hand-back path (a request the proxy declines, a health or admin route on the same
server, a drained connection), and the queue in front of it absorbs a burst. The driver
starts before the pool so the pool can be sized from `server->evloop`;
`http_evloop_start` reads only the mounted proxy options at that point and nothing the
pool owns, so the order is safe.

## Why here

`split.sh` puts the whole of the gap in **kernel time**, and this was the one structural
difference found that lands in that half:

| at 50 connections | total | user | kernel |
|---|---|---|---|
| aether | 18.5 us/req | **4.9 (26.6%)** | **13.5 (73.4%)** |
| nginx | 16.5 us/req | 5.7 (34.4%) | 10.8 (65.6%) |
| haproxy | 16.6 us/req | 7.0 (42.0%) | 9.6 (58.0%) |

We have the **lowest user time of the three** and make the **fewest syscalls** (4.58/req
against nginx 5.14, haproxy 6.29). That is why a long run of user-space optimisation
moved instruction counts and cache misses without moving the clock: it was tuning the
half we were already winning. The README now records that, so the next person starts
from it.

## What this does not claim

**Not a proven wall-clock win.** Two paired A/B runs came back with the controls moving
37.6% and 103.9% between rounds, which the harness itself says makes any delta
unreadable; nginx's own figure swung between 9.6 and 55.6 us/req across them. The
least-contended round showed -6.6% and -7.3%, the medians +0.3% and -0.4%. None of that
is separable from noise on this machine, and I am not going to present it as a speedup.

What is provable and is the reason to merge: eight threads that cannot serve a proxied
request are no longer created. Verifying the timing needs a quiet box, and the honest
place for that is the N100 rather than Docker-on-Apple-Silicon.

## Evidence

| check | result |
|---|---|
| unit | 409 passed, 0 failed |
| http_reverse_proxy | 14/14 |
| http_reverse_proxy_pool / _extra | 9/9, 8/8 |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_proxy_stale_pooled_connection | 60/60 |
| http_client_disconnect | pass |
| http_reverse_proxy_tls | 4/4 |
| http_proxy_response_injection | 2/2 paths |
| compiler warnings | 0 |

The pool suites matter most here: they exercise the hand-back path that the remaining
workers serve.