### PR TITLE
fix(heap): don't free a garbage tracker when a setter assigns a string field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Assigning a `string` field through a setter segfaulted on a hand-malloc'd
+  box** (#1873, regression in 0.624.0). #1866 correctly made the ownership
+  wrapper fire for a pointer-to-struct *parameter*, so a setter's store takes
+  ownership like a local's does. But the emitted store also reads the box's
+  `_heap_<field>` tracker to decide whether to release the previous value, and
+  a box made with `malloc(n) as *T` has never had that tracker initialised —
+  so a non-zero garbage value made it call `aether_heap_str_free()` on a
+  garbage pointer.
+
+  The parameter case now stores and sets the tracker (keeping #1866's leak
+  fix) without reading the uninitialised one, since a parameter is no promise
+  that the caller zeroed the box. `heap.new` boxes are unaffected and keep the
+  releasing behaviour.
+
+  This shipped: it crashed aether-ui's font_picker on the first click under
+  0.626.0 while 0.613.0 survived, pinning that line to the older toolchain.
+  The existing test used a zeroed box, so CI stayed green; the new one uses a
+  hand-malloc'd box with padding, because glibc's free-list metadata zeroes
+  the tracker in a smaller struct and masks the bug.
+
 ## [0.626.0]
 
 ### Added

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1486,6 +1486,10 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
      * destructor reclaims it. */
     const char* acc;
     const char* struct_name;
+    /* Whether `_heap_<field>` is known zero-initialised, and so safe to READ
+     * in order to release the previous value (#1873). A value struct and a
+     * heap.new box both qualify; a pointer parameter does not. */
+    int tracker_is_trustworthy = 1;
     if (obj_type->kind == TYPE_STRUCT && obj_type->struct_name) {
         acc = ".";
         struct_name = obj_type->struct_name;
@@ -1494,6 +1498,13 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
                obj_type->element_type->struct_name &&
                (is_heap_box_var(gen, obj->value) ||
                 is_ptr_struct_param(gen, obj->value))) {
+        /* #1873: a PARAMETER is not a promise that the box was zeroed — the
+         * caller may have handed us `malloc(n) as *T`, whose `_heap_<field>`
+         * tracker is garbage. Reading it to decide whether to free the
+         * previous value then frees a garbage pointer. Only a local we can
+         * SEE was made by heap.new carries that guarantee, so remember which
+         * branch we are on and suppress just the free for the other. */
+        tracker_is_trustworthy = is_heap_box_var(gen, obj->value);
         /* Only a heap.new(T) box has zero-initialised `_heap_<field>`
          * trackers, so only there is reading/freeing the previous field
          * value safe. A raw `malloc(...) as *T` has garbage trackers — its
@@ -1520,6 +1531,20 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
 
     int rhs_is_heap = is_heap_string_expr(gen, rhs);
     print_indent(gen);
+    if (!tracker_is_trustworthy) {
+        /* #1873: store and SET the tracker (so the destructor still reclaims
+         * this value — #1866's leak fix is preserved), but do not read the
+         * pre-existing tracker to free the old value. On a hand-malloc'd box
+         * that read is uninitialised memory, and acting on it frees a garbage
+         * pointer. Not freeing here can leak a previous value on a box that
+         * was genuinely zeroed; that is strictly better than a segfault, and
+         * the caller can use heap.new to get the releasing behaviour. */
+        fprintf(gen->output, "{ %s%s%s = ", obj->value, acc, lhs->value);
+        generate_expression(gen, rhs);
+        fprintf(gen->output, "; %s%s_heap_%s = %d; }\n",
+                obj->value, acc, lhs->value, rhs_is_heap ? 1 : 0);
+        return 1;
+    }
     fprintf(gen->output,
             "{ const char* _tmp_old = %s%s%s; %s%s%s = ",
             obj->value, acc, lhs->value,

--- a/tests/integration/heap_field_setter_malloc_box/prog.ae
+++ b/tests/integration/heap_field_setter_malloc_box/prog.ae
@@ -1,0 +1,46 @@
+// #1873: a string field assigned through a pointer-to-struct PARAMETER, on a
+// box made by hand with malloc rather than heap.new.
+//
+// #1866 made that assignment release the previous value, which requires
+// reading the box's `_heap_<field>` tracker. A malloc'd box has never had
+// that tracker initialised, so a non-zero garbage value made the store free
+// a garbage pointer — segfault. This is the shape that crashed aether-ui's
+// font_picker on 0.626.0 while 0.613.0 survived.
+//
+// The padding matters: glibc writes free-list metadata over the first ~16
+// bytes of a freed block, which zeroes the tracker in a smaller struct and
+// masks the bug. A small-struct version of this test passes even when the
+// defect is live.
+@extern("malloc") malloc(n: int) -> ptr
+@extern("free") c_free(p: ptr)
+@extern("memset") memset(p: ptr, c: int, n: int) -> ptr
+
+struct Box {
+    p0: int
+    p1: int
+    p2: int
+    p3: int
+    p4: int
+    p5: int
+    p6: int
+    p7: int
+    s: string
+}
+
+set_it(b: *Box) {
+    b.s = "hello"
+}
+
+main() {
+    // Dirty a block, free it, then take it back: the tracker slot now holds
+    // 0xAB bytes rather than incidental zeros.
+    dirty = malloc(128)
+    _x = memset(dirty, 171, 128)
+    c_free(dirty)
+
+    b = malloc(128) as *Box
+    b.p0 = 1
+    set_it(b)
+    println("survived: ${b.s}")
+    return 0
+}

--- a/tests/integration/heap_field_setter_malloc_box/test_heap_field_setter_malloc_box.sh
+++ b/tests/integration/heap_field_setter_malloc_box/test_heap_field_setter_malloc_box.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# #1873: assigning a string field through a pointer-to-struct parameter must
+# not free a garbage pointer when the box was hand-malloc'd (non-zeroed).
+#
+# Regression guard for the 0.624.0 crash that pinned the aether-ui line to
+# v0.613.0: #1866 correctly made setter assignment take ownership, but the
+# emitted store read an ownership tracker that a malloc'd box never
+# initialised, then freed on it.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+OUT=$("$AE" run "$SCRIPT_DIR/prog.ae" 2>&1) || {
+    echo "  [FAIL] heap_field_setter_malloc_box: program did not exit cleanly"
+    echo "$OUT" | sed 's/^/    /' | head -10
+    exit 1
+}
+
+case "$OUT" in
+    *"survived: hello"*) ;;
+    *)
+        echo "  [FAIL] heap_field_setter_malloc_box: unexpected output"
+        echo "$OUT" | sed 's/^/    /' | head -10
+        exit 1
+        ;;
+esac
+
+# The crash was a SIGSEGV, so an empty/short output with a zero status would
+# also be wrong; the string check above covers it.
+echo "  [PASS] heap_field_setter_malloc_box: setter assignment on a malloc'd box does not free garbage"


### PR DESCRIPTION
Fixes #1873. Regression from #1866 (0.624.0) that **shipped** and pinned the
aether-ui line to v0.613.0.

## The bug

#1866 made the ownership wrapper fire for a pointer-to-struct **parameter** —
correct, since a setter's store should take ownership like an assignment on a
local. But the emitted store also *reads* the box's tracker:

```c
{ const char* _tmp_old = b->s; b->s = "hello";
  if (b->_heap_s) aether_heap_str_free(_tmp_old); b->_heap_s = 0; }
```

A box made with `malloc(n) as *T` has **never had that tracker initialised**.
When the garbage is non-zero, this frees a garbage pointer.

The guard directly above the change already states the invariant — *"Only a
`heap.new(T)` box has zero-initialised `_heap_<field>` trackers, so only there
is reading/freeing the previous field value safe"* — and `is_ptr_struct_param`
was OR'd in beside `is_heap_box_var`, which breaks it. **A parameter is no
promise that the caller zeroed anything.**

#1866's message anticipates the hazard, arguing such a box is "already unsound"
because the destructor reads the same tracker. That holds for the *destructor*,
which only runs for boxes with a lifecycle. It doesn't carry to an
*assignment*: before #1866 a setter store never read the tracker, so
`malloc` + assign was sound in practice, and `malloc(n) as *T` is a documented
pattern. A previously-safe store became a load-bearing read of uninitialised
memory.

## The fix

The parameter case stores and **sets** the tracker — so the destructor still
reclaims the value and #1866's leak fix is preserved — but doesn't read the
pre-existing one. Not releasing there can leak a previous value on a box that
*was* genuinely zeroed; strictly better than a segfault, and `heap.new` gets
the releasing behaviour. `heap.new` boxes are untouched.

## Verification

**Against the reporter's real app.** aether-ui's `font_picker`, rebuilt with
this compiler, survives the click that killed it: `http=200`, process alive,
label updates to `"selected: DejaVu Sans"` — the behaviour their report says
only v0.613.0 achieved.

**Bisected** with a 30-line reproducer first:

| compiler | result |
| --- | --- |
| `21004a26^` (pre-#1866) | `survived: hello` ×3 |
| `main` | segfault ×5 |

**The new test is a real guard**: confirmed it FAILS with signal 11 on unfixed
`main` and passes with the fix. It uses a hand-malloc'd box with **padded**
fields on purpose — glibc writes free-list metadata over the first ~16 bytes of
a freed block, which zeroes the tracker in a smaller struct and masks the crash.
The existing `heap_field_setter_ownership` test uses a zeroed box, which is
exactly why CI stayed green through this regression.

`make test` 409/409; `check-docs` green; the six `heap_*` integration suites
pass; `heap_field_setter_ownership` (#1866's own test) still passes.

## Note for #1866's author

The behaviour change #1866 documented — *"a setter that freed the previous value
by hand must stop"* — still holds for `heap.new` boxes. This only narrows it for
boxes the compiler cannot know were zeroed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
