### PR TITLE
fix(http, sandbox): redirect origin check, and permissions vs builder contexts

### DIFF
--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -4857,6 +4857,17 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
     print_line(gen, "static inline void _aether_ctx_push(void* ctx) { if (_aether_ctx_depth < 64) _aether_ctx_stack[_aether_ctx_depth++] = ctx; }");
     print_line(gen, "static inline void _aether_ctx_pop(void) { if (_aether_ctx_depth > 0) _aether_ctx_depth--; }");
     print_line(gen, "static inline void* _aether_ctx_get(void) { return _aether_ctx_depth > 0 ? _aether_ctx_stack[_aether_ctx_depth-1] : (void*)0; }");
+    /* #1704: the sandbox permission stack is SEPARATE from the builder
+     * context stack above. They used to be the same array, so entering any
+     * trailing block pushed that builder's config object onto the stack the
+     * permission checker walks. The checker then read the config as a
+     * permission list, found no entries, and denied everything: the same
+     * grant that worked in a plain function was refused inside a
+     * `spec.describe` block. Two different things were sharing one stack. */
+    print_line(gen, "static void* _aether_sandbox_stack[64];");
+    print_line(gen, "static int _aether_sandbox_depth = 0;");
+    print_line(gen, "static inline void _aether_sandbox_push(void* ctx) { if (_aether_sandbox_depth < 64) _aether_sandbox_stack[_aether_sandbox_depth++] = ctx; }");
+    print_line(gen, "static inline void _aether_sandbox_pop(void) { if (_aether_sandbox_depth > 0) _aether_sandbox_depth--; }");
     // Only emit sandbox bridge code if the program actually uses sandbox builtins.
     // This avoids preamble bloat and the list_size/list_get dependency for programs
     // that don't use sandboxing.
@@ -4894,20 +4905,20 @@ void generate_program(CodeGenerator* gen, ASTNode* program) {
         print_line(gen, "}");
         print_line(gen, "extern void aether_sandbox_audit(const char*, const char*, int);");
         print_line(gen, "static int _aether_sandbox_check_impl(const char* category, const char* resource) {");
-        print_line(gen, "    if (_aether_ctx_depth <= 0) return 1;");
+        print_line(gen, "    if (_aether_sandbox_depth <= 0) return 1;");
         print_line(gen, "    int _allowed = 1;");
-        print_line(gen, "    for (int level = 0; level < _aether_ctx_depth; level++) {");
-        print_line(gen, "        if (!_aether_perms_allow(_aether_ctx_stack[level], category, resource)) { _allowed = 0; break; }");
+        print_line(gen, "    for (int level = 0; level < _aether_sandbox_depth; level++) {");
+        print_line(gen, "        if (!_aether_perms_allow(_aether_sandbox_stack[level], category, resource)) { _allowed = 0; break; }");
         print_line(gen, "    }");
         // Audit every in-process permission check — allowed and denied.
         // The sink is opt-in (AETHER_SANDBOX_AUDIT) and the ring buffer
         // is cheap, so this is unconditional. Note this runs only when a
-        // sandbox is active (_aether_ctx_depth > 0).
+        // sandbox is active (_aether_sandbox_depth > 0).
         print_line(gen, "    aether_sandbox_audit(category, resource, _allowed);");
         print_line(gen, "    return _allowed;");
         print_line(gen, "}");
         print_line(gen, "static void _aether_sandbox_install(void) { _aether_sandbox_checker = _aether_sandbox_check_impl; }");
-        print_line(gen, "static void _aether_sandbox_uninstall(void) { if (_aether_ctx_depth <= 0) _aether_sandbox_checker = 0; }");
+        print_line(gen, "static void _aether_sandbox_uninstall(void) { if (_aether_sandbox_depth <= 0) _aether_sandbox_checker = 0; }");
         print_line(gen, "extern int aether_spawn_sandboxed(void* grant_list, const char* program, const char* arg);");
     }
     print_line(gen, "");

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -4226,12 +4226,12 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                 }
                 // ctx_push(ptr) / ctx_pop() — explicit context stack manipulation
                 else if (strcmp(func_name, "sandbox_push") == 0 && expr->child_count == 1) {
-                    fprintf(gen->output, "_aether_ctx_push((void*)(intptr_t)");
+                    fprintf(gen->output, "_aether_sandbox_push((void*)(intptr_t)");
                     generate_expression(gen, expr->children[0]);
                     fprintf(gen->output, ")");
                 }
                 else if (strcmp(func_name, "sandbox_pop") == 0 && expr->child_count == 0) {
-                    fprintf(gen->output, "_aether_ctx_pop()");
+                    fprintf(gen->output, "_aether_sandbox_pop()");
                 }
                 // sandbox_install() — activate runtime sandbox checking
                 else if (strcmp(func_name, "sandbox_install") == 0 && expr->child_count == 0) {

--- a/std/net/aether_http.c
+++ b/std/net/aether_http.c
@@ -3509,18 +3509,32 @@ HttpResponse* http_send_raw(HttpClientRequest* req) {
             break;
         }
 
-        /* Strip cross-host auth headers if the host changed.
-         * parse_url returns 1 on success — same inverted-check bug
-         * as http_resolve_location had above; without this fix the
-         * strip path never fired in practice (because parse_url
-         * always succeeds for well-formed URLs). */
+        /* Strip credentials when the redirect leaves the ORIGIN, which is
+         * scheme + host + port together, not the host alone (#1741). The port
+         * and TLS flag were parsed here and then never compared, so a redirect
+         * from http://host:8080/ to http://host:9090/ replayed the caller's
+         * Authorization and Cookie headers at a different service on the same
+         * machine, owned by whoever holds that port. An http -> https upgrade
+         * changes the origin the same way. This is curl's rule: any of the
+         * three changing drops the credentials.
+         *
+         * parse_url always fills the port from the scheme (80 / 443) and lets
+         * an explicit :port override it, so http://host and http://host:80
+         * compare equal and only a real origin change strips.
+         *
+         * parse_url returns 1 on success — same inverted-check bug as
+         * http_resolve_location had above; without that fix the strip path
+         * never fired in practice (because parse_url always succeeds for
+         * well-formed URLs). */
         char curr_host[256], next_host[256], dummy_path[1024];
         int curr_port = 0, next_port = 0, curr_tls = 0, next_tls = 0;
         if (parse_url(current_url, curr_host, sizeof(curr_host), &curr_port,
                       dummy_path, sizeof(dummy_path), &curr_tls) != 0 &&
             parse_url(next_url, next_host, sizeof(next_host), &next_port,
                       dummy_path, sizeof(dummy_path), &next_tls) != 0) {
-            if (strcmp(curr_host, next_host) != 0) {
+            if (strcmp(curr_host, next_host) != 0 ||
+                curr_port != next_port ||
+                curr_tls != next_tls) {
                 http_strip_cross_host_headers(req);
             }
         }

--- a/tests/ae_sweep_prune.txt
+++ b/tests/ae_sweep_prune.txt
@@ -108,6 +108,7 @@ tests/integration/http_middleware_d1/
 tests/integration/http_middleware_d2/
 tests/integration/http_park_idle_connections/
 tests/integration/http_redirect_cross_host/
+tests/integration/http_redirect_cross_port/
 tests/integration/http_real_ip/
 tests/integration/http_request_conn_accessors/
 tests/integration/http_request_header_iter/

--- a/tests/integration/http_redirect_cross_host/driver.ae
+++ b/tests/integration/http_redirect_cross_host/driver.ae
@@ -9,8 +9,9 @@
 //   /start -> localhost:18211   (host name differs: must be stripped)
 //   /same  -> 127.0.0.1:18211   (host name identical: must survive)
 //
-// Port is deliberately equal on both hops: the implemented rule compares the
-// parsed host and nothing else, so keeping the port fixed isolates it.
+// Port is deliberately equal on both hops so this test isolates the host.
+// The rule compares the whole origin (scheme, host and port) since #1741;
+// http_redirect_cross_port covers the port half.
 //
 // The same-host hop is what makes the cross-host result meaningful: without
 // it, a client that dropped the header unconditionally would also pass.

--- a/tests/integration/http_redirect_cross_host/test_http_redirect_cross_host.sh
+++ b/tests/integration/http_redirect_cross_host/test_http_redirect_cross_host.sh
@@ -13,9 +13,9 @@
 # that dropped the headers unconditionally would satisfy the first assertion
 # and fail the second.
 #
-# The rule the client implements compares the parsed host and nothing else,
-# so the port is held equal across both hops to isolate it. A change of port
-# alone does NOT strip today; that is filed separately.
+# The port is held equal across both hops so this test isolates the host.
+# A port change strips too, since #1741 made the decision compare the whole
+# origin; tests/integration/http_redirect_cross_port covers that half.
 
 case "$(uname -s 2>/dev/null)" in
     MINGW*|MSYS*|CYGWIN*|Windows_NT)

--- a/tests/integration/http_redirect_cross_port/driver.ae
+++ b/tests/integration/http_redirect_cross_port/driver.ae
@@ -1,0 +1,61 @@
+// Does a redirect to another PORT on the same host carry the credentials?
+//
+// The client compared the parsed host and nothing else, so a hop from
+// 127.0.0.1:18221 to 127.0.0.1:18222 kept Authorization and Cookie and
+// handed them to a different service on the same machine (#1741). An origin
+// is scheme + host + port together, which is the rule curl applies.
+//
+// Two hops, one assertion each, same host name throughout:
+//   /start -> 127.0.0.1:18222  (port differs: must be stripped)
+//   /same  -> 127.0.0.1:18221  (identical origin: must survive)
+//
+// The same-origin hop is what makes the cross-port result meaningful:
+// without it, a client that dropped the headers unconditionally would pass.
+
+import std.http.client
+import std.string
+
+check(url: string, want: string, label: string) -> int {
+    req = client.request("GET", url)
+    client.set_header(req, "Authorization", "Bearer test-token")
+    client.set_header(req, "Cookie", "session=abc123")
+    err_follow = client.set_follow_redirects(req, 3)
+    if err_follow != "" {
+        println("FAIL: ${label}: set_follow_redirects: ${err_follow}")
+        client.request_free(req)
+        return 1
+    }
+    resp, err = client.send_request(req)
+    if err != "" {
+        println("FAIL: ${label}: send_request: ${err}")
+        client.request_free(req)
+        return 1
+    }
+    status = client.response_status(resp)
+    body = client.response_body(resp)
+    client.response_free(resp)
+    client.request_free(req)
+    if status != 200 {
+        println("FAIL: ${label}: status ${status}, expected 200")
+        return 1
+    }
+    if string.contains(body, want) == 0 {
+        println("FAIL: ${label}: landing saw '${body}', expected '${want}'")
+        return 1
+    }
+    return 0
+}
+
+main() {
+    bad = 0
+    // The port differs: a different service, so the credentials must not
+    // be replayed there.
+    bad = bad + check("http://127.0.0.1:18221/start",
+        "auth=absent cookie=absent", "cross-port")
+    // Identical origin: dropping them here would break ordinary redirects.
+    bad = bad + check("http://127.0.0.1:18221/same",
+        "auth=present cookie=present", "same-origin")
+    if bad == 0 {
+        println("PASS: credentials dropped across ports, kept within one origin")
+    }
+}

--- a/tests/integration/http_redirect_cross_port/origin_server.ae
+++ b/tests/integration/http_redirect_cross_port/origin_server.ae
@@ -1,0 +1,64 @@
+// Origin fixture for the cross-PORT redirect check (#1741).
+//
+// Same host name on both hops, different port. That isolates the port: the
+// client used to compare only the parsed host, so a redirect to another port
+// on the same machine replayed the caller's Authorization and Cookie at a
+// service the user never authorised, owned by whoever holds that port.
+//
+// /start redirects to the OTHER port, /same redirects to this one as the
+// control, and /landing echoes so the same-origin hop can be checked here.
+
+import std.http
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18221
+const TARGET_PORT = 18222
+
+cross_port_handler(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 302)
+    http.response_set_header(res, "Location",
+        "http://127.0.0.1:18222/landing")
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "moved\n")
+}
+
+// Same host AND same port: the credentials must survive this one, or the
+// cross-port assertion would also pass for a client that strips everything.
+same_origin_handler(req: ptr, res: ptr, ud: ptr) {
+    http.response_set_status(res, 302)
+    http.response_set_header(res, "Location",
+        "http://127.0.0.1:18221/landing")
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "moved\n")
+}
+
+echo_handler(req: ptr, res: ptr, ud: ptr) {
+    // An absent header comes back as null, not "".
+    auth = http.get_header(req, "Authorization")
+    cookie = http.get_header(req, "Cookie")
+    body = "auth=present"
+    if auth == null {
+        body = "auth=absent"
+    }
+    if cookie == null {
+        body = "${body} cookie=absent"
+    } else {
+        body = "${body} cookie=present"
+    }
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "${body}\n")
+}
+
+main() {
+    s = http.server_create(PORT)
+    http.server_set_host(s, "127.0.0.1")
+    http.server_get(s, "/start", cross_port_handler, 0)
+    http.server_get(s, "/same", same_origin_handler, 0)
+    http.server_get(s, "/landing", echo_handler, 0)
+    println("READY")
+    http_server_start_raw(s)
+    exit(0)
+}

--- a/tests/integration/http_redirect_cross_port/target_server.ae
+++ b/tests/integration/http_redirect_cross_port/target_server.ae
@@ -1,0 +1,36 @@
+// Target fixture for the cross-PORT redirect check (#1741): a second service
+// on a different port of the same host, standing in for the neighbour that
+// must never receive the caller's credentials.
+
+import std.http
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18222
+
+echo_handler(req: ptr, res: ptr, ud: ptr) {
+    auth = http.get_header(req, "Authorization")
+    cookie = http.get_header(req, "Cookie")
+    body = "auth=present"
+    if auth == null {
+        body = "auth=absent"
+    }
+    if cookie == null {
+        body = "${body} cookie=absent"
+    } else {
+        body = "${body} cookie=present"
+    }
+    http.response_set_status(res, 200)
+    http.response_set_header(res, "Content-Type", "text/plain")
+    http.response_set_body(res, "${body}\n")
+}
+
+main() {
+    s = http.server_create(PORT)
+    http.server_set_host(s, "127.0.0.1")
+    http.server_get(s, "/landing", echo_handler, 0)
+    println("READY")
+    http_server_start_raw(s)
+    exit(0)
+}

--- a/tests/integration/http_redirect_cross_port/test_http_redirect_cross_port.sh
+++ b/tests/integration/http_redirect_cross_port/test_http_redirect_cross_port.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# std.http.client must not replay credentials across a PORT change (#1741).
+#
+# The client dropped Authorization, Cookie and Proxy-Authorization when a
+# redirect changed host, and decided that on the host name alone: the parsed
+# port and TLS flag were read and then never compared. A hop from
+# 127.0.0.1:18221 to 127.0.0.1:18222 therefore handed the caller's bearer
+# token to a different service on the same machine, owned by whoever holds
+# that port.
+#
+# An origin is scheme + host + port together, which is the rule curl applies.
+# Two servers, same host name, different ports, plus a same-origin control:
+# a client that stripped unconditionally would satisfy the first assertion
+# and fail the second.
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] http_redirect_cross_port — POSIX sockets; covered by the POSIX matrix"
+        exit 0
+        ;;
+esac
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] http_redirect_cross_port: ae not built"
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+ORIGIN_PID=""
+TARGET_PID=""
+cleanup() {
+    for p in $ORIGIN_PID $TARGET_PID; do
+        kill "$p" 2>/dev/null || true
+        wait "$p" 2>/dev/null || true
+    done
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+fail() { echo "  [FAIL] $1"; [ -f "$TMP/driver.out" ] && sed 's/^/        /' "$TMP/driver.out" | head -6; exit 1; }
+
+"$AE" build "$SCRIPT_DIR/origin_server.ae" -o "$TMP/origin" >"$TMP/b1.log" 2>&1 \
+    || { sed 's/^/        /' "$TMP/b1.log" | head -8; fail "origin_server.ae did not build"; }
+"$AE" build "$SCRIPT_DIR/target_server.ae" -o "$TMP/target" >"$TMP/b2.log" 2>&1 \
+    || { sed 's/^/        /' "$TMP/b2.log" | head -8; fail "target_server.ae did not build"; }
+"$AE" build "$SCRIPT_DIR/driver.ae" -o "$TMP/driver" >"$TMP/b3.log" 2>&1 \
+    || { sed 's/^/        /' "$TMP/b3.log" | head -8; fail "driver.ae did not build"; }
+
+"$TMP/origin" >"$TMP/origin.log" 2>&1 &
+ORIGIN_PID=$!
+"$TMP/target" >"$TMP/target.log" 2>&1 &
+TARGET_PID=$!
+
+deadline=$(($(date +%s) + 15))
+until curl -s -o /dev/null --max-time 1 "http://127.0.0.1:18221/landing" 2>/dev/null \
+   && curl -s -o /dev/null --max-time 1 "http://127.0.0.1:18222/landing" 2>/dev/null; do
+    [ "$(date +%s)" -ge "$deadline" ] && fail "servers never accepted connections"
+    sleep 0.1
+done
+
+"$TMP/driver" >"$TMP/driver.out" 2>&1 || fail "driver exited non-zero"
+grep -q "^PASS:" "$TMP/driver.out" || fail "driver did not report PASS"
+
+echo "  [PASS] http_redirect_cross_port: credentials dropped on a port change, kept within one origin"

--- a/tests/integration/sandbox_in_spec_block/prog.ae
+++ b/tests/integration/sandbox_in_spec_block/prog.ae
@@ -1,0 +1,49 @@
+// A sandbox grant must be honoured inside a trailing block (#1704).
+//
+// The permission stack and the BUILDER context stack used to be the same
+// array, so entering any trailing block pushed that builder's config object
+// onto the stack the permission checker walks. The checker read the config as
+// a permission list, found no entries, and denied: the identical grant that
+// worked in a plain function was refused inside `spec.describe`.
+//
+// The same helper runs in three places. All three must agree.
+
+import std.spec
+import std.audit
+import std.list
+import std.os
+
+fn add_perm(t: ptr, c: string, p: string) {
+    list.add(t, c)
+    list.add(t, p)
+}
+
+fn run_sandboxed(perms: ptr, code: fn) {
+    sandbox_push(perms)
+    sandbox_install()
+    call(code, perms)
+    sandbox_uninstall()
+    sandbox_pop()
+}
+
+fn check(label: string) {
+    audit.clear()
+    perms = list.new()
+    add_perm(perms, "env", "HOME")
+    w = | _ctx: ptr | { os_getenv("HOME") }
+    run_sandboxed(perms, w)
+    c, r, a = audit.entry(0)
+    println("${label} allowed=${a}")
+}
+
+main() {
+    fw = spec.init()
+    check("outside")
+    spec.describe(fw, "d") {
+        check("in-describe")
+        spec.it("t") callback {
+            check("in-it")
+        }
+    }
+    return spec.run_summary(fw)
+}

--- a/tests/integration/sandbox_in_spec_block/test_sandbox_in_spec_block.sh
+++ b/tests/integration/sandbox_in_spec_block/test_sandbox_in_spec_block.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# A sandbox grant must be honoured inside a spec.describe / spec.it block (#1704).
+#
+# The permission stack and the builder context stack were the same array, so
+# entering any trailing block pushed that builder's config object onto the
+# stack the permission checker walks. `_aether_perms_allow` then read a
+# builder config as a permission list, found no entries, and denied
+# everything. The same grant that worked in a plain function was refused
+# inside a describe block, which silently turns a sandboxed test suite into
+# one that tests nothing but denials.
+#
+# A grant for env:HOME must be allowed in all three positions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+if ! "$AE" build "$SCRIPT_DIR/prog.ae" -o "$TMP/prog" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] sandbox_in_spec_block: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -8
+    exit 1
+fi
+
+"$TMP/prog" > "$TMP/out.txt" 2>&1 || true
+
+fail=0
+for label in outside in-describe in-it; do
+    line="$(grep "^${label} " "$TMP/out.txt" || true)"
+    case "$line" in
+        *"allowed=1") ;;
+        *) echo "  [FAIL] sandbox_in_spec_block: ${label}: expected allowed=1, got '${line}'"; fail=1 ;;
+    esac
+done
+[ "$fail" -eq 0 ] || exit 1
+
+echo "  [PASS] sandbox_in_spec_block: a grant holds inside describe and it, not just in a plain function"


### PR DESCRIPTION
Two bugs, each reproduced first and each with a regression test that fails without the fix.

Closes #1741
Closes #1704

## #1741 — credentials replayed across a port or scheme change

`std.http.client` dropped `Authorization`, `Cookie` and `Proxy-Authorization` when a redirect changed host, and decided that on the **host name alone**. The port and TLS flag were parsed right there and then never compared:

```c
int curr_port = 0, next_port = 0, curr_tls = 0, next_tls = 0;
if (parse_url(current_url, curr_host, ..., &curr_port, ..., &curr_tls) != 0 && ...) {
    if (strcmp(curr_host, next_host) != 0) {   /* port and tls unused */
```

So a redirect from `http://host:8080/` to `http://host:9090/` replayed the caller's bearer token at a **different service on the same machine**, owned by whoever holds that port. An `http -> https` upgrade changed the origin the same way and also kept them.

An origin is scheme + host + port together, which is curl's rule: any of the three changing drops the credentials. `parse_url` already fills the port in from the scheme and lets an explicit `:port` override it, so `http://host` and `http://host:80` still compare equal and only a real origin change strips.

`tests/integration/http_redirect_cross_port` uses two servers on the same host, different ports, plus a same-origin control so a client that stripped unconditionally could not pass. Reverting just the comparison:

```
FAIL: cross-port: landing saw 'auth=present cookie=present', expected 'auth=absent cookie=absent'
```

The sibling cross-host test carried comments stating that a port change does not strip; both are updated to say which half each now covers.

## #1704 — sandbox grants ignored inside a describe block

The permission stack and the builder context stack were **the same array**. `_aether_ctx_stack` served both the `_ctx` injection that trailing blocks rely on and the sandbox stack the checker walks, so entering any trailing block pushed that builder's config object onto the permission stack. `_aether_perms_allow` then read a builder config as a permission list; it has no entries, and an empty list denies rather than abstains, so every check inside the block failed.

It was never really about `spec`: **any** builder block does it, and `spec.describe` is simply where a sandboxed test suite meets one. The failure mode is quiet and bad, since a suite that sandboxes its cases keeps passing while testing nothing but denials.

The sandbox now has its own `_aether_sandbox_stack` / `_aether_sandbox_depth`, touched only by `sandbox_push` / `sandbox_pop` and read only by the checker. The builder stack keeps `_aether_ctx_get` and `builder_depth`, which have nothing to do with permissions.

Nesting semantics are unchanged: `tests/syntax/test_sandbox_nesting` still reports HOME allow / USER deny, and `sandbox-demo` and `audit-demo` behave as before.

## Verification

`make test` 409/409, `make examples` 90/90, and all four new and existing related integration tests pass locally.

Also closed #1855 separately: it does not reproduce on current `main` nor on the pre-batch commit, evidenced on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
