### PR TITLE
perf(proxy): send a small response in one call instead of a scatter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **A small response leaves the proxy in one `send()` instead of a scatter
+  list.** A pass-through answered with a two-segment `sendmsg`, the head from
+  the connection's buffer and the body from wherever the upstream's bytes
+  landed. That is the right shape for a large body, which is why the
+  pass-through exists, and the wrong one for a small one, where the `msghdr`
+  the kernel walks costs more than copying a few dozen bytes. A body of 2 KiB
+  or less now joins the head; a larger one still leaves from where it landed.
+  **Syscalls per request 4.58 to 4.30**, with `sendmsg` gone from the profile.
+  That count does not vary with load, which is why it is quoted and no
+  wall-clock claim is: the ratio of this proxy's kernel time to nginx's swung
+  between 1.25 and 1.37 across runs that changed nothing.
+
 ## [0.620.0]
 
 ### Fixed

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -711,11 +711,19 @@ static int ev_step_client_send(EvDriver* d, EvConn* c) {
              * disposition for that is to kill the process. The server ignores
              * SIGPIPE when it starts, and this asks for the same per call so
              * an embedder that sets its own disposition is still safe. */
-            struct msghdr msg;
-            memset(&msg, 0, sizeof(msg));
-            msg.msg_iov    = iov;
-            msg.msg_iovlen = (size_t)n_iov;
-            w = sendmsg(c->client_fd, &msg, AE_SEND_NOSIGNAL);
+            if (n_iov == 1) {
+                /* One segment needs no scatter list. send() skips the msghdr
+                 * the kernel would otherwise have to walk, and takes the same
+                 * flags. */
+                w = send(c->client_fd, iov[0].iov_base, iov[0].iov_len,
+                         AE_SEND_NOSIGNAL);
+            } else {
+                struct msghdr msg;
+                memset(&msg, 0, sizeof(msg));
+                msg.msg_iov    = iov;
+                msg.msg_iovlen = (size_t)n_iov;
+                w = sendmsg(c->client_fd, &msg, AE_SEND_NOSIGNAL);
+            }
         }
         if (w > 0) {
             size_t left = (size_t)w;
@@ -1029,6 +1037,20 @@ static int ev_try_direct(EvDriver* d, EvConn* c) {
     c->out_body      = direct.body;
     c->out_body_len  = direct.body_len;
     c->out_body_sent = 0;
+
+    /* A body small enough to copy joins the head, so the response leaves in
+     * one send() rather than a two-segment sendmsg. The copy is a few dozen
+     * bytes; the scatter list it removes is a msghdr the kernel walks on every
+     * response. A large body still goes out from where it landed, which is the
+     * whole point of the pass-through. */
+    if (direct.body && direct.body_len > 0 && direct.body_len <= 2048 &&
+        head_len + (size_t)direct.body_len + 1 <= c->out_cap) {
+        memcpy(c->out + head_len, direct.body, (size_t)direct.body_len);
+        c->out_len      = head_len + (size_t)direct.body_len;
+        c->out_body     = NULL;
+        c->out_body_len = 0;
+    }
+
     c->state = EV_CLIENT_SEND;
     return 1;
 }


### PR DESCRIPTION
A pass-through answered with a two-segment `sendmsg`: the head from the connection's
buffer, the body from wherever the upstream's bytes landed. That is the right shape for
a large body, which is the reason the pass-through exists, and the wrong one for a small
one, where the `msghdr` the kernel walks costs more than copying a few dozen bytes.

A body of 2 KiB or less now joins the head and goes out with `send()`. A larger one still
leaves from where it landed and still uses `sendmsg`, so the zero-copy path for real
payloads is untouched.

```
syscalls per request   4.58 -> 4.30      and sendmsg disappears from the profile
```

That count does not move with load, which is the only reason it is quotable. **This box
cannot resolve wall-clock differences of this size** — the ratio of our kernel time to
nginx's swung between 1.25 and 1.37 across runs that changed nothing at all, so I am not
attaching a timing claim to it.

## Evidence

| check | result |
|---|---|
| unit | 409 passed, 0 failed |
| http_reverse_proxy | 14/14 |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_reverse_proxy_pool_extra | 8/8 |
| http_proxy_stale_pooled_connection | 60/60 |
| http_client_disconnect | pass |
| http_reverse_proxy_tls | 4/4 |
| http_proxy_response_injection | 2/2 paths |
| compiler warnings | 0 |

The equivalence suite matters most here: the direct pass-through still emits bytes
identical to the copying path across all five shapes, including the 64 KiB body that
takes the `sendmsg` path, which is what holds a change to the write path honest.

## Context

Two other things were tried on the way here and are **not** in this PR, because both
measured worse or neutral and I would rather say so than ship them:

- Dropping the permanent `EPOLLOUT` registration on the edge-triggered path: kernel-time
  ratio went from 1.25 to 1.37. The existing comment is right.
- Using `send()` for single-segment writes alone, without coalescing: no change, because
  responses had two segments and the branch never fired. It is in this PR only because
  coalescing makes one segment the ordinary case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)