### PR TITLE
std.math: add lrint — round-to-nearest returning an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **`math.lrint(x) -> long`** — round-to-nearest returning an integer directly,
+  so callers stop declaring `extern lrint` themselves. An Aether extern cannot
+  spell libm's prototype: `-> long` emits `int64_t` and `-> int` emits `int`,
+  and C `long` is neither. The resulting redeclaration is invisible on Linux,
+  where `int64_t` *is* `long`, and a hard **error** on macOS/iOS, where
+  `int64_t` is `long long` — which is why it surfaced only on Apple targets
+  (reported by the aether-ui line, whose `vg/` tree carried 30 such externs).
+  Declaring it once in C against the real `<math.h>` is the only place the
+  prototype can be correct.
+
+  It rounds half-to-**even** (`lrint(0.5)` is `0`, `lrint(1.5)` is `2`),
+  matching libm, whereas `math.round` rounds half-away-from-zero and returns a
+  `float` the caller must then cast. The two are not interchangeable: an 8-bit
+  colour channel computed as `lrint(v * 255.0)` is off by one at exact halves
+  if it silently becomes `round`.
+
 ## [0.625.0]
 
 ### Added

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -49,7 +49,7 @@ header comment is the authoritative description.
 | `std.longarr` | Fixed-size packed-long buffer. | 13 | [guide](../std/longarr/README.md) · [source](../std/longarr/module.ae) |
 | `std.lzf` | One-shot LZF compression and decompression. | 12 | [guide](../std/lzf/README.md) · [source](../std/lzf/module.ae) |
 | `std.map` | Hash map, re-exported from `std.collections`, with readable key snapshots. | 18 | [guide](../std/map/README.md) · [source](../std/map/module.ae) |
-| `std.math` | Arithmetic, trigonometry, rounding and floating-point helpers. | 31 | [full section](#math-stdmath) |
+| `std.math` | Arithmetic, trigonometry, rounding and floating-point helpers. | 32 | [full section](#math-stdmath) |
 | `std.mem` | Byte-level reads and writes over caller-allocated raw pointers. | 102 | [guide](../std/mem/README.md) · [source](../std/mem/module.ae) |
 | `std.message` | ICU MessageFormat formatting and message catalogues. | 8 | [guide](../std/message/README.md) · [source](../std/message/module.ae) |
 | `std.msgpack` | MessagePack serialisation and deserialisation. | 35 | [guide](../std/msgpack/README.md) · [source](../std/msgpack/module.ae) |

--- a/std/math/README.md
+++ b/std/math/README.md
@@ -27,10 +27,27 @@ locale-appropriate decimal separator — is `std.number`'s job.
 ## Exports
 
 `sqrt`, `pow`, `exp`, `log`, `log10`, `sin`, `cos`, `tan`, `asin`, `acos`,
-`atan`, `atan2`, `floor`, `ceil`, `round`, `deg_to_rad`, `rad_to_deg`;
+`atan`, `atan2`, `floor`, `ceil`, `round`, `lrint`, `deg_to_rad`, `rad_to_deg`;
 `abs_int`, `abs_float`, `min_int`, `max_int`, `min_float`, `max_float`,
 `clamp_int`, `clamp_float`; `random_seed`, `random_int`, `random_float`; and
 the constants `pi`, `tau`, `e`.
 
 `random_*` is a plain PRNG for simulation and sampling — not a CSPRNG. Use
 `std.cryptography.random_bytes` for anything security-bearing.
+
+`round` and `lrint` both round to nearest but differ in two ways that matter:
+
+| | returns | halfway cases |
+|---|---|---|
+| `round(x)` | `float` | away from zero — `round(0.5)` is `1.0` |
+| `lrint(x)` | `long` | to even — `lrint(0.5)` is `0`, `lrint(1.5)` is `2` |
+
+Use `lrint` when you want an integer out, rather than `round(x) as int`: it
+saves the cast, and `as int` truncates, so `round` composed with a cast is only
+correct because `round` has already moved the value to a whole number.
+
+`lrint` also exists so callers do not declare `extern lrint` themselves. An
+Aether extern cannot spell libm's prototype — `-> long` emits `int64_t` and
+`-> int` emits `int`, and C `long` is neither — so such a declaration collides
+with `<math.h>`. It is invisible on Linux, where `int64_t` *is* `long`, and a
+hard error on macOS/iOS, where `int64_t` is `long long`.

--- a/std/math/README.md
+++ b/std/math/README.md
@@ -39,15 +39,16 @@ the constants `pi`, `tau`, `e`.
 
 | | returns | halfway cases |
 |---|---|---|
-| `round(x)` | `float` | away from zero — `round(0.5)` is `1.0` |
-| `lrint(x)` | `long` | to even — `lrint(0.5)` is `0`, `lrint(1.5)` is `2` |
+| `round(x)` | float | away from zero — `round(0.5)` is 1.0 |
+| `lrint(x)` | long | to even — `lrint(0.5)` is 0, `lrint(1.5)` is 2 |
 
 Use `lrint` when you want an integer out, rather than `round(x) as int`: it
 saves the cast, and `as int` truncates, so `round` composed with a cast is only
 correct because `round` has already moved the value to a whole number.
 
 `lrint` also exists so callers do not declare `extern lrint` themselves. An
-Aether extern cannot spell libm's prototype — `-> long` emits `int64_t` and
-`-> int` emits `int`, and C `long` is neither — so such a declaration collides
-with `<math.h>`. It is invisible on Linux, where `int64_t` *is* `long`, and a
-hard error on macOS/iOS, where `int64_t` is `long long`.
+Aether extern cannot spell libm's prototype: an Aether long return emits C
+int64_t and an int return emits C int, and C's own long type is neither — so
+such a declaration collides with the one in math.h. The collision is invisible
+on Linux, where int64_t and long are the same type, and a hard error on
+macOS/iOS, where int64_t is long long.

--- a/std/math/aether_math.c
+++ b/std/math/aether_math.c
@@ -89,6 +89,29 @@ double math_round(double x) {
     return round(x);
 }
 
+/* Round to nearest and return an INTEGER type, unlike math_round which rounds
+ * correctly but hands back a double that the caller must then cast.
+ *
+ * This exists so callers do not declare `extern lrint` themselves. An Aether
+ * extern cannot spell libm's prototype: `-> long` emits int64_t and `-> int`
+ * emits int, and C `long` is neither, so every such declaration collides with
+ * <math.h> and clang warns (-Wincompatible-library-redeclaration) in every
+ * generated program that uses it. Declaring it once here, in C, against the
+ * real header is the only place the prototype can be correct.
+ *
+ * int64_t, not long, is the return type: it is what an Aether `-> long` binds
+ * to, and it is the same width on every LP64 target while being well-defined
+ * on LLP64 (Windows) where long is 32 bits and would silently narrow.
+ *
+ * NB this rounds half-to-EVEN (lrint honours the current rounding mode, which
+ * defaults to FE_TONEAREST), whereas math_round rounds half-away-from-zero:
+ * math_lrint(0.5) == 0 but math_round(0.5) == 1.0. That is the documented
+ * difference between the two, not an accident — callers converting a
+ * hand-rolled `extern lrint` keep their existing behaviour by using this. */
+int64_t math_lrint(double x) {
+    return (int64_t)llrint(x);
+}
+
 double math_log(double x) {
     return log(x);
 }

--- a/std/math/aether_math.h
+++ b/std/math/aether_math.h
@@ -1,6 +1,8 @@
 #ifndef AETHER_MATH_H
 #define AETHER_MATH_H
 
+#include <stdint.h>   /* int64_t, for math_lrint's return type */
+
 // Basic math operations
 int math_abs_int(int x);
 double math_abs_float(double x);
@@ -24,6 +26,8 @@ double math_atan2(double y, double x);
 double math_floor(double x);
 double math_ceil(double x);
 double math_round(double x);
+/* Round half-to-even and return an integer (see the note in aether_math.c). */
+int64_t math_lrint(double x);
 double math_log(double x);
 double math_log10(double x);
 double math_exp(double x);

--- a/std/math/module.ae
+++ b/std/math/module.ae
@@ -8,7 +8,7 @@ exports(
     math_sqrt, math_pow,
     math_sin, math_cos, math_tan,
     math_asin, math_acos, math_atan, math_atan2,
-    math_floor, math_ceil, math_round,
+    math_floor, math_ceil, math_round, math_lrint,
     math_log, math_log10, math_exp,
     math_random_seed, math_random_int, math_random_float,
     math_pi, math_tau, math_e, math_deg_to_rad, math_rad_to_deg
@@ -37,6 +37,9 @@ extern math_atan2(y: float, x: float) -> float
 extern math_floor(x: float) -> float
 extern math_ceil(x: float) -> float
 extern math_round(x: float) -> float
+// Rounds half-to-EVEN and returns an integer directly (math_round rounds
+// half-away-from-zero and returns a float you must then cast).
+extern math_lrint(x: float) -> long
 extern math_log(x: float) -> float
 extern math_log10(x: float) -> float
 extern math_exp(x: float) -> float

--- a/tests/regression/test_math_lrint.ae
+++ b/tests/regression/test_math_lrint.ae
@@ -1,0 +1,53 @@
+// math.lrint: round-to-nearest returning an integer directly.
+//
+// Exists so callers need not declare `extern lrint` themselves. An Aether
+// extern cannot spell libm's prototype (`-> long` emits int64_t, `-> int`
+// emits int, and C `long` is neither), so such a declaration collides with
+// <math.h>: invisible on Linux where int64_t IS long, a hard error on
+// macOS/iOS where int64_t is long long. Declaring it in C against the real
+// header is the only place the prototype can be correct.
+//
+// Asserts half-to-EVEN rounding, which is what distinguishes it from
+// math.round (half-away-from-zero) and is what an `lrint` caller expects.
+import std.math
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    // Ordinary rounding, both directions.
+    a = math.lrint(3.7)
+    if a != 4 { fail("lrint(3.7) = ${a}, want 4") }
+    b = math.lrint(3.2)
+    if b != 3 { fail("lrint(3.2) = ${b}, want 3") }
+    c = math.lrint(-3.7)
+    if c != -4 { fail("lrint(-3.7) = ${c}, want -4") }
+
+    // Halfway cases round to EVEN, unlike math.round which rounds away from
+    // zero. This is the documented difference between the two.
+    d = math.lrint(0.5)
+    if d != 0 { fail("lrint(0.5) = ${d}, want 0 (half-to-even)") }
+    e = math.lrint(1.5)
+    if e != 2 { fail("lrint(1.5) = ${e}, want 2 (half-to-even)") }
+    f = math.lrint(2.5)
+    if f != 2 { fail("lrint(2.5) = ${f}, want 2 (half-to-even)") }
+    g = math.lrint(-2.5)
+    if g != -2 { fail("lrint(-2.5) = ${g}, want -2 (half-to-even)") }
+
+    // math.round differs on exactly those inputs, so the two are not
+    // interchangeable: a colour channel computed as lrint(v * 255.0) is off
+    // by one if it silently becomes round().
+    h = math.round(0.5)
+    if h != 1.0 { fail("round(0.5) = ${h}, want 1.0 (half-away-from-zero)") }
+
+    // The motivating case: 8-bit colour channel conversion.
+    i = math.lrint(255.0 * 0.5)
+    if i != 128 { fail("lrint(127.5) = ${i}, want 128") }
+
+    println("test_math_lrint: OK")
+    return 0
+}


### PR DESCRIPTION
Follow-up to #1868, answering the aether-ui line's item 10 rebuttal.

## I was wrong, and Linux-blind about it

In #1868 I reported `lrint` as "not ours" because it appears nowhere in
`std/`, `runtime/`, `include/`, or codegen. That check was correct and the
conclusion was not: **30 modules under their `vg/` tree declare
`extern lrint(x: float) -> long`**, so codegen emits `int64_t lrint(double);`
and it collides with libm's.

Why I couldn't see it from this machine:

| | `int64_t` is | result |
|---|---|---|
| Linux x86-64 | `long` | same declaration — **no diagnostic** |
| macOS / iOS | `long long` | distinct type — **hard error** |

I verified both directions rather than take it on faith: forcing `<math.h>`
into the emitted TU on Linux still warns about nothing, and declaring
`long long lrint(double)` against `<math.h>` reproduces
`conflicting types for 'lrint'` on gcc *and* clang. So the report was right and
my dismissal was an artifact of the platform I tested on.

## Why this belongs here, not there

They can't spell it correctly on their side either — `-> long` emits `int64_t`,
`-> int` emits `int`, and C `long` is neither, so **no Aether extern matches
libm's prototype**. Declaring it once in C against the real header is the only
place it can be correct. That turns a 30-module workaround into one function.

This is option 1 of the three they offered, which is also the cheapest for
them: they delete 30 externs and the warning goes with them.

## Semantics — deliberately not `math.round`

`math_lrint` uses `llrint`, so it rounds **half-to-even**, matching libm and
therefore matching what their existing `extern lrint` callers already get.

| | returns | halfway |
|---|---|---|
| `round(x)` | `float` | away from zero — `round(0.5)` = `1.0` |
| `lrint(x)` | `long` | to even — `lrint(0.5)` = `0`, `lrint(1.5)` = `2` |

These are not interchangeable, which is the trap in their suggested option 3
(`math.round(...) as int`): an 8-bit colour channel computed as
`lrint(v * 255.0)` is **off by one at exact halves** if it silently becomes
`round`. Their vg colour paths do exactly that per channel. The README now
tabulates the difference so nobody swaps one for the other by accident.

Returns `int64_t` rather than `long`: it's what an Aether `-> long` binds to,
and it stays 64-bit on LLP64 (Windows), where `long` is 32 bits and would
silently narrow.

## Testing

- The generated C declares only `int64_t math_lrint(double)` — **our own
  symbol**, so it cannot collide with libm on any platform — and compiles clean
  under gcc and clang with `-Wall -Wextra`.
- New `tests/regression/test_math_lrint.ae` covers both rounding directions,
  all four half-to-even cases, the divergence from `math.round`, and the
  colour-channel case.
- `make test` 409/409; `make check-docs` green (stdlib index count updated from
  31 to 32 — that gate caught the omission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
