### PR TITLE
fix(heap): own a struct string field assigned through a setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ version number before tagging the release.
 
 ## [current]
 
+- **A struct's `string` field was owned only when the assignment was written on
+  a local pointer, not through a setter.** The ownership wrapper that sets the
+  hidden `_heap_<field>` tracker fired for an assignment written against a
+  local heap-box pointer and not for one written through a pointer parameter,
+  which is what every setter has. The box's destructor then believed it owned
+  nothing and the field leaked. The practical consequence was that no single
+  destructor was correct: freeing the field by hand double-freed in the first
+  case and not freeing it leaked in the second, so a codebase using both styles
+  could not be right either way. The wrapper now fires for a pointer-to-struct
+  parameter as well. A setter that freed the previous value by hand as a
+  workaround must stop doing so: the field is owned by the box, the assignment
+  releases what was there, and freeing it again is a double free.
+
 ## [0.623.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1436,6 +1436,40 @@ static void emit_return_escape_drains_for_unreturned(CodeGenerator* gen,
  * assignment), 0 if the LHS shape isn't one of the recognised
  * struct-field patterns (caller falls through to the existing
  * bare-assignment emission). */
+/* #1866: is `name` a POINTER-TO-STRUCT PARAMETER of the function being
+ * emitted? A setter takes the box as a parameter, so the field assignment
+ * inside it is written through a parameter rather than a local, and the
+ * ownership wrapper below used to skip it: the tracker was never set and the
+ * box's destructor believed it owned nothing. That left no correct way to
+ * write a destructor at all, since freeing the field by hand double-frees
+ * when the assignment was written on a local and leaks when it went through a
+ * setter.
+ *
+ * Locals stay excluded, so a raw `malloc(...) as *T` local keeps the #790
+ * treatment. That guard is narrower than it looks either way: the generated
+ * destructor reads the same `_heap_<field>` tracker unconditionally at free
+ * time, so a non-zeroed box is already unsound there regardless of what this
+ * assignment site does. heap.new zero-inits, which is the documented way to
+ * make one. */
+static int is_ptr_struct_param(CodeGenerator* gen, const char* name) {
+    if (!gen || !gen->current_function || !name) return 0;
+    ASTNode* fn = gen->current_function;
+    for (int i = 0; i < fn->child_count; i++) {
+        ASTNode* p = fn->children[i];
+        /* Parameters come from parse_pattern, so a plain `name: T` is a
+         * pattern-variable node rather than a dedicated parameter node. The
+         * body is the last child and is not a parameter. */
+        if (!p || !p->value) continue;
+        if (p->type != AST_PATTERN_VARIABLE && p->type != AST_IDENTIFIER) continue;
+        if (strcmp(p->value, name) != 0) continue;
+        Type* t = p->node_type;
+        return t && t->kind == TYPE_PTR && t->element_type &&
+               t->element_type->kind == TYPE_STRUCT &&
+               t->element_type->struct_name != NULL;
+    }
+    return 0;
+}
+
 static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNode* rhs) {
     if (!gen || !lhs || !rhs) return 0;
     if (lhs->type != AST_MEMBER_ACCESS || !lhs->value) return 0;
@@ -1458,7 +1492,8 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
     } else if (obj_type->kind == TYPE_PTR && obj_type->element_type &&
                obj_type->element_type->kind == TYPE_STRUCT &&
                obj_type->element_type->struct_name &&
-               is_heap_box_var(gen, obj->value)) {
+               (is_heap_box_var(gen, obj->value) ||
+                is_ptr_struct_param(gen, obj->value))) {
         /* Only a heap.new(T) box has zero-initialised `_heap_<field>`
          * trackers, so only there is reading/freeing the previous field
          * value safe. A raw `malloc(...) as *T` has garbage trackers — its

--- a/tests/integration/heap_field_setter_ownership/prog.ae
+++ b/tests/integration/heap_field_setter_ownership/prog.ae
@@ -1,0 +1,58 @@
+// A struct string field must be owned the same way however it was assigned (#1866).
+//
+// The ownership wrapper only fired when the assignment was written against a
+// LOCAL heap-box pointer. A setter takes the box as a parameter, so its
+// assignment was a bare store that never set the `_heap_<field>` tracker, and
+// the box's destructor then believed it owned nothing.
+//
+// That left no correct way to write a destructor: freeing the field by hand
+// double-frees in the local case and leaks in the setter case.
+//
+// Both styles below must free exactly once, so the program has to run to
+// completion (a double free aborts) AND report no leak.
+
+import std.heap
+import std.string
+
+struct Entry { path: string }
+struct Uniform { name: string, kind: int }
+
+// Style A: assignment written on the local pointer.
+make_entry(value: string) -> *Entry {
+    e = heap.new(Entry)
+    e.path = string.copy(value)
+    return e
+}
+
+// Style B: assignment through a pointer parameter, which is what a setter is.
+// It does NOT free the previous value by hand: the field is owned by the box,
+// so the assignment releases whatever was there. That is the same rule the
+// local-pointer style follows, which is the point of the fix -- before it, a
+// setter had to free by hand or leak, and a local had to not free or double
+// free, so the two styles needed opposite code.
+uniform_set_name(u: *Uniform, value: string) {
+    u.name = string.copy(value)
+}
+
+upsert(value: string) -> *Uniform {
+    u = heap.new(Uniform)
+    uniform_set_name(u, value)
+    u.kind = 1
+    return u
+}
+
+main() {
+    e = make_entry("local")
+    println("${e.path}")
+    heap.free(e)
+
+    u = upsert("setter")
+    println("${u.name}")
+    // Reassign through the setter: the previous value must be released by
+    // `own`, and the final one by heap.free.
+    uniform_set_name(u, "setter-again")
+    println("${u.name}")
+    heap.free(u)
+
+    println("both freed")
+}

--- a/tests/integration/heap_field_setter_ownership/test_heap_field_setter_ownership.sh
+++ b/tests/integration/heap_field_setter_ownership/test_heap_field_setter_ownership.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# A struct string field is owned the same way however it was assigned (#1866).
+#
+# The ownership wrapper only fired for an assignment written against a local
+# heap-box pointer. A setter assigns through a pointer PARAMETER, so its store
+# never set the `_heap_<field>` tracker and the box's destructor believed it
+# owned nothing. There was therefore no correct way to write a destructor:
+# freeing the field by hand double-frees in the local case and leaks in the
+# setter case.
+#
+# Running to completion is half the assertion (a double free aborts). The
+# emitted ownership claim is checked directly too, so this still means
+# something on platforms with no leak checker.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+AETHERC="$ROOT/build/aetherc"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+if ! "$AETHERC" "$SCRIPT_DIR/prog.ae" "$TMP/out.c" > "$TMP/gen.log" 2>&1; then
+    echo "  [FAIL] heap_field_setter_ownership: codegen failed"
+    sed 's/^/        /' "$TMP/gen.log" | head -8
+    exit 1
+fi
+
+# Style A (local pointer) and style B (setter through a parameter) must BOTH
+# claim ownership. Before the fix only the first appeared.
+if ! grep -q "_heap_path = 1" "$TMP/out.c"; then
+    echo "  [FAIL] heap_field_setter_ownership: local-pointer assignment did not claim ownership"
+    exit 1
+fi
+if ! grep -q "_heap_name = 1" "$TMP/out.c"; then
+    echo "  [FAIL] heap_field_setter_ownership: setter assignment did not claim ownership"
+    exit 1
+fi
+
+if ! "$AE" build "$SCRIPT_DIR/prog.ae" -o "$TMP/prog" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] heap_field_setter_ownership: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -8
+    exit 1
+fi
+
+if ! "$TMP/prog" > "$TMP/out.txt" 2>&1; then
+    echo "  [FAIL] heap_field_setter_ownership: program aborted (double free?)"
+    sed 's/^/        /' "$TMP/out.txt" | head -6
+    exit 1
+fi
+grep -q "^both freed$" "$TMP/out.txt" || {
+    echo "  [FAIL] heap_field_setter_ownership: program did not run to completion"
+    sed 's/^/        /' "$TMP/out.txt" | head -6
+    exit 1
+}
+
+echo "  [PASS] heap_field_setter_ownership: a field assigned through a setter is owned like one assigned on a local"


### PR DESCRIPTION
Closes #1866

The ownership wrapper that sets a struct's hidden `_heap_<field>` tracker fired only when the assignment was written against a **local** heap-box pointer. A setter takes the box as a parameter, so its store was a bare assignment that never claimed ownership, and the box's destructor then believed it owned nothing.

The report's framing is the actual problem, and it is worse than a leak: **there was no single correct way to write a destructor.** Freeing the field by hand double-freed when the assignment had been written on a local, and not freeing it leaked when it had gone through a setter. A codebase using both styles could not be correct either way.

## The fix

The wrapper now also fires for a pointer-to-struct **parameter**, which is what a setter has. Pointer *locals* are unchanged, so a raw `malloc(...) as *T` local keeps exactly the treatment it had.

On that guard, since it is the reason the parameter case was excluded: it exists because a non-zeroed box has garbage trackers. It is narrower than it looks, because the generated destructor reads the same `_heap_<field>` **unconditionally at free time**, so a non-zeroed box is already unsound there regardless of what this assignment site does. I confirmed that directly: `malloc(64) as *Box` followed by `heap.free` reads the tracker and only survives when the allocator happened to hand back zeroed memory. `heap.new` zero-inits and is the documented way to make a box.

## Behaviour change worth calling out

A setter that freed the previous value **by hand** as a workaround must stop. The field is owned by the box now, so the assignment releases what was there and freeing it as well is a double free. That is the same rule the local-pointer style has always followed, which is the point of the change: one rule for both styles.

I hit this while writing the test. The first version used the report's `own(previous, value)` helper, which frees by hand, and it aborted — correctly.

## Verification

Both repros from the issue, on the built compiler:

```
repro A (local pointer): 0 leaks for 0 total
repro B (setter):        0 leaks for 0 total      # was 2 leaks for 80 bytes
```

`tests/integration/heap_field_setter_ownership` covers both styles plus a reassignment through the setter, and asserts the emitted ownership claim as well as running to completion, so it still means something where no leak checker exists.

`make test` 409/409, `make examples` 90/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
