### PR TITLE
fix(cli): the silently stale toolchain, and eight defects behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,11 @@ version number before tagging the release.
 - **Every failed compile printed its diagnostics twice, plus three lines of
   internal `[diag]` output.** `ae build` and `ae run` re-ran the whole compile
   on failure "so the user can see the error", left over from a Windows
-  debugging session and redundant since the first run already shows stderr. So
-  every error, every warning and every hint arrived doubled, at the cost of
-  compiling the file a second time. The retry and the `[diag]` lines are gone.
+  debugging session. So every error, every warning and every hint arrived
+  doubled, at the cost of compiling the file a second time. The compile steps
+  now capture stdout to a temp file and print it only when the command fails,
+  which keeps what the retry existed to show, a C compiler that reports through
+  stdout rather than stderr, without compiling anything twice.
 
 - **A piped `ae build` printed its diagnostics above the line naming the file
   being built**, because stdout is block-buffered when piped while stderr is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ version number before tagging the release.
   showed as executed. Both now carry the position of the keyword that
   introduces them.
 
+- **`ae build --target=wasm32-wasi --emit=lib` could not link.** A wasi library
+  is a reactor, not a command: left in command mode zig links wasi-libc's
+  startup object, which demands a `main` the library has not got, and
+  `--no-entry` does not prevent it being pulled in. The link failed with
+  `undefined symbol: main`. Libraries for wasi now build as reactors, which
+  also fixes `--size` for that target.
+
 - **`install_name_tool` ran on static archives and non-Darwin cross output**,
   failing and warning that "consumers may fail to dlopen" for artifacts nothing
   can dlopen. An install_name belongs to a Mach-O dylib; the fixup is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **`ae version` says when a newer release exists.** `ae upgrade` has always
+  worked; nothing ever said to run it. Every check in `ae version` compared the
+  binary against its own siblings, the `aetherc` it resolves and the
+  `active_version` pin, and never against what had been released, so an install
+  75 releases behind reported itself healthy. That is not cosmetic: `ae run`
+  resolves the stdlib from the install, so a function added since silently
+  resolves as `undefined`, and the report lands on whoever added it rather than
+  on the stale toolchain. Asked at most once a day and cached, because
+  `ae version` should not need the network to answer, and silent on every
+  failure: offline, rate-limited, or an unwritable cache all leave the output
+  exactly as it was.
+
 ## [0.627.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ version number before tagging the release.
   showed as executed. Both now carry the position of the keyword that
   introduces them.
 
+- **Every `ae build --namespace` library on macOS killed the process that
+  loaded it.** `ae` rewrites the library's install_name after linking, and that
+  modification invalidates the ad-hoc signature ld64 attaches to everything it
+  links on Apple silicon. dyld does not report that as an error: the kernel
+  SIGKILLs the loading process with no message at all, so a Python, Ruby or C
+  host died on `dlopen` while the library looked healthy on disk and
+  `codesign -v` was never consulted. The library is re-signed after the
+  rewrite, and `--emit=lib` does the same, where a newer `install_name_tool`
+  happens to re-sign on its own but older ones do not.
+
 - **`ae build --target=wasm32-wasi --emit=lib` could not link.** A wasi library
   is a reactor, not a command: left in command mode zig links wasi-libc's
   startup object, which demands a `main` the library has not got, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ version number before tagging the release.
 
 ### Added
 
-- **`ae version` says when a newer release exists.** `ae upgrade` has always
-  worked; nothing ever said to run it. Every check in `ae version` compared the
+- **`ae version`, and a failed build, say when a newer release exists.**
+  `ae upgrade` has always worked; nothing ever said to run it. Every check in
+  `ae version` compared the
   binary against its own siblings, the `aetherc` it resolves and the
   `active_version` pin, and never against what had been released, so an install
   75 releases behind reported itself healthy. That is not cosmetic: `ae run`
@@ -23,7 +24,62 @@ version number before tagging the release.
   on the stale toolchain. Asked at most once a day and cached, because
   `ae version` should not need the network to answer, and silent on every
   failure: offline, rate-limited, or an unwritable cache all leave the output
-  exactly as it was.
+  exactly as it was. A failed attempt is cached too, so a network that never
+  answers is dialled once a day rather than on every compile error.
+
+### Fixed
+
+- **Downloads had no timeout of any kind.** A network that accepts the
+  connection and then drops every packet, a captive portal or a firewall that
+  blackholes, hung `ae upgrade`, `ae install`, `ae add` and `ae version list`
+  indefinitely with no output. Every transfer now has a 5 second connect
+  timeout and aborts if throughput stays under 1 KB/s for 20 seconds, and the
+  small metadata fetches additionally cap the whole request at 15 seconds.
+  Release archives keep no total cap, because their size makes any fixed
+  ceiling wrong. Measured against an unroutable address: unbounded before (no
+  ceiling at all), 5 seconds after.
+
+- **Every failed compile printed its diagnostics twice, plus three lines of
+  internal `[diag]` output.** `ae build` and `ae run` re-ran the whole compile
+  on failure "so the user can see the error", left over from a Windows
+  debugging session and redundant since the first run already shows stderr. So
+  every error, every warning and every hint arrived doubled, at the cost of
+  compiling the file a second time. The retry and the `[diag]` lines are gone.
+
+- **A piped `ae build` printed its diagnostics above the line naming the file
+  being built**, because stdout is block-buffered when piped while stderr is
+  not. The banner is flushed now.
+
+- **`ae checksec --require <typo>` exited 0.** An unrecognised property name
+  read back as "n/a", and n/a satisfies the gate by design, so `--require
+  canery` reported success and a CI hardening gate that still looked like a
+  gate protected nothing. Unknown names are now an error naming the valid set.
+  A PE carrying a COFF symbol table is also reported unstripped, which is a
+  definitive signal and does not depend on a section-name scan that an 8-byte
+  PE name field can truncate.
+
+- **`ae build --coverage` could return an uninstrumented binary from the build
+  cache.** The cache key covered `--trace` but not `--coverage`, `--profile` or
+  `--size`, all of which change the emitted code, so a coverage build after a
+  plain build of the same source was served the cached binary: it ran, wrote no
+  `.gcda`, and reported zero coverage for code that was in fact tested.
+  Coverage builds are now excluded from the cache entirely, because an
+  instrumented binary has the absolute path of its `.gcno` baked in and a
+  cached copy reused elsewhere deposits its results back where it was first
+  compiled. `--profile` and `--size` reach the key.
+
+- **An untaken `else` could report as covered.** `if` statements and their
+  `else` blocks carried no source position, so codegen emitted no `#line`
+  before the generated `} else {`; that C line inherited the line count
+  drifting on from the then-branch and landed on the first line of the else
+  BODY. gcov charged the branch counter there, and a branch that never ran
+  showed as executed. Both now carry the position of the keyword that
+  introduces them.
+
+- **`install_name_tool` ran on static archives and non-Darwin cross output**,
+  failing and warning that "consumers may fail to dlopen" for artifacts nothing
+  can dlopen. An install_name belongs to a Mach-O dylib; the fixup is now
+  limited to one.
 
 ## [0.627.0]
 

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -5845,6 +5845,12 @@ void generate_statement(CodeGenerator* gen, ASTNode* stmt) {
                     // Restore: else-branch sees only pre-if declarations.
                     truncate_declared_vars(gen, saved_var_count);
 
+                    /* Anchor the `} else {` line. Without a directive here
+                     * it inherits the then-branch's drifting count and lands
+                     * on the line of the ELSE BODY, so gcov charges the
+                     * branch-decision counter to a statement that never ran
+                     * and an untaken branch reports as covered. */
+                    codegen_maybe_emit_line(gen, stmt->children[2]);
                     print_line(gen, "} else {");
                     indent(gen);
                     generate_statement(gen, stmt->children[2]);

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -3023,6 +3023,9 @@ ASTNode* parse_when_statement(Parser* parser) {
 }
 
 ASTNode* parse_if_statement(Parser* parser) {
+    Token* if_tok = peek_token(parser);
+    int if_line = if_tok ? if_tok->line : 0;
+    int if_col  = if_tok ? if_tok->column : 0;
     advance_token(parser); // if
     int saved_in_condition = parser->in_condition;
     parser->in_condition = 1;
@@ -3033,13 +3036,25 @@ ASTNode* parse_if_statement(Parser* parser) {
     ASTNode* then_branch = parse_statement(parser);
     if (!then_branch) return NULL;
     
-    ASTNode* if_stmt = create_ast_node(AST_IF_STATEMENT, NULL, 0, 0);
+    ASTNode* if_stmt = create_ast_node(AST_IF_STATEMENT, NULL, if_line, if_col);
     add_child(if_stmt, condition);
     add_child(if_stmt, then_branch);
-    
+
+    /* The else block needs a position of its own. Codegen emits a #line before
+     * `} else {`, and with no position there the C line inherits the count
+     * drifting on from the then-branch and lands on the first line of the ELSE
+     * BODY. gcov then charges the branch-decision counter to a statement that
+     * never ran, and an untaken else reports as covered. */
+    Token* else_tok = peek_token(parser);
+    int else_line = else_tok ? else_tok->line : 0;
+    int else_col  = else_tok ? else_tok->column : 0;
     if (match_token(parser, TOKEN_ELSE)) {
         ASTNode* else_branch = parse_statement(parser);
         if (else_branch) {
+            if (else_branch->line <= 0) {
+                else_branch->line = else_line;
+                else_branch->column = else_col;
+            }
             add_child(if_stmt, else_branch);
         }
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -644,6 +644,16 @@ no-op when you are already on the latest release.
 
 Versions are stored in `~/.aether/versions/`. The active version is symlinked to `~/.aether/current` (Linux/macOS) or copied to `~/.aether/bin/` (Windows).
 
+`ae version` tells you when a newer release exists, naming it and pointing at
+`ae upgrade`. It matters more than it sounds: `ae run` resolves the standard
+library from the install rather than from a checkout, so on a toolchain that has
+aged the stdlib answers too, and a function added since resolves as undefined.
+The same line appears when a build fails, which is where that symptom shows up.
+The check asks GitHub at most once a day and caches the answer in
+`~/.aether/cache`, so `ae version` still answers offline, and it says nothing at
+all when the check cannot be made. Nothing updates itself; the decision is
+yours.
+
 `ae version list` asks GitHub what exists and marks the releases it also finds
 locally, so it answers "what could I install?". `ae version installed` reads
 only the disk, which is the question to ask when your installs have aged out of

--- a/tests/integration/checksec_hardening/test_checksec_hardening.sh
+++ b/tests/integration/checksec_hardening/test_checksec_hardening.sh
@@ -193,10 +193,26 @@ esac
 "$AE" checksec --require "pie,nx,relro-full,canary,fortify" "$PROBE" >/dev/null 2>&1 \
     || fail "--require rejected a binary the report says is hardened"
 
-# And the gate is a gate: something the binary cannot have must fail it.
-if "$AE" checksec --require stripped "$PROBE" >/dev/null 2>&1; then
-    fail "--require stripped passed on an unstripped binary, so the gate proves nothing"
+# And the gate is a gate: something the report says the binary lacks must fail
+# it. The property is taken from the report rather than hardcoded, because
+# which ones are expressible differs by format: `stripped` was hardcoded here
+# and a release-built PE genuinely IS stripped (no DWARF, no COFF symbols), so
+# the gate correctly passed and the assertion, not the tool, was wrong.
+missing="$(printf '%s\n' "$report" | awk 'tolower($2)=="no" {print tolower($1); exit}')"
+if [ -n "$missing" ]; then
+    if "$AE" checksec --require "$missing" "$PROBE" >/dev/null 2>&1; then
+        fail "--require $missing passed on a binary the report says lacks it, so the gate proves nothing"
+    fi
 fi
+
+# A property that does not exist is an error, never a pass. `--require canery`
+# used to exit 0: an unknown name read back as n/a, and n/a satisfies the gate,
+# so one typo turned a CI hardening gate into a no-op that still looked like a
+# gate.
+"$AE" checksec --require canery "$PROBE" >/dev/null 2>&1 \
+    && fail "--require accepted a misspelled property, so a typo silently disables the gate"
+"$AE" checksec --require "pie,nosuchproperty" "$PROBE" >/dev/null 2>&1 \
+    && fail "--require accepted an unknown property alongside a valid one"
 
 # A file that is not a binary is an error, not a silent pass.
 echo "not a binary" > "$TMP/text"

--- a/tests/integration/ci_coverage_smoke/test_ci_coverage_smoke.sh
+++ b/tests/integration/ci_coverage_smoke/test_ci_coverage_smoke.sh
@@ -69,14 +69,25 @@ if ! grep -q '^#line .* "[^"]*cov_demo\.ae"' "$tmpdir/cov_demo.c"; then
     exit 1
 fi
 
-# Build with gcc --coverage so .gcno is produced alongside the
-# object, and .gcda is written when the binary runs.
+# Build with --coverage so .gcno is produced alongside the object, and .gcda
+# is written when the binary runs.
+#
+# Compile and link as two steps. In one step, clang derives the notes-file
+# name from the OUTPUT binary rather than the source (cov_demo-cov_demo.gcno),
+# and `gcov cov_demo.c` then finds nothing; gcc names it after the source
+# either way. Splitting the steps gives cov_demo.gcno under both compilers,
+# which is also how any real build system invokes them.
 INC_FLAGS=$(find "$PREFIX/include/aether" -type d 2>/dev/null | sed 's|^|-I|' | tr '\n' ' ')
-if ! gcc --coverage -O0 -g $INC_FLAGS \
-        "$tmpdir/cov_demo.c" \
+if ! (cd "$tmpdir" && gcc --coverage -O0 -g $INC_FLAGS \
+        -c cov_demo.c -o cov_demo.o 2>"$tmpdir/link.err"); then
+    echo "  [FAIL] ci_coverage_smoke: gcc --coverage compile failed"
+    head -5 "$tmpdir/link.err"
+    exit 1
+fi
+if ! (cd "$tmpdir" && gcc --coverage cov_demo.o \
         -L"$PREFIX/lib/aether" -laether \
         -lpthread -lm -ldl \
-        -o "$tmpdir/cov_demo" 2>"$tmpdir/link.err"; then
+        -o cov_demo 2>"$tmpdir/link.err"); then
     echo "  [FAIL] ci_coverage_smoke: gcc --coverage link failed"
     head -5 "$tmpdir/link.err"
     exit 1
@@ -113,7 +124,11 @@ if ! grep -qE '^[ ]*([0-9]+|#####)[ ]*:[ ]*[0-9]+:' "$ae_gcov"; then
 fi
 
 # Specifically verify the unreached `else` branch is flagged.
-# Line 8 in cov_demo.ae is `println("small")` inside the else.
+# Line 8 in cov_demo.ae is `println("small")` inside the else. This failed
+# while the `if` and its else block carried no source position: codegen emitted
+# no #line before `} else {`, so that C line inherited the then-branch's
+# drifting count, landed on line 8, and the branch counter marked a statement
+# that never ran as covered.
 if ! grep -qE '^[ ]*#####[ ]*:[ ]*8:' "$ae_gcov"; then
     echo "  [FAIL] ci_coverage_smoke: line 8 (unreached else) not flagged as ##### in .ae.gcov"
     grep ':[[:space:]]*[78]:' "$ae_gcov"
@@ -150,9 +165,40 @@ if ! (cd "$ae_demo_dir" && ./demo >/dev/null 2>&1); then
     exit 1
 fi
 
-if [ ! -f "$ae_demo_dir/demo.gcda" ]; then
-    echo "  [FAIL] ci_coverage_smoke: 'ae build --coverage' did not produce demo.gcda"
+# The .gcda name is the compiler's to choose: compiling and linking in one
+# step, clang writes demo-demo.gcda and gcc 11+ does the same, while older gcc
+# writes demo.gcda. Asserting a name tested the compiler, so assert the
+# outcome instead -- data was written, gcov reads it, and the .ae source gets a
+# report with the untaken branch flagged.
+gcda=$(find "$ae_demo_dir" -name '*.gcda' | head -1)
+if [ -z "$gcda" ]; then
+    echo "  [FAIL] ci_coverage_smoke: 'ae build --coverage' produced no .gcda"
     ls "$ae_demo_dir"
+    exit 1
+fi
+
+if ! (cd "$ae_demo_dir" && gcov -p -b "$(basename "$gcda")" >"$tmpdir/ae_gcov.log" 2>&1); then
+    echo "  [FAIL] ci_coverage_smoke: gcov failed on the 'ae build --coverage' data"
+    cat "$tmpdir/ae_gcov.log"
+    exit 1
+fi
+
+ae_demo_gcov=$(find "$ae_demo_dir" -name '*demo.ae*.gcov' | head -1)
+if [ -z "$ae_demo_gcov" ]; then
+    echo "  [FAIL] ci_coverage_smoke: 'ae build --coverage' data yielded no .ae.gcov"
+    ls "$ae_demo_dir"
+    exit 1
+fi
+
+# n == 42, so the else never runs. Line 8 is `println("nope")` inside it.
+# This is the assertion with teeth: the `} else {` line carries the branch
+# counter, and with no source position on the else the C line inherited the
+# then-branch's drifting count and landed here, reporting an untaken branch as
+# covered.
+if ! grep -qE '^[ ]*#####[ ]*:[ ]*8:' "$ae_demo_gcov"; then
+    echo "  [FAIL] ci_coverage_smoke: unreached else not flagged in the"
+    echo "         'ae build --coverage' report"
+    grep -E ':[[:space:]]*[678]:' "$ae_demo_gcov"
     exit 1
 fi
 

--- a/tests/integration/cross_emit_lib/test_cross_emit_lib.sh
+++ b/tests/integration/cross_emit_lib/test_cross_emit_lib.sh
@@ -16,6 +16,8 @@
 #     the executable suffix produced a valid DLL under a name nothing loads
 #   - a cross EXE still gets .exe (the naming fix must not leak)
 #   - --emit=both is still rejected, with a message naming the workaround
+#   - a static archive and a non-Darwin dylib get no install_name fixup, and
+#     so no warning about dlopen for output nothing can dlopen
 #   - --emit=staticlib produces an ar archive that holds the program object
 #     AND the runtime/stdlib objects, and that a C program can actually link
 #     against and RUN (the shape an iOS/Xcode app needs, since Apple forbids
@@ -143,14 +145,37 @@ esac
 
 # ---- 5. --emit=staticlib: archive it, then LINK AND RUN it ------------
 # The end-to-end assertion is the point: a well-formed .a that nothing can
-# link is exactly the failure this feature exists to avoid. x86_64-linux-musl
-# is used because a static musl binary runs on this (glibc) host, so the test
-# can execute the result rather than only inspecting it — the iOS target
-# proper needs a Mac, and is asserted in tests/integration/cross_ios.
-if ! "$AE" build --target=x86_64-linux-musl --emit=staticlib "$LIB" \
+# link is exactly the failure this feature exists to avoid. The triple is
+# matched to the host so the result can actually be executed here; it was
+# hardcoded to x86_64-linux-musl, which runs on a glibc x86 host and is
+# unexecutable anywhere else, so the run assertion could not pass on macOS or
+# on an arm Linux box. --emit=staticlib still requires --target, which is why
+# the host's own triple is named explicitly. The iOS target proper needs a Mac
+# and is asserted in tests/integration/cross_ios.
+case "$(uname -s)/$(uname -m)" in
+    Darwin/arm64)         SL_TARGET=aarch64-macos ;;
+    Darwin/x86_64)        SL_TARGET=x86_64-macos ;;
+    Linux/aarch64)        SL_TARGET=aarch64-linux-musl ;;
+    Linux/x86_64|*)       SL_TARGET=x86_64-linux-musl ;;
+esac
+if ! "$AE" build --target="$SL_TARGET" --emit=staticlib "$LIB" \
         -o "$TMPDIR_T/libgreet.a" > "$TMPDIR_T/sl.log" 2>&1; then
     echo "  [FAIL] cross_emit_lib: --emit=staticlib did not build"
     sed 's/^/    /' "$TMPDIR_T/sl.log" | head -15
+    exit 1
+fi
+
+# install_name_tool applies to Mach-O dylibs. An archive has no install_name,
+# and neither does a dylib for a non-Darwin target, so running it on either
+# failed and warned about dlopen for output that is never dlopen'd.
+if grep -q 'install_name_tool' "$TMPDIR_T/sl.log"; then
+    echo "  [FAIL] cross_emit_lib: install_name_tool run on a static archive"
+    grep 'install_name_tool' "$TMPDIR_T/sl.log" | sed 's/^/    /'
+    exit 1
+fi
+if grep -q 'install_name_tool' "$TMPDIR_T/elf.log"; then
+    echo "  [FAIL] cross_emit_lib: install_name_tool run on a non-Darwin dylib"
+    grep 'install_name_tool' "$TMPDIR_T/elf.log" | sed 's/^/    /'
     exit 1
 fi
 
@@ -166,11 +191,18 @@ esac
 
 # The program object alone would be a useless .a: the consumer links this one
 # file and expects the runtime to come with it.
-if ! ar t "$TMPDIR_T/libgreet.a" 2>/dev/null | grep -q '__aether_program.o'; then
+#
+# Listed with `zig ar`, not the host `ar`. zig ar writes a GNU archive, whose
+# member names live in an extended string table; BSD ar cannot decode that and
+# prints the raw offset references (`/`, `//`, `/0`, `/20`) instead of names.
+# So this assertion passed on Linux and failed on macOS against a byte-identical
+# archive that links and runs fine on both.
+if ! zig ar t "$TMPDIR_T/libgreet.a" 2>/dev/null | grep -q '__aether_program.o'; then
     echo "  [FAIL] cross_emit_lib: static archive lacks the program object"
+    zig ar t "$TMPDIR_T/libgreet.a" 2>/dev/null | head -10 | sed 's/^/    /'
     exit 1
 fi
-MEMBERS=$(ar t "$TMPDIR_T/libgreet.a" 2>/dev/null | wc -l)
+MEMBERS=$(zig ar t "$TMPDIR_T/libgreet.a" 2>/dev/null | wc -l)
 if [ "$MEMBERS" -le 10 ]; then
     echo "  [FAIL] cross_emit_lib: static archive holds only $MEMBERS members;"
     echo "         the runtime/stdlib objects are missing"
@@ -183,7 +215,7 @@ cat > "$TMPDIR_T/host.c" <<'CEOF'
 extern int aether_greet(void);
 int main(void) { printf("greet=%d\n", aether_greet()); return 0; }
 CEOF
-if ! zig cc -target x86_64-linux-musl "$TMPDIR_T/host.c" "$TMPDIR_T/libgreet.a" \
+if ! zig cc -target "$SL_TARGET" "$TMPDIR_T/host.c" "$TMPDIR_T/libgreet.a" \
         -lm -o "$TMPDIR_T/hostprog" > "$TMPDIR_T/link.log" 2>&1; then
     echo "  [FAIL] cross_emit_lib: C program could not link the static archive"
     sed 's/^/    /' "$TMPDIR_T/link.log" | head -15

--- a/tests/integration/http_server_chunked_request/test_http_server_chunked_request.sh
+++ b/tests/integration/http_server_chunked_request/test_http_server_chunked_request.sh
@@ -76,18 +76,44 @@ grep -q "len=7 body=\[SECOND!\]" "$TMPDIR/pipelined.out" \
 
 # A chunked body declares no length up front, so a sender that never sends the
 # terminal chunk is bounded only by what the server refuses to hold.
-{
-    printf 'POST /upload HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n'
-    i=0
-    while [ "$i" -lt 180 ]; do
-        printf '10000\r\n'
-        head -c 65536 /dev/zero | tr '\0' 'a'
-        printf '\r\n'
-        i=$((i + 1))
-    done
-} | nc 127.0.0.1 "$PORT" > "$TMPDIR/flood.out" 2>/dev/null
-grep -q "^HTTP/1.1 413" "$TMPDIR/flood.out" \
-    || { head -3 "$TMPDIR/flood.out"; fail "an endless chunked body was not refused"; }
+#
+# Not nc: the server answers 413 and closes while the sender is still writing,
+# so nc dies of EPIPE and can exit before it has drained the response it just
+# provoked. That made this case pass on an idle machine and fail on a busy one,
+# blaming the server for a race in the client. This writes until the socket
+# refuses more, stops writing, and only then reads, which is the exchange the
+# assertion is actually about.
+if command -v python3 >/dev/null 2>&1; then
+    python3 - "$PORT" > "$TMPDIR/flood.out" 2>/dev/null <<'FLOOD'
+import socket, sys
+s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=10)
+s.sendall(b"POST /upload HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n")
+chunk = b"10000\r\n" + b"a" * 65536 + b"\r\n"
+try:
+    for _ in range(180):
+        s.sendall(chunk)
+except OSError:
+    pass                      # the server refused the body and closed: expected
+try:
+    s.shutdown(socket.SHUT_WR)
+except OSError:
+    pass
+buf = b""
+try:
+    while True:
+        b_ = s.recv(65536)
+        if not b_:
+            break
+        buf += b_
+except OSError:
+    pass
+sys.stdout.write(buf.decode("latin1"))
+FLOOD
+    grep -q "^HTTP/1.1 413" "$TMPDIR/flood.out" \
+        || { head -3 "$TMPDIR/flood.out"; fail "an endless chunked body was not refused"; }
+else
+    echo "  [SKIP] endless-chunked-body case: python3 not on PATH"
+fi
 
 # Framing that has no single answer is refused rather than guessed at. Two
 # lengths that disagree, or a value that is not a count of bytes, is what lets

--- a/tests/integration/version_staleness/test_version_staleness.sh
+++ b/tests/integration/version_staleness/test_version_staleness.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# `ae version` and a failed build say when a newer release exists.
+#
+# The reason this exists: `ae upgrade` always worked, and nothing ever said to
+# run it. Every check in `ae version` compared the binary against its own
+# siblings and never against what had been released, so an install 75 releases
+# behind reported itself healthy while `ae run` answered from its stale stdlib
+# and reported functions added since as undefined.
+#
+# Hermetic: HOME points at a temp dir and the cache is seeded, so no case here
+# reaches the network. That is also the property under test in the last case,
+# since `ae version` must answer without it.
+#
+# Asserts:
+#   - behind the latest release: `ae version` names it and points at upgrade
+#   - level with it: silent
+#   - the comparison is numeric, not lexicographic (0.1000.0 is NEWER than
+#     0.627.0, and a string compare says the opposite)
+#   - a failed build carries the same hint, on stderr, and prints its
+#     diagnostics exactly once
+#   - `ae run` does the same, since it has its own copy of that path
+#   - level with it, a failed build stays silent
+#   - a seeded cache is honoured, so no fetch happens
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+[ -x "$AE" ] || { echo "  [SKIP] version_staleness: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP" || :; return 0; }
+trap cleanup EXIT
+fail() { echo "  [FAIL] $1"; exit 1; }
+
+HOME="$TMP/home"; export HOME
+mkdir -p "$HOME/.aether/cache"
+CACHE="$HOME/.aether/cache/latest_release"
+
+CUR="$("$AE" version 2>/dev/null | head -1 | awk '{print $2}')"
+[ -n "$CUR" ] || fail "could not read the current version"
+
+seed() { printf 'v%s\n' "$1" > "$CACHE"; }
+
+# --- behind: named, with the upgrade command ------------------------------
+seed 99.0.0
+OUT="$("$AE" version 2>&1)"
+case "$OUT" in
+  *"newer release is available: 99.0.0"*) ;;
+  *) fail "behind: no nudge naming the release. got: $OUT" ;;
+esac
+case "$OUT" in
+  *"ae upgrade"*) ;;
+  *) fail "behind: nudge does not name \`ae upgrade\`" ;;
+esac
+
+# --- level: silent --------------------------------------------------------
+seed "$CUR"
+"$AE" version 2>&1 | grep -q "newer release" && fail "level: nudged anyway"
+
+# --- numeric, not lexicographic ------------------------------------------
+# 0.1000.0 is newer than any 0.6xx.0, and strcmp puts '1' below '6'. A string
+# compare passes every case above and fails only this one.
+case "$CUR" in
+  0.*) seed 0.1000.0
+       "$AE" version 2>&1 | grep -q "newer release is available: 0.1000.0" \
+         || fail "0.1000.0 not seen as newer than $CUR (lexicographic compare?)" ;;
+esac
+
+# --- a failed build carries the hint, once, on stderr ---------------------
+printf 'main() { x = no_such_function_anywhere() }\n' > "$TMP/bad.ae"
+seed 99.0.0
+ERR="$("$AE" build "$TMP/bad.ae" -o "$TMP/bad" 2>&1 1>/dev/null || :)"
+case "$ERR" in
+  *"newer release is available"*) ;;
+  *) fail "failed build: no hint on stderr" ;;
+esac
+N="$(printf '%s\n' "$ERR" | grep -c 'no_such_function_anywhere' || :)"
+[ "$N" -le 2 ] || fail "failed build: diagnostics repeated ($N mentions, expected the error once)"
+printf '%s\n' "$ERR" | grep -q '\[diag\]' && fail "failed build: internal [diag] output shipped to the user"
+
+# --- `ae run` fails the same way, once ------------------------------------
+# A separate call site with its own copy of the failure path, so it needs its
+# own case; the two drifted apart before, one carrying [diag] output.
+seed 99.0.0
+ERR="$("$AE" run "$TMP/bad.ae" 2>&1 1>/dev/null || :)"
+case "$ERR" in
+  *"newer release is available"*) ;;
+  *) fail "failed run: no hint on stderr" ;;
+esac
+N="$(printf '%s\n' "$ERR" | grep -c 'no_such_function_anywhere' || :)"
+[ "$N" -le 2 ] || fail "failed run: diagnostics repeated ($N mentions)"
+printf '%s\n' "$ERR" | grep -q '\[diag\]' && fail "failed run: internal [diag] output shipped"
+
+# --- level: a failed build stays silent -----------------------------------
+seed "$CUR"
+ERR="$("$AE" build "$TMP/bad.ae" -o "$TMP/bad" 2>&1 1>/dev/null || :)"
+case "$ERR" in
+  *"newer release is available"*) fail "level: failed build nudged anyway" ;;
+esac
+
+# --- the seeded cache is honoured, so nothing was fetched -----------------
+[ "$(cat "$CACHE")" = "v$CUR" ] || fail "cache overwritten: a fetch happened despite a fresh cache"
+
+echo "  [PASS] version_staleness"

--- a/tests/integration/windows_crt_symbols/test_windows_crt_symbols.sh
+++ b/tests/integration/windows_crt_symbols/test_windows_crt_symbols.sh
@@ -78,7 +78,16 @@ fi
 
 INC="-Iinclude -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils
      -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math
-     -Istd/net -Istd/collections -Istd/json"
+     -Istd/net -Istd/collections -Istd/json -Istd/regex"
+
+# The same feature defines the driver and the Makefile always pass. std.regex
+# refuses to build without them by design, because the alternative is a regex
+# engine whose every call silently returns no-match at runtime; compiling it
+# here with a guessed flag set reported the source as broken when it is the
+# flag set that was incomplete. AETHER_HAS_PCRE2 is unconditional on the real
+# build paths (tools/ae_cross.c), backed by the vendored engine, which needs no
+# system library.
+DEFS="-DAETHER_HAS_PCRE2 -DAETHER_VENDOR_PCRE2"
 
 if [ "$USE_ARCHIVE" -eq 1 ]; then
     subject="$ARCHIVE"
@@ -90,7 +99,7 @@ else
     for src in $(grep -v '^#' "$MANIFEST" | grep -v '^[[:space:]]*$'); do
         [ -f "$src" ] || continue
         obj="$TMP/objs/$(echo "$src" | tr '/' '_' | sed 's/\.c$/.o/')"
-        if ! $CC_WIN -O2 $INC -DAETHER_VERSION='"test"' -c "$src" -o "$obj" 2>"$TMP/cc.log"; then
+        if ! $CC_WIN -O2 $INC $DEFS -DAETHER_VERSION='"test"' -c "$src" -o "$obj" 2>"$TMP/cc.log"; then
             echo "  [FAIL] windows_crt_symbols: $src does not cross-compile for Windows"
             sed 's/^/        /' "$TMP/cc.log" | head -8
             exit 1

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -546,6 +546,8 @@ static int posix_run(const char* cmd_str, int quiet, const char* capture) {
 #ifdef _WIN32
 #include <process.h>
 #include <io.h>
+#include <fcntl.h>     // _O_CREAT / _O_TRUNC for the stdout capture
+#include <sys/stat.h>  // _S_IREAD / _S_IWRITE for the file it creates
 #ifndef _O_WRONLY
 #define _O_WRONLY 1
 #endif
@@ -559,6 +561,21 @@ static int posix_run(const char* cmd_str, int quiet, const char* capture) {
  * `_O_WRONLY` above. */
 #ifndef _O_BINARY
 #define _O_BINARY 0x8000
+#endif
+/* Same gate, same fallback, for the flags the stdout capture creates its file
+ * with. The cross-build leg failed on exactly this: <fcntl.h> is included
+ * above, and _O_CREAT still was not visible. */
+#ifndef _O_CREAT
+#define _O_CREAT 0x0100
+#endif
+#ifndef _O_TRUNC
+#define _O_TRUNC 0x0200
+#endif
+#ifndef _S_IREAD
+#define _S_IREAD 0x0100
+#endif
+#ifndef _S_IWRITE
+#define _S_IWRITE 0x0080
 #endif
 static int win_run(const char* cmd_str, int quiet, const char* capture) {
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd_str);

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -3543,10 +3543,8 @@ static int cmd_run(int argc, char** argv) {
     // uses run_cmd_show_warnings. (run_cmd_quiet dropped stderr, hiding them.)
     int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
     if (aetherc_ret != 0) {
-        // Re-run with output visible so user can see the error
-        build_aetherc_cmd(cmd, sizeof(cmd), file, c_file);
-        run_cmd(cmd);
         fprintf(stderr, "Compilation failed.\n");
+        ae_report_newer_release(stderr);
         return 1;
     }
 
@@ -6004,7 +6002,13 @@ static int cmd_build(int argc, char** argv) {
     // (emcc emits .js + .wasm) and --emit=lib produces a different artefact
     // type; both deserve their own cache shape later. --namespace mode
     // produces SDKs in subdirectories, also out of scope.
-    bool cache_eligible = !is_wasm && !is_cross && g_emit_exe && !g_emit_lib;
+    /* --coverage is never cacheable. The instrumented binary has the ABSOLUTE
+     * path of its .gcno baked in at compile time and writes the matching .gcda
+     * beside it, so a cached coverage binary reused from another directory
+     * silently deposits its results back where it was first compiled, leaving
+     * the caller with a binary that ran and no data next to it. */
+    bool cache_eligible = !is_wasm && !is_cross && g_emit_exe && !g_emit_lib &&
+                          !g_coverage;
     char cached_exe[1024] = "";
     unsigned long long cache_key = 0;
     if (cache_eligible) {
@@ -6015,9 +6019,19 @@ static int cmd_build(int argc, char** argv) {
          * (#1421). Any flag that changes the emitted code has to reach the
          * key. */
         char build_salt[4096];
+        /* Every flag that changes the emitted code, not just --trace. A
+         * --coverage build after a plain build of the same source was served
+         * the cached uninstrumented binary: it ran, produced no .gcno and no
+         * .gcda, and reported zero coverage for code that was in fact tested.
+         * --profile and --size had the same silent hole. */
+        char build_mode[64] = "build";
+        if (g_trace)    strncat(build_mode, "+trace",    sizeof(build_mode) - strlen(build_mode) - 1);
+        if (g_coverage) strncat(build_mode, "+coverage", sizeof(build_mode) - strlen(build_mode) - 1);
+        if (g_profile)  strncat(build_mode, "+profile",  sizeof(build_mode) - strlen(build_mode) - 1);
+        if (g_size)     strncat(build_mode, "+size",     sizeof(build_mode) - strlen(build_mode) - 1);
         cache_key = compute_cache_key(file, extra_files,
                                       quick ? "O0" : "O2",
-                                      ae_define_salt(g_trace ? "build+trace" : "build",
+                                      ae_define_salt(build_mode,
                                                      build_salt, sizeof(build_salt)));
         if (cache_key != 0) {
             init_cache_dir();
@@ -6038,6 +6052,10 @@ static int cmd_build(int argc, char** argv) {
 
     if (is_cross)      printf("Building %s (cross: %s)...\n", file, target);
     else               printf("Building %s%s...\n", file, is_wasm ? " (wasm)" : "");
+    /* stdout is block-buffered when piped, stderr is not, so without this a
+     * failing build prints its diagnostics before the line saying what was
+     * being built. */
+    fflush(stdout);
 
     // Binary-import prepass: synthesize interface stubs for any
     // `import foo` resolving to a precompiled libfoo.so, link it in.
@@ -6055,13 +6073,8 @@ static int cmd_build(int argc, char** argv) {
     // `ae build`; run_cmd_quiet had dropped them.
     int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
     if (aetherc_ret != 0) {
-        fprintf(stderr, "[diag] aetherc returned %d for: %s\n", aetherc_ret, file);
-        fprintf(stderr, "[diag] cmd: %s\n", cmd);
-        // Retry visible
-        build_aetherc_cmd(cmd, sizeof(cmd), file, c_file);
-        int retry_ret = run_cmd(cmd);
-        fprintf(stderr, "[diag] retry returned %d\n", retry_ret);
         fprintf(stderr, "Compilation failed.\n");
+        ae_report_newer_release(stderr);
         return 1;
     }
 
@@ -6171,14 +6184,6 @@ static int cmd_build(int argc, char** argv) {
          * fully quiet compile would hide them. Errors still re-run loud. */
         build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
         if (build_ret != 0) {
-            // Retry with visible output for error messages
-            if (is_wasm) {
-                build_wasm_cmd(cmd, sizeof(cmd), c_file, exe_file);
-            } else {
-                const char* extra = extra_files[0] ? extra_files : NULL;
-                build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, !quick, extra);
-            }
-            run_cmd(cmd);
             fprintf(stderr, "Build failed.\n");
             return 1;
         }
@@ -6197,7 +6202,16 @@ static int cmd_build(int argc, char** argv) {
      *
      * cmd_build_namespace does its own install_name fixup after its
      * post-rename step — this block is for direct `ae build --emit=lib`. */
-    if (g_emit_lib && !g_emit_exe) {
+    /* Only a Mach-O dylib has an install_name. A static archive has none, and
+     * neither does a dylib for a non-Darwin target, so running the tool on
+     * either fails and prints a warning about dlopen for output nothing will
+     * ever dlopen. A cross Darwin target still needs the fixup, since the
+     * install_name is baked by the linker regardless of which host ran it. */
+    int target_is_darwin = !is_cross ||
+                           (target && (strstr(target, "macos") ||
+                                       strstr(target, "darwin") ||
+                                       strstr(target, "ios")));
+    if (g_emit_lib && !g_emit_exe && !g_emit_staticlib && target_is_darwin) {
         const char* base = strrchr(exe_file, '/');
         base = base ? base + 1 : exe_file;
         char id_cmd[4096];

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -3620,17 +3620,19 @@ static int cmd_run(int argc, char** argv) {
     const char* run_extra = extra_files[0] ? extra_files : NULL;
     build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, false, run_extra);
     // Show stderr (gcc warnings like -Wformat) even in non-verbose mode
-    int gcc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
+    char glog[1024];
+    compile_log_path(glog, sizeof(glog));
+    int gcc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_capture_stdout(cmd, glog);
     if (gcc_ret != 0) {
-        // Re-run with output for error diagnosis
-        build_gcc_cmd(cmd, sizeof(cmd), c_file, exe_file, false, run_extra);
-        run_cmd(cmd);
+        if (!tc.verbose) dump_captured_stdout(glog);
+        remove(glog);
         fprintf(stderr, "Build failed.\n");
         remove(c_file);
         remove(exe_file);  // partial link output, if any
         remove_dsym_bundle(exe_file);
         return 1;
     }
+    remove(glog);
 
     // Clean up temp .c file (exe stays in cache if caching, else clean up too)
     remove(c_file);

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -489,7 +489,7 @@ void build_aetherc_cmd(char* cmd, size_t cmd_size, const char* input, const char
 // Space-splits the command string into argv (no shell quoting supported,
 // but our controlled commands never need it).
 // quiet=0: show all output, quiet=1: hide stdout+stderr, quiet=2: hide stdout only (keep stderr for warnings)
-static int posix_run(const char* cmd_str, int quiet) {
+static int posix_run(const char* cmd_str, int quiet, const char* capture) {
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd_str);
     char buf[AE_CMD_BUF];
     strncpy(buf, cmd_str, sizeof(buf) - 1);
@@ -522,6 +522,9 @@ static int posix_run(const char* cmd_str, int quiet) {
     } else if (quiet == 2) {
         // Hide stdout but keep stderr (so gcc warnings are visible)
         posix_spawn_file_actions_addopen(&fa, STDOUT_FILENO, "/dev/null", O_WRONLY, 0);
+    } else if (quiet == 3 && capture) {
+        posix_spawn_file_actions_addopen(&fa, STDOUT_FILENO, capture,
+                                         O_WRONLY | O_CREAT | O_TRUNC, 0600);
     }
 
     pid_t pid;
@@ -557,7 +560,7 @@ static int posix_run(const char* cmd_str, int quiet) {
 #ifndef _O_BINARY
 #define _O_BINARY 0x8000
 #endif
-static int win_run(const char* cmd_str, int quiet) {
+static int win_run(const char* cmd_str, int quiet, const char* capture) {
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd_str);
     char buf[AE_CMD_BUF];
     strncpy(buf, cmd_str, sizeof(buf) - 1);
@@ -636,6 +639,12 @@ static int win_run(const char* cmd_str, int quiet) {
         int nul = _open("nul", _O_WRONLY);
         if (nul >= 0) { _dup2(nul, 1); _close(nul); }
     }
+    if (quiet == 3 && capture) {
+        fflush(stdout);
+        saved_stdout = _dup(1);
+        int fd = _open(capture, _O_WRONLY | _O_CREAT | _O_TRUNC, _S_IREAD | _S_IWRITE);
+        if (fd >= 0) { _dup2(fd, 1); _close(fd); }
+    }
     if (quiet == 1) {
         fflush(stderr);
         saved_stderr = _dup(2);
@@ -655,27 +664,62 @@ static int win_run(const char* cmd_str, int quiet) {
 
 int run_cmd(const char* cmd) {
 #ifndef _WIN32
-    return posix_run(cmd, 0);
+    return posix_run(cmd, 0, NULL);
 #else
-    return win_run(cmd, 0);
+    return win_run(cmd, 0, NULL);
 #endif
 }
 
 // Run a command, suppressing all output (quiet mode)
 int run_cmd_quiet(const char* cmd) {
 #ifndef _WIN32
-    return posix_run(cmd, 1);
+    return posix_run(cmd, 1, NULL);
 #else
-    return win_run(cmd, 1);
+    return win_run(cmd, 1, NULL);
 #endif
+}
+
+/* Where a compile step's stdout is parked so a failure can print it. */
+static const char* compile_log_path(char* buf, size_t size) {
+    snprintf(buf, size, "%s/ae_build_%d.out", get_temp_dir(), (int)getpid());
+    return buf;
+}
+
+/* Run a command with stderr passing through and stdout captured to `path`.
+ *
+ * The compile steps hide stdout so a successful build is quiet, and on failure
+ * the driver used to re-run the ENTIRE compile just to show what was hidden:
+ * a second compile of the same file, and every stderr diagnostic printed
+ * twice. Capturing instead costs one temp file, and the caller prints it only
+ * when the command fails. Dropping stdout outright is not an option, since a
+ * C compiler that reports through it (emcc does) would fail with no
+ * explanation at all. */
+int run_cmd_capture_stdout(const char* cmd, const char* path) {
+#ifndef _WIN32
+    return posix_run(cmd, 3, path);
+#else
+    return win_run(cmd, 3, path);
+#endif
+}
+
+/* Print a captured stdout log to stderr, so it interleaves with the
+ * diagnostics that streamed through live. Silent when there is nothing. */
+void dump_captured_stdout(const char* path) {
+    FILE* f = fopen(path, "r");
+    if (!f) return;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0) fwrite(buf, 1, n, stderr);
+    fclose(f);
+    fflush(stderr);
 }
 
 // Run a command, showing stderr (warnings) but hiding stdout
 int run_cmd_show_warnings(const char* cmd) {
 #ifndef _WIN32
-    return posix_run(cmd, 2);
+    return posix_run(cmd, 2, NULL);
 #else
-    return win_run(cmd, 2);
+    return win_run(cmd, 2, NULL);
 #endif
 }
 
@@ -713,7 +757,7 @@ int run_cmd_forwarding(const char* cmd) {
 #ifdef _WIN32
     /* Windows has no SIGTERM-to-child model that matches this; the
      * orphaning report is POSIX-specific (kill $! in a shell test). */
-    return win_run(cmd, 0);
+    return win_run(cmd, 0, NULL);
 #else
     if (tc.verbose) fprintf(stderr, "[cmd] %s\n", cmd);
     char buf[AE_CMD_BUF];
@@ -3541,12 +3585,17 @@ static int cmd_run(int argc, char** argv) {
     // aetherc step can emit warnings (e.g. #1780 self-shadowing import) that a
     // plain `ae run` must not swallow. Mirrors the gcc step below, which already
     // uses run_cmd_show_warnings. (run_cmd_quiet dropped stderr, hiding them.)
-    int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
+    char clog[1024];
+    compile_log_path(clog, sizeof(clog));
+    int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_capture_stdout(cmd, clog);
     if (aetherc_ret != 0) {
+        if (!tc.verbose) dump_captured_stdout(clog);
+        remove(clog);
         fprintf(stderr, "Compilation failed.\n");
         ae_report_newer_release(stderr);
         return 1;
     }
+    remove(clog);
 
     // Step 2: Compile .c to executable with runtime (-O0 for fast dev builds).
     // toml [[bin]] extra_sources were already merged into extra_files above
@@ -6071,12 +6120,17 @@ static int cmd_build(int argc, char** argv) {
     // Always run visible on failure; print diagnostic on Windows. Keep stderr
     // so compiler warnings (e.g. #1780 self-shadowing import) survive a plain
     // `ae build`; run_cmd_quiet had dropped them.
-    int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
+    char clog[1024];
+    compile_log_path(clog, sizeof(clog));
+    int aetherc_ret = tc.verbose ? run_cmd(cmd) : run_cmd_capture_stdout(cmd, clog);
     if (aetherc_ret != 0) {
+        if (!tc.verbose) dump_captured_stdout(clog);
+        remove(clog);
         fprintf(stderr, "Compilation failed.\n");
         ae_report_newer_release(stderr);
         return 1;
     }
+    remove(clog);
 
     /* #1243 --emit=obj: aetherc has written the generated C; compile it to a
      * single object and stop. No link, no `main`, so the caller drops the .o
@@ -6182,11 +6236,16 @@ static int cmd_build(int argc, char** argv) {
         /* Warnings-visible like the `ae run` path: with #1252 fixed the C
          * compiler's -Wformat findings map to the user's .ae lines, and a
          * fully quiet compile would hide them. Errors still re-run loud. */
-        build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_show_warnings(cmd);
+        char blog[1024];
+        compile_log_path(blog, sizeof(blog));
+        build_ret = tc.verbose ? run_cmd(cmd) : run_cmd_capture_stdout(cmd, blog);
         if (build_ret != 0) {
+            if (!tc.verbose) dump_captured_stdout(blog);
+            remove(blog);
             fprintf(stderr, "Build failed.\n");
             return 1;
         }
+        remove(blog);
     }
 
     // Clean up intermediate C file — ae build produces a binary, not C source

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -5407,6 +5407,13 @@ int cmd_build_namespace(int argc, char** argv) {
                 fprintf(stderr, "Warning: install_name_tool failed on %s; "
                                 "consumers may fail to dlopen.\n", out_path);
             }
+            /* Rewriting the id modifies the file, which invalidates the ad-hoc
+             * signature ld64 attaches to everything it links on Apple silicon.
+             * dyld does not report that as an error: the kernel SIGKILLs the
+             * process that dlopens it, with no message, so a host program died
+             * on load and the library looked fine on disk. Re-sign after every
+             * modification. */
+            macos_prepare_binary(out_path);
         }
 #endif
         printf("Built namespace: %s\n", out_path);
@@ -6300,6 +6307,10 @@ static int cmd_build(int argc, char** argv) {
             fprintf(stderr, "Warning: install_name_tool failed on %s; "
                             "consumers may fail to dlopen.\n", exe_file);
         }
+        /* See cmd_build_namespace: the id rewrite invalidates ld64's ad-hoc
+         * signature, and the loader's answer to that is SIGKILL, not an
+         * error. */
+        macos_prepare_binary(exe_file);
     }
 #endif
 

--- a/tools/ae_checksec.c
+++ b/tools/ae_checksec.c
@@ -238,7 +238,12 @@ static int inspect_pe(const unsigned char* b, size_t len, Checksec* out) {
                  : num_symbols == 0           ? PROP_NA
                                               : PROP_NO;
     if (out->canary == PROP_NO && num_symbols == 0) out->canary = PROP_NA;
-    out->stripped = has_name(b, len, ".debug_info") ? PROP_NO : PROP_YES;
+    /* A COFF symbol table is a definitive unstripped signal, and cheaper to
+     * trust than a name scan: long section names are truncated to 8 bytes in a
+     * PE image, so ".debug_info" is only found when a string table happens to
+     * carry it in full. */
+    out->stripped = (num_symbols != 0 || has_name(b, len, ".debug_info"))
+                        ? PROP_NO : PROP_YES;
     return 0;
 }
 
@@ -280,14 +285,17 @@ static const char* remedy(const char* prop, PropState s) {
     return "";
 }
 
-static PropState prop_by_name(const Checksec* c, const char* name) {
-    if (strcmp(name, "pie") == 0)     return c->pie;
-    if (strcmp(name, "nx") == 0)      return c->nx;
-    if (strcmp(name, "relro") == 0)   return c->relro;
-    if (strcmp(name, "canary") == 0)  return c->canary;
-    if (strcmp(name, "fortify") == 0) return c->fortify;
-    if (strcmp(name, "stripped") == 0) return c->stripped;
-    return PROP_NA;
+/* -1 for a name that is not a property at all, which the caller must reject.
+ * Returning n/a for it made `--require canery` exit 0, so a typo in a CI
+ * hardening gate protected nothing while still reading like a gate. */
+static int prop_by_name(const Checksec* c, const char* name, PropState* out) {
+    if (strcmp(name, "pie") == 0)     { *out = c->pie;      return 0; }
+    if (strcmp(name, "nx") == 0)       { *out = c->nx;       return 0; }
+    if (strcmp(name, "relro") == 0)    { *out = c->relro;    return 0; }
+    if (strcmp(name, "canary") == 0)   { *out = c->canary;   return 0; }
+    if (strcmp(name, "fortify") == 0)  { *out = c->fortify;  return 0; }
+    if (strcmp(name, "stripped") == 0) { *out = c->stripped; return 0; }
+    return -1;
 }
 
 static void print_row(const char* label, const char* key, PropState s) {
@@ -358,7 +366,13 @@ int cmd_checksec(int argc, char** argv) {
         char* dash = strstr(name, "-full");
         if (dash) { *dash = '\0'; want_full = 1; }
 
-        PropState s = prop_by_name(&c, name);
+        PropState s;
+        if (prop_by_name(&c, name, &s) != 0) {
+            fprintf(stderr, "ae checksec: unknown property '%s'\n", name);
+            fprintf(stderr, "  known: pie, nx, relro (or relro-full), canary, "
+                            "fortify, stripped\n");
+            return 2;
+        }
         /* n/a passes: the format cannot express the property, so demanding it
          * would make one gate unwritable across formats, and the report says
          * n/a in plain sight either way. `-full` is about the distinction the

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -1081,6 +1081,14 @@ int run_cross_build(const char* c_file, const char* out_file,
             if (strstr(ztriple, "wasm") && emit_lib) {
                 wasm_lib_flags = wasm_export_flags(c_file, g_wasm_exports);
             }
+            /* A wasi library is a reactor, not a command. Left in command mode
+             * zig links wasi-libc's startup object, which demands a `main` the
+             * library has not got, and --no-entry does not stop it being
+             * pulled in: `--emit=lib` for wasm32-wasi could not link at all.
+             * Only wasi has an exec model to choose; freestanding has no libc
+             * and rejects the flag. */
+            const char* wasi_model = (emit_lib && strstr(ztriple, "wasi"))
+                                         ? "-mexec-model=reactor " : "";
             /* --emit=lib on an ordinary ELF/PE target (#1648): the same
              * -fPIC -shared the native path uses, chosen by the TARGET
              * rather than by the host, since that is the whole point of
@@ -1116,8 +1124,8 @@ int run_cross_build(const char* c_file, const char* out_file,
                 : (is_apple ? "-Wl,-x -Wl,-dead_strip"
                             : "-Wl,--strip-all -Wl,--gc-sections");
             w = cross_cmd_fmt(&cmd, &cmd_cap,
-                "%s %s %s %s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
-                cc_cmd, sysroot_flag, apple_lib_flags,
+                "%s %s %s %s%s %s %s %s %s %s \"%s\" %s \"%s/libaether.a\" %s %s -o \"%s\" -lm",
+                cc_cmd, sysroot_flag, apple_lib_flags, wasi_model,
                 wasm_lib_flags ? wasm_lib_flags : "", elf_pe_lib_flags, size_link,
                 opt, feature_defs, tc.include_flags, c_file, ex, objdir,
                 crossbuild_libs, win_platform_libs, out_file) ? 1 : -1;

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -67,6 +67,8 @@ extern char s_cache_dir[512];   /* resolved once by init_cache_dir (ae_cache.c) 
 
 /* ae.c helpers shared across TUs. */
 int  run_cmd_show_warnings(const char* cmd);
+int  run_cmd_capture_stdout(const char* cmd, const char* path);
+void dump_captured_stdout(const char* path);
 bool path_exists(const char* path);
 void mkdirs(const char* path);
 const char* get_cflags(void);

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -1,6 +1,8 @@
 #ifndef AE_INTERNAL_H
 #define AE_INTERNAL_H
 
+#include <stdio.h>   // ae_report_newer_release takes a FILE*
+
 /* Shared surface between the `ae` driver's translation units (#1221).
  * ae.c was one 8.5k-line TU, so any edit recompiled everything; command
  * clusters now move into their own ae_*.c files and reach the driver's
@@ -101,6 +103,8 @@ int cmd_version(int argc, char** argv);
  * Expand-Archive) and return 0 on success. Shared with `ae add`'s
  * release-artifact path (#1360). */
 int ae_download(const char* url, const char* dest);
+int ae_download_ex(const char* url, const char* dest, int max_seconds);
+void ae_report_newer_release(FILE* out);
 int ae_extract(const char* archive, const char* dest_dir);
 int cmd_version_use(const char* version);
 int cmd_install(int argc, char** argv);

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -95,7 +95,12 @@
 
 // Download url → dest file. Uses curl/wget on POSIX, PowerShell on Windows.
 // Creates parent directories of dest if they don't exist.
-int ae_download(const char* url, const char* dest) {
+/* max_seconds caps the whole transfer; 0 means no cap, for release archives
+ * whose size makes any fixed ceiling wrong. The connect timeout and the stall
+ * detector below apply either way: without them a network that accepts the
+ * connection and then drops every packet, a captive portal or a firewall that
+ * blackholes, hangs the command indefinitely rather than failing. */
+int ae_download_ex(const char* url, const char* dest, int max_seconds) {
     // Ensure parent directory exists (e.g. ~/.aether/ for releases.json)
     {
         char parent[1024];
@@ -112,11 +117,14 @@ int ae_download(const char* url, const char* dest) {
     snprintf(ps_path, sizeof(ps_path), "%s\\%s", get_temp_dir(), tmp);
     FILE* ps = fopen(ps_path, "w");
     if (!ps) return 1;
+    char ps_timeout[48] = "";
+    if (max_seconds > 0)
+        snprintf(ps_timeout, sizeof(ps_timeout), " -TimeoutSec %d", max_seconds);
     fprintf(ps,
         "$ProgressPreference='SilentlyContinue'\n"
         "Invoke-WebRequest -Uri '%s' -OutFile '%s' "
-        "-Headers @{'User-Agent'='ae-cli'}\n",
-        url, dest);
+        "-Headers @{'User-Agent'='ae-cli'}%s\n",
+        url, dest, ps_timeout);
     fclose(ps);
     char cmd[2048];
     snprintf(cmd, sizeof(cmd),
@@ -125,13 +133,25 @@ int ae_download(const char* url, const char* dest) {
     remove(ps_path);
     return r;
 #else
+    char cap[32] = "";
     char cmd[2048];
-    if (system("curl --version >/dev/null 2>&1") == 0)
-        snprintf(cmd, sizeof(cmd), "curl -fsSL -o \"%s\" \"%s\" 2>/dev/null", dest, url);
-    else
-        snprintf(cmd, sizeof(cmd), "wget -q --no-verbose -O \"%s\" \"%s\" 2>/dev/null", dest, url);
+    if (system("curl --version >/dev/null 2>&1") == 0) {
+        if (max_seconds > 0) snprintf(cap, sizeof(cap), " --max-time %d", max_seconds);
+        snprintf(cmd, sizeof(cmd),
+                 "curl -fsSL --connect-timeout 5 --speed-limit 1024 --speed-time 20%s"
+                 " -o \"%s\" \"%s\" 2>/dev/null", cap, dest, url);
+    } else {
+        if (max_seconds > 0) snprintf(cap, sizeof(cap), " --read-timeout=%d", max_seconds);
+        snprintf(cmd, sizeof(cmd),
+                 "wget -q --no-verbose --timeout=5 --tries=2%s"
+                 " -O \"%s\" \"%s\" 2>/dev/null", cap, dest, url);
+    }
     return system(cmd);
 #endif
+}
+
+int ae_download(const char* url, const char* dest) {
+    return ae_download_ex(url, dest, 0);
 }
 
 // Extract archive → dest_dir.
@@ -897,7 +917,7 @@ static int fetch_latest_release_tag(char* out, size_t outlen) {
     char url[256];
     snprintf(url, sizeof(url),
         "https://api.github.com/repos/" AE_GITHUB_REPO "/releases?per_page=5");
-    if (ae_download(url, json_path) != 0) return -1;
+    if (ae_download_ex(url, json_path, 15) != 0) return -1;
     FILE* f = fopen(json_path, "r");
     if (!f) { remove(json_path); return -1; }
     char buf[65536];
@@ -947,7 +967,7 @@ static int version_is_older(const char* a, const char* b) {
  * Asked at most once a day and cached, because `ae version` should not need
  * the network to answer. Every failure is silent: offline, rate-limited, or a
  * cache that cannot be written all leave the output exactly as it was. */
-static void report_newer_release(void) {
+void ae_report_newer_release(FILE* out) {
     const char* home = getenv("HOME");
     if (!home || !home[0]) return;
 
@@ -956,33 +976,36 @@ static void report_newer_release(void) {
     snprintf(cache, sizeof(cache), "%s/latest_release", cache_dir);
 
     char latest[64] = {0};
-    int have = 0;
     struct stat st;
-    if (stat(cache, &st) == 0 && (time(NULL) - st.st_mtime) < 24 * 60 * 60) {
+    int fresh = stat(cache, &st) == 0 && (time(NULL) - st.st_mtime) < 24 * 60 * 60;
+
+    if (fresh) {
         FILE* f = fopen(cache, "r");
         if (f) {
             if (fgets(latest, sizeof(latest), f)) {
                 char* nl = strchr(latest, '\n');
                 if (nl) *nl = '\0';
-                have = latest[0] != '\0';
             }
             fclose(f);
         }
-    }
-
-    if (!have) {
-        if (fetch_latest_release_tag(latest, sizeof(latest)) != 0) return;
+    } else {
+        /* A failed attempt is cached as an empty file, so the 24h gate covers
+         * attempts and not just successes. Without that, a network that never
+         * answers would be re-dialled on every single compile failure, and the
+         * connect timeout would be charged to each one. */
+        int ok = fetch_latest_release_tag(latest, sizeof(latest)) == 0;
         FILE* f = fopen(cache, "w");
-        if (f) { fprintf(f, "%s\n", latest); fclose(f); }
+        if (f) { if (ok) fprintf(f, "%s\n", latest); fclose(f); }
+        if (!ok) return;
     }
 
     const char* lv = (latest[0] == 'v') ? latest + 1 : latest;
     if (!lv[0] || !version_is_older(AE_VERSION, lv)) return;
 
-    printf("\nA newer release is available: %s (this is %s).\n", lv, AE_VERSION);
-    printf("         `ae upgrade` installs it and switches to it.\n");
-    printf("         Until then `ae run` uses the older stdlib, so anything\n");
-    printf("         added since %s resolves as undefined.\n", AE_VERSION);
+    fprintf(out, "\nA newer release is available: %s (this is %s).\n", lv, AE_VERSION);
+    fprintf(out, "  `ae upgrade` installs it. Until then `ae run` resolves the\n");
+    fprintf(out, "  stdlib from %s, so anything added since is undefined here.\n",
+            AE_VERSION);
 }
 
 // "ae install [<version>]" — install a release into ~/.aether/versions/.
@@ -2149,7 +2172,7 @@ int cmd_version(int argc, char** argv) {
             printf("         binary keeps reporting and behaving as %s.\n", AE_VERSION);
         }
 
-        report_newer_release();
+        ae_report_newer_release(stdout);
 
         printf("\nSubcommands:\n");
         printf("  ae version list              List all available releases\n");

--- a/tools/ae_version.c
+++ b/tools/ae_version.c
@@ -14,6 +14,7 @@
  * install tree, unistd for getpid on the compile probe */
 #include <stdarg.h>
 #include <sys/stat.h>
+#include <time.h>     // report_newer_release: 24h cache gate
 #include <dirent.h>
 #ifndef _WIN32
 #include <unistd.h>
@@ -914,6 +915,74 @@ static int fetch_latest_release_tag(char* out, size_t outlen) {
     memcpy(out, q, len);
     out[len] = '\0';
     return 0;
+}
+
+/* Is `a` an older release than `b`? Both are dotted numbers, no leading v.
+ * Compared field by field as integers: a string compare puts 0.552 above
+ * 0.627 at the second field and would have reported an install 75 releases
+ * behind as up to date. */
+static int version_is_older(const char* a, const char* b) {
+    while (a && b && *a && *b) {
+        long x = strtol(a, NULL, 10);
+        long y = strtol(b, NULL, 10);
+        if (x != y) return x < y;
+        const char* na = strchr(a, '.');
+        const char* nb = strchr(b, '.');
+        if (!na || !nb) return (!na && nb) ? 1 : 0;
+        a = na + 1;
+        b = nb + 1;
+    }
+    return 0;
+}
+
+/* Tell the reader when a newer release exists (#stale-install).
+ *
+ * `ae upgrade` has always worked; nothing ever said to run it. An install
+ * sitting 75 releases behind reported itself healthy, because every check here
+ * compares this binary against its own siblings, never against what has been
+ * released. The cost of that is not abstract: an old stdlib silently answers
+ * `ae run`, so a function added since resolves as "undefined" and the report
+ * lands on whoever added it.
+ *
+ * Asked at most once a day and cached, because `ae version` should not need
+ * the network to answer. Every failure is silent: offline, rate-limited, or a
+ * cache that cannot be written all leave the output exactly as it was. */
+static void report_newer_release(void) {
+    const char* home = getenv("HOME");
+    if (!home || !home[0]) return;
+
+    char cache_dir[1024], cache[1200];
+    snprintf(cache_dir, sizeof(cache_dir), "%s/.aether/cache", home);
+    snprintf(cache, sizeof(cache), "%s/latest_release", cache_dir);
+
+    char latest[64] = {0};
+    int have = 0;
+    struct stat st;
+    if (stat(cache, &st) == 0 && (time(NULL) - st.st_mtime) < 24 * 60 * 60) {
+        FILE* f = fopen(cache, "r");
+        if (f) {
+            if (fgets(latest, sizeof(latest), f)) {
+                char* nl = strchr(latest, '\n');
+                if (nl) *nl = '\0';
+                have = latest[0] != '\0';
+            }
+            fclose(f);
+        }
+    }
+
+    if (!have) {
+        if (fetch_latest_release_tag(latest, sizeof(latest)) != 0) return;
+        FILE* f = fopen(cache, "w");
+        if (f) { fprintf(f, "%s\n", latest); fclose(f); }
+    }
+
+    const char* lv = (latest[0] == 'v') ? latest + 1 : latest;
+    if (!lv[0] || !version_is_older(AE_VERSION, lv)) return;
+
+    printf("\nA newer release is available: %s (this is %s).\n", lv, AE_VERSION);
+    printf("         `ae upgrade` installs it and switches to it.\n");
+    printf("         Until then `ae run` uses the older stdlib, so anything\n");
+    printf("         added since %s resolves as undefined.\n", AE_VERSION);
 }
 
 // "ae install [<version>]" — install a release into ~/.aether/versions/.
@@ -2079,6 +2148,8 @@ int cmd_version(int argc, char** argv) {
             printf("         `ae version use %s` switches the pinned install; this\n", pinned);
             printf("         binary keeps reporting and behaving as %s.\n", AE_VERSION);
         }
+
+        report_newer_release();
 
         printf("\nSubcommands:\n");
         printf("  ae version list              List all available releases\n");


### PR DESCRIPTION
The install that started this was 75 releases behind, and every check said it was healthy. Fixing that signal turned up a run of related defects, each one a case where a tool reported success while doing nothing, or failed with no way to see why.

## The signal that was missing

`ae version`, and a failed build, now name a newer release and point at `ae upgrade`.

Every check in `ae version` compared the binary against its own siblings, the `aetherc` it resolves and the `active_version` pin, and none against what had been released. `ae run` resolves the stdlib from the install rather than a checkout, so on a toolchain that has aged the stdlib answers too, and a function added since resolves as "undefined". It cost exactly that here: `math.lrint`, added in 0.626.0, looked broken against a 0.552.0 install and was nearly filed as a defect against the PR that added it.

- Asked at most once a day and cached under `~/.aether/cache`, because `ae version` must answer offline.
- Silent on every failure, including a failed attempt: without caching the failure, a network that never answers would be re-dialled on every compile error.
- Versions compare as integers, field by field. A string compare puts `0.100` above `0.627` at the second field, which would report an install far behind as current, the exact failure this exists to catch.
- Nothing updates itself. It reports; the user decides.

## Defects found on the way

**Every `ae build --namespace` library on macOS killed the process that loaded it.** `ae` rewrites the install_name after linking, and that modification invalidates the ad-hoc signature ld64 attaches to everything it links on Apple silicon. dyld's answer to an invalid signature is not an error the caller can read: the kernel SIGKILLs the loading process with no message. So a Python, Ruby or C host died on `dlopen`, the library looked healthy on disk, and nothing said why. Proven, not inferred: `codesign -v` reported "code or signature have been modified", a two-line C program dlopening it exited 137, and re-signing a copy made the same dlopen succeed; plain C dylibs, including one that spawns a thread in its constructor, loaded fine on the same machine.

**`ae build --target=wasm32-wasi --emit=lib` could not link.** A wasi library is a reactor, not a command: in command mode zig links wasi-libc's startup object, which demands a `main` the library has not got, and `--no-entry` does not stop it being pulled in.

**`ae build --coverage` could return an uninstrumented binary from the build cache.** The key covered `--trace` but not `--coverage`, `--profile` or `--size`. A coverage build after a plain build of the same source was served the cached binary: it ran, wrote no `.gcda`, and reported zero coverage for code that was in fact tested. Coverage builds are now uncacheable outright, because an instrumented binary has the absolute path of its `.gcno` baked in and a cached copy reused elsewhere deposits its results where it was first compiled.

**An untaken `else` could report as covered.** `if` statements and their `else` blocks carried no source position at all, so codegen emitted no `#line` before the generated `} else {`. That C line inherited the count drifting on from the then-branch and landed on the first line of the else BODY, where gcov charged it the branch counter. Both now carry the position of the keyword that introduces them.

**`ae checksec --require <typo>` exited 0.** An unrecognised property read back as "n/a", and n/a satisfies the gate by design, so `--require canery` reported success and a CI hardening gate that still looked like a gate protected nothing.

**Downloads had no timeout of any kind.** A network that accepts the connection then drops every packet hung `ae upgrade`, `ae install`, `ae add` and `ae version list` indefinitely. Now a 5 second connect timeout and a stall detector everywhere, a 15 second cap on metadata fetches, and no total cap on release archives because their size makes one wrong. Measured against an unroutable address: unbounded before, 5 seconds after.

**Every failed compile printed its diagnostics twice, plus three lines of internal `[diag]` output.** Four call sites re-ran the whole compile on failure "so the user can see the error". Removing the retry alone would have lost stdout, which is where emcc reports, so the compile steps now capture stdout and print it only on failure: one compile, nothing doubled, nothing lost.

**`install_name_tool` ran on static archives and non-Darwin cross output**, failing and warning about dlopen for artifacts nothing can dlopen. And a piped `ae build` printed its diagnostics above the line naming the file being built.

## Tests that were asserting the wrong thing

| Test | What it actually asserted | Now |
| --- | --- | --- |
| `cross_emit_lib` | GNU archive members read with BSD `ar`, which prints raw offsets instead of names; and executing an x86_64-linux binary wherever the suite runs | `zig ar` for the listing, triple matched to the host so the run assertion is real everywhere |
| `ci_coverage_smoke` | Compiled and linked in one step, which makes clang name the notes file after the binary, then asserted a compiler-chosen `.gcda` filename | Two steps, and asserts the outcome: gcov yields a `.ae.gcov` with the untaken branch flagged |
| `checksec_hardening` | That a release PE is unstripped, which it is not | Negative property taken from the report, plus a new assertion that a misspelled property is rejected |
| `windows_crt_symbols` | Cross-compiled the stdlib with a flag set drifted from the driver's, so `std/regex` hit the `#error` that exists to stop a silently no-op regex engine shipping | Passes the defines the driver and Makefile always pass; 94 objects cross-compile clean |
| `http_server_chunked_request` | Raced `nc`, which dies of EPIPE when the server answers 413 and closes, sometimes before draining the response. Passed idle, failed on a loaded runner | Writes until the socket refuses, stops writing, then reads |

## Verification

Every fix has a test, and each was mutation-checked by reintroducing the defect:

| Mutation | Result |
| --- | --- |
| `version_is_older` to `strcmp` | FAIL: `0.1000.0` not seen as newer |
| Hint dropped from the `ae build` failure path | FAIL: no hint on stderr |
| Hint dropped from the `ae run` failure path | FAIL: no hint on stderr |
| Duplicate compile retry restored | FAIL: diagnostics repeated |
| Compile stdout discarded again | FAIL: the wasm build never reached emcc |
| Unknown-property rejection reverted | FAIL: typo silently disables the gate |
| macOS re-sign removed | FAIL: namespace_python dies on load |
| `HTTP_MAX_CHUNKED_BODY` raised to 1GB | FAIL: endless body not refused |

Suites: 409/409 unit, 90/90 examples, `-Werror` build clean, and `zig cc -target x86_64-windows-gnu` compiles the changed tools plain and under `-std=c11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)