### PR TITLE
perf(proxy): keep a few upstream connections on the thread that used them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ version number before tagging the release.
   wall-clock claim is: the ratio of this proxy's kernel time to nginx's swung
   between 1.25 and 1.37 across runs that changed nothing.
 
+- **The upstream connection pool is no longer locked on every proxied
+  request.** The pool is one list behind one mutex, and a request took it
+  twice: once to borrow a connection and once to return it. Every driver thread
+  did that on every request, so it was the piece of this path that got worse as
+  threads were added, and the cost landed in kernel time where this proxy is
+  already behind both controls. A connection belongs to one driver for its
+  whole life, so the thread that returns it is the thread that wants it next: a
+  few per thread are now kept in front of the shared pool and the steady state
+  never takes the lock. **`futex` disappears from the syscall profile.**
+  Anything the cache cannot hold falls through to the shared pool exactly as
+  before, so the caps, the expiry sweep and the HTTP client's own use of the
+  pool are unchanged, and a cached connection is checked against the same idle
+  timeout the sweep uses so a stale one is closed rather than handed out.
+
 ## [0.620.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **The upstream connection pool is no longer locked on every proxied
+  request.** The pool is one list behind one mutex, and a request took it
+  twice: once to borrow a connection and once to return it. Every driver thread
+  did that on every request, so it was the piece of this path that got worse as
+  threads were added, and the cost landed in kernel time where this proxy is
+  already behind both controls. A connection belongs to one driver for its
+  whole life, so the thread that returns it is the thread that wants it next: a
+  few per thread are now kept in front of the shared pool and the steady state
+  never takes the lock. **`futex` disappears from the syscall profile.**
+  Anything the cache cannot hold falls through to the shared pool exactly as
+  before, so the caps, the expiry sweep and the HTTP client's own use of the
+  pool are unchanged, and a cached connection is checked against the same idle
+  timeout the sweep uses so a stale one is closed rather than handed out.
+
+
 ## [0.621.0]
 
 ### Changed
@@ -26,20 +43,6 @@ version number before tagging the release.
   That count does not vary with load, which is why it is quoted and no
   wall-clock claim is: the ratio of this proxy's kernel time to nginx's swung
   between 1.25 and 1.37 across runs that changed nothing.
-
-- **The upstream connection pool is no longer locked on every proxied
-  request.** The pool is one list behind one mutex, and a request took it
-  twice: once to borrow a connection and once to return it. Every driver thread
-  did that on every request, so it was the piece of this path that got worse as
-  threads were added, and the cost landed in kernel time where this proxy is
-  already behind both controls. A connection belongs to one driver for its
-  whole life, so the thread that returns it is the thread that wants it next: a
-  few per thread are now kept in front of the shared pool and the steady state
-  never takes the lock. **`futex` disappears from the syscall profile.**
-  Anything the cache cannot hold falls through to the shared pool exactly as
-  before, so the caps, the expiry sweep and the HTTP client's own use of the
-  pool are unchanged, and a cached connection is checked against the same idle
-  timeout the sweep uses so a stale one is closed rather than handed out.
 
 ## [0.620.0]
 

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -564,8 +564,17 @@ typedef struct {
 
 static AETHER_TLS HttpTCacheSlot http_tcache[HTTP_TCACHE_MAX];
 static AETHER_TLS int            http_tcache_n = 0;
+/* Off unless this thread owns its connections for their whole life, which is
+ * true of an event-driver thread and of nothing else. The HTTP client's work
+ * moves between scheduler threads, so a connection parked on the thread that
+ * returned it would be invisible to the thread that asks next and the shared
+ * pool would never see it either: the client would dial every time. */
+static AETHER_TLS int            http_tcache_on = 0;
+
+void http_pool_thread_cache_enable(void) { http_tcache_on = 1; }
 
 static int http_tcache_take(const char* key, Transport* out, int64_t now) {
+    if (!http_tcache_on) return 0;
     for (int i = http_tcache_n - 1; i >= 0; i--) {
         if (strcmp(http_tcache[i].key, key) != 0) continue;
         Transport t = http_tcache[i].t;
@@ -582,6 +591,7 @@ static int http_tcache_take(const char* key, Transport* out, int64_t now) {
 }
 
 static int http_tcache_put(const char* key, Transport* t, int64_t now) {
+    if (!http_tcache_on) return 0;
     if (http_tcache_n >= HTTP_TCACHE_MAX) return 0;
     size_t kl = strlen(key);
     if (kl >= HTTP_POOL_KEY_MAX) return 0;

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -537,8 +537,66 @@ static void http_pool_expire_locked(int64_t now) {
 
 /* Take an idle connection for `key`, newest first (the most recently used is
  * the one the peer is least likely to have closed). Returns 1 on a hit. */
+/* A few connections kept on the thread that last used them, in front of the
+ * shared pool.
+ *
+ * The shared pool is one list behind one mutex, and a proxied request takes it
+ * twice: once to borrow an upstream and once to give it back. Every driver
+ * thread does that on every request, so the lock is the piece of this path
+ * that gets worse as threads are added, and the cost lands in kernel time
+ * where this proxy is already behind both controls.
+ *
+ * A connection belongs to one driver for its whole life, so the thread that
+ * returns it is the thread that will want it next: a handful per thread serves
+ * the steady state without touching the lock. Anything the cache cannot hold
+ * falls through to the shared pool exactly as before, so the caps, the expiry
+ * sweep and the client's own use of the pool are unchanged.
+ *
+ * Entries are checked against the same idle timeout the sweep uses, so a
+ * cached connection that went stale is closed here rather than handed out. */
+#define HTTP_TCACHE_MAX 4
+
+typedef struct {
+    Transport t;
+    char      key[HTTP_POOL_KEY_MAX];
+    int64_t   idle_since_ms;
+} HttpTCacheSlot;
+
+static AETHER_TLS HttpTCacheSlot http_tcache[HTTP_TCACHE_MAX];
+static AETHER_TLS int            http_tcache_n = 0;
+
+static int http_tcache_take(const char* key, Transport* out, int64_t now) {
+    for (int i = http_tcache_n - 1; i >= 0; i--) {
+        if (strcmp(http_tcache[i].key, key) != 0) continue;
+        Transport t = http_tcache[i].t;
+        int64_t idle = http_tcache[i].idle_since_ms;
+        http_tcache[i] = http_tcache[--http_tcache_n];
+        if (now - idle >= http_pool_idle_ms) {
+            transport_close(&t);
+            return 0;                  /* stale: the caller dials instead */
+        }
+        *out = t;
+        return 1;
+    }
+    return 0;
+}
+
+static int http_tcache_put(const char* key, Transport* t, int64_t now) {
+    if (http_tcache_n >= HTTP_TCACHE_MAX) return 0;
+    size_t kl = strlen(key);
+    if (kl >= HTTP_POOL_KEY_MAX) return 0;
+    HttpTCacheSlot* s = &http_tcache[http_tcache_n];
+    s->t = *t;
+    memcpy(s->key, key, kl);
+    s->key[kl] = '\0';
+    s->idle_since_ms = now;
+    http_tcache_n++;
+    return 1;
+}
+
 static int http_pool_take(const char* key, Transport* out) {
     if (!http_pool_enabled) return 0;
+    if (http_tcache_take(key, out, http_now_ms())) return 1;
     int found = 0;
     pthread_mutex_lock(http_pool_lock());
     http_pool_expire_locked(http_now_ms());
@@ -566,6 +624,7 @@ static void http_pool_put(const char* key, Transport* t) {
         transport_close(t);
         return;
     }
+    if (http_tcache_put(key, t, http_now_ms())) return;
     HttpIdleConn* c = (HttpIdleConn*)malloc(sizeof(HttpIdleConn));
     if (!c) {
         transport_close(t);

--- a/std/net/aether_http.h
+++ b/std/net/aether_http.h
@@ -381,6 +381,10 @@ int http_find_header_in_block(const char* block, const char* end,
 typedef struct HttpUpstreamConnOpaque HttpUpstreamConn;
 
 int  http_upstream_acquire(const char* host, int port, HttpUpstreamConn* out);
+/* Let this thread keep a few upstream connections of its own in front of the
+ * shared pool. Only for a thread that owns its connections for their whole
+ * life; see the note on the cache itself. */
+void http_pool_thread_cache_enable(void);
 /* As above, but `allow_pool` 0 forces a fresh connection. Use it when a pooled
  * connection has just been found closed: the pool may hold more of them, and
  * spending a retry on another corpse is how a client ends up with nothing. */

--- a/std/net/aether_http_evloop.c
+++ b/std/net/aether_http_evloop.c
@@ -1248,6 +1248,9 @@ static void ev_take_submissions(EvDriver* d) {
 
 static void* ev_driver_main(void* arg) {
     EvDriver* d = (EvDriver*)arg;
+    /* This thread owns each of its connections from accept to close, so an
+     * upstream it returns is one it will want again. */
+    http_pool_thread_cache_enable();
     AetherIoEvent events[64];
 
     aether_io_poller_add(&d->poller, d->wake_r, NULL, AETHER_IO_READ);


### PR DESCRIPTION
The upstream connection pool is one list behind one mutex, and a proxied request took
it **twice**: once to borrow a connection and once to return it. Every driver thread did
that on every request, so the lock was the piece of this path that gets worse as threads
are added — and the cost lands in kernel time, which is where this proxy is behind both
controls *while making fewer syscalls than either*.

A connection belongs to one driver for its whole life, so the thread that returns it is
the thread that will want it next. Four per thread in front of the shared pool cover the
steady state without taking the lock at all.

```
futex disappears from the syscall profile
```

Anything the cache cannot hold falls through to the shared pool exactly as before, so
the caps, the expiry sweep, and the HTTP client's own use of the pool are unchanged. A
cached connection is checked against the same idle timeout the sweep uses, so one that
went stale is closed rather than handed out — the answer the sweep would have given it.

## No wall-clock claim

The two runs after this change put aether at 22.3 us/req against nginx's 23.9 in one,
and 25.1 against 18.5 in the next. That spread is the machine, not the code. The syscall
profile is the part that does not move with load, so it is the only thing quoted here.

## Why this, and what it leaves

`split.sh` puts the whole of the gap in kernel time while our user time is the lowest of
the three. Measured and ruled out along the way: syscall count (we make the fewest),
control fairness, buffer sizes, socket counts, connection counts, thread count, and
user-space work. Lock contention was the last structural difference reachable from here;
what remains is *why the individual calls cost more*, and that needs `perf` on hardware
where it runs.

## Evidence

| check | result |
|---|---|
| unit | 409 passed, 0 failed |
| http_reverse_proxy | 14/14 |
| http_reverse_proxy_pool / _extra | 9/9, 8/8 |
| http_proxy_stale_pooled_connection | 60/60 |
| http_proxy_direct_equivalence | 5/5 byte-identical |
| http_client_disconnect | pass |
| http_reverse_proxy_tls | 4/4 |
| compiler warnings | 0 |

The pool suites and the stale-connection suite matter most here: they exercise reuse,
the caps, and a connection the upstream closed while it sat idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)