### PR TITLE
fix(cache): hash the working directory, not only the entry file's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A test suite in `tests/` reported green against code it never compiled**
+  (#1882). Module resolution is CWD-relative, so a project-root module resolves
+  for an entry file anywhere — but the cache key hashed only the directory the
+  *entry* sits in. That is the project root when you run `ae run main.ae`, and
+  is not when you run `ae run tests/suite.ae`, where it hashed `tests/` and
+  never saw the module that actually got compiled. Editing the module under
+  test left the key unchanged, so the suite re-ran the previous binary and
+  reported its results.
+
+  `tests/<suite>.ae` importing a module from the project root is the ordinary
+  layout for an Aether project's own test suite, so this sat on the default
+  path rather than an exotic one. The working directory is now hashed too, and
+  skipped when it is already the entry's own directory so the common case does
+  not hash the same tree twice. Same failure shape as #1421, one resolution
+  root over.
+
 ## [0.629.0]
 
 ### Fixed

--- a/tests/integration/cache_subdir_entry_root_module/test_cache_subdir_entry_root_module.sh
+++ b/tests/integration/cache_subdir_entry_root_module/test_cache_subdir_entry_root_module.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Regression (#1882): editing a PROJECT-ROOT module must invalidate the cache
+# when the entry file sits in a SUBDIRECTORY.
+#
+# Module resolution is CWD-relative (aether_module.c "Try 3-6": src/<m>/module.ae,
+# <m>/module.ae, <m>.ae, all probed from the process's cwd), so a project-root
+# module resolves for an entry file anywhere. But the cache key hashed only the
+# directory the ENTRY sits in (#1421) — the project root when you run
+# `ae run main.ae`, and NOT when you run `ae run tests/suite.ae`, where it
+# hashed tests/ and never saw the module that actually got compiled.
+#
+# `tests/<suite>.ae` importing a module from the project root is the ordinary
+# layout for an Aether project's own test suite, so this sat on the default
+# path: editing the module under test left the key unchanged and the suite
+# re-ran the PREVIOUS binary. The failure mode is the bad one — a test suite
+# reporting GREEN against code it never compiled.
+#
+# Asserts both directions, since a cache that never hits would also "pass" a
+# staleness check while making every run slow.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+
+if [ ! -x "$AE" ]; then
+    echo "  [SKIP] cache_subdir_entry_root_module: ae not built"
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/proj/greeter" "$TMP/proj/tests"
+cd "$TMP/proj" || exit 1
+
+write_greeter() {
+    cat > greeter/module.ae <<AEOF
+exports(greet)
+greet() -> string {
+    return "$1"
+}
+AEOF
+}
+
+cat > tests/test_it.ae <<'AEOF'
+import greeter
+
+main() {
+    println(greeter.greet())
+}
+AEOF
+
+run_sub() { "$AE" run tests/test_it.ae 2>&1 | tail -1; }
+
+# --- 1. the entry-in-a-subdirectory case, which is the bug ---------------
+write_greeter "V1"
+got=$(run_sub)
+[ "$got" = "V1" ] || { echo "  [FAIL] cache_subdir_entry_root_module: first run printed '$got', want V1"; exit 1; }
+
+write_greeter "V2"
+got=$(run_sub)
+[ "$got" = "V2" ] || {
+    echo "  [FAIL] cache_subdir_entry_root_module: after editing greeter/module.ae the"
+    echo "         subdirectory entry printed '$got', want V2 — a stale cached binary"
+    exit 1
+}
+
+# A second edit, so this cannot pass by invalidating exactly once.
+write_greeter "V3"
+got=$(run_sub)
+[ "$got" = "V3" ] || { echo "  [FAIL] cache_subdir_entry_root_module: second edit printed '$got', want V3"; exit 1; }
+
+# --- 2. the root-entry case must keep working (it always did) ------------
+cp tests/test_it.ae ./root_entry.ae
+write_greeter "R1"
+got=$("$AE" run root_entry.ae 2>&1 | tail -1)
+[ "$got" = "R1" ] || { echo "  [FAIL] cache_subdir_entry_root_module: root entry printed '$got', want R1"; exit 1; }
+write_greeter "R2"
+got=$("$AE" run root_entry.ae 2>&1 | tail -1)
+[ "$got" = "R2" ] || { echo "  [FAIL] cache_subdir_entry_root_module: root entry after edit printed '$got', want R2"; exit 1; }
+
+# --- 3. and the cache must still HIT when nothing changed ----------------
+# Over-invalidating would pass every check above while making each run a full
+# rebuild, so measure that an unchanged re-run is materially faster.
+write_greeter "S1"
+"$AE" run tests/test_it.ae >/dev/null 2>&1          # populate
+t0=$(date +%s%N 2>/dev/null || echo 0)
+"$AE" run tests/test_it.ae >/dev/null 2>&1
+t1=$(date +%s%N 2>/dev/null || echo 0)
+if [ "$t0" != "0" ] && [ "$t1" != "0" ]; then
+    ms=$(( (t1 - t0) / 1000000 ))
+    # A real rebuild of even this trivial program is >100ms; a cache hit is
+    # a handful. 80ms leaves generous headroom on a loaded CI runner.
+    [ "$ms" -lt 80 ] || {
+        echo "  [FAIL] cache_subdir_entry_root_module: an unchanged re-run took ${ms}ms;"
+        echo "         the cache appears never to hit, so every run is a rebuild"
+        exit 1
+    }
+fi
+
+echo "  [PASS] cache_subdir_entry_root_module: a root module edit invalidates a subdir entry's cache, and the cache still hits"

--- a/tools/ae_cache.c
+++ b/tools/ae_cache.c
@@ -350,6 +350,52 @@ unsigned long long compute_cache_key(const char* ae_file,
             pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
                             ":src=%016llx", src_tree);
         }
+
+        /* #1882: the WORKING DIRECTORY tree, when it is not the entry's own.
+         *
+         * Module resolution is CWD-relative (aether_module.c "Try 3-6":
+         * `src/<m>/module.ae`, `<m>/module.ae`, `<m>.ae`, all probed from the
+         * process's cwd), so a project-root module resolves for an entry file
+         * anywhere. The block above hashes only the directory the ENTRY sits
+         * in, which is the project root when you run `ae run main.ae` and is
+         * NOT when you run `ae run tests/suite.ae` — there it hashes `tests/`
+         * and never sees the module that actually got compiled.
+         *
+         * `tests/<suite>.ae` importing a module from the project root is the
+         * ordinary layout for an Aether project's own test suite, so this sat
+         * on the default path: editing the module under test left the key
+         * unchanged and the suite re-ran the PREVIOUS binary, reporting green
+         * against code it never compiled. Same failure shape as #1421, one
+         * resolution root over.
+         *
+         * Skipped when cwd IS the entry dir, so the ordinary root-entry case
+         * does not hash the same tree twice. */
+        {
+            char cwd[1024];
+            if (getcwd(cwd, sizeof(cwd))) {
+                char entry_abs[1024];
+                int same = 0;
+                if (entry_dir[0] == '/' ) {
+                    same = (strcmp(entry_dir, cwd) == 0);
+                } else if (strcmp(entry_dir, ".") == 0) {
+                    same = 1;
+                } else {
+                    /* A relative entry_dir names a path UNDER cwd, so it can
+                     * only be the same directory when it resolves to it. */
+                    snprintf(entry_abs, sizeof(entry_abs), "%s/%s", cwd, entry_dir);
+                    same = (strcmp(entry_abs, cwd) == 0);
+                }
+                if (!same) {
+                    unsigned long long cwd_tree = 0;
+                    int cwd_count = 0;
+                    hash_lib_dir_entries(cwd, "", &cwd_tree, &cwd_count, 0);
+                    if (cwd_count > 0) {
+                        pos += snprintf(key_buf + pos, sizeof(key_buf) - pos,
+                                        ":cwd=%016llx", cwd_tree);
+                    }
+                }
+            }
+        }
     }
 
     /* Issue #413: include the --lib search path in the cache key.


### PR DESCRIPTION
Fixes #1882.

## The bug

Module resolution is **CWD-relative** — `aether_module.c` "Try 3–6" probe `src/<m>/module.ae`, `<m>/module.ae` and `<m>.ae` from the process's cwd — so a project-root module resolves for an entry file anywhere.

The cache key, though, hashed only the directory the **entry** sits in (#1421). That *is* the project root when you run `ae run main.ae`, and is **not** when you run `ae run tests/suite.ae` — there it hashed `tests/` and never saw the module that actually got compiled.

So editing the module under test left the key unchanged, and the suite re-ran the previous binary.

| entry | hashed | root-module edit seen? |
|---|---|---|
| `main.ae` | project root | yes |
| `tests/suite.ae` | `tests/` | **no** |

## Why it matters more than it looks

`tests/<suite>.ae` importing a module from the project root is the **ordinary layout** for an Aether project's own test suite, so this sat on the default path.

And as the reporter puts it: a stale binary that *crashes* gets investigated; a stale binary that *passes its tests* does not. They hit it mid-port and briefly believed a broken SDK was passing its own suite. It also cost them a bisect — adding a `println` to the *entry* file changes its hash and forces a rebuild, so a debug print appears to "cause" the failure it merely reveals.

## Fix

Hash the working directory too, skipped when it is already the entry's own directory so the common root-entry case doesn't hash the same tree twice.

Same failure shape as #1421, one resolution root over: the key covered the entry file, the entry's directory and the `--lib` dirs — and cwd was a fourth resolution root that nothing covered.

## Testing

The regression test asserts **both directions**, following `build_cache_import_edit`'s own reasoning that a cache which never hits would also "pass" a staleness check:

- an edit invalidates — **twice**, so it cannot pass by invalidating exactly once
- the root-entry case still works
- an unchanged re-run still **hits** the cache (measured 147ms → **11ms**); over-invalidating would satisfy every staleness check while silently turning each run into a full rebuild

Verified the test **FAILS on the unfixed compiler** (prints the stale `V1`) and passes with the fix. All six `cache_*` integration suites pass, `make test` 409/409, fmt gate and check-docs green.

Also verified the issue's real-world shape end to end: a suite in `tests/` importing an SDK module at the root, breaking the module under test, and confirming the suite now reports the failure instead of green.

## Note

The reporter's guess in the issue — *"the dependency paths recorded in the cache key are probably relative to the entry file's directory rather than to the resolution root"* — was essentially right. It isn't that dependency paths are recorded relative to the wrong root; it's that the resolution root itself (cwd) was never hashed at all.

Their workaround (`rm -rf ~/.aether/cache` before any test task) can be dropped once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
