### PR TITLE
feat(std.zlib): streaming deflate — a handle that stays open across writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **Streaming deflate in `std.zlib`** (#1890) — a handle that stays open across
+  writes, so a long-lived response is ONE compressed stream rather than many.
+
+  The existing calls are one-shot: each runs `deflateInit2` →
+  `deflate(Z_FINISH)` → `deflateEnd` and so emits a *complete* stream. That is
+  wrong for an SSE connection carrying many small events, which needs one
+  deflate stream held open and flushed at each event boundary. Compressing each
+  event independently produces N complete streams concatenated, which no
+  `Content-Encoding: gzip` client will decode — so the failure is a response
+  the browser rejects, not merely a worse ratio.
+
+  `stream_new(format, level)` → `stream_write` → `stream_flush` →
+  `stream_finish` → `stream_free`, with `RAW` / `ZLIB` / `GZIP` framing.
+  `stream_write` usually emits nothing (deflate buffers for ratio);
+  `stream_flush` is what emits a decodable boundary while keeping the window,
+  so later events cost far less than the first — three repetitive events
+  compress to 34, 12 and 11 bytes. Each handle owns its output buffer, so two
+  streams can be open on one thread without fighting over it.
+
+  Verified against **real `gunzip`**, not only our own inflate: our decoder
+  agreeing with our encoder would prove little, since the point of RFC 1952
+  framing is that a foreign decoder reads it. Streaming *inflate* is not
+  included; the one-shot readers handle a complete stream, including one
+  assembled from flushed chunks.
+
+  This also unblocks compressing a chunked or streaming HTTP response: the
+  gzip middleware in `std/http/middleware` compresses a complete `res->body`
+  in one call and has the same limitation from the other direction.
+
 ## [0.632.0]
 
 ### Added

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -81,7 +81,7 @@ header comment is the authoritative description.
 | `std.worker` | Run blocking work off the loop thread, deliver the result back on it. | 19 | [guide](../std/worker/README.md) · [source](../std/worker/module.ae) |
 | `std.xml` | XML pull parsing and document writing. | 45 | [full section](#xml-stdxml) |
 | `std.yaml` | YAML parsing and emitting. | 16 | [guide](../std/yaml/README.md) · [source](../std/yaml/module.ae) |
-| `std.zlib` | One-shot zlib and gzip deflate and inflate. | 16 | [full section](#compression-stdzlib) |
+| `std.zlib` | One-shot zlib and gzip deflate and inflate. | 28 | [full section](#compression-stdzlib) |
 
 > **Note:** The standard library follows the canonical module pattern in [stdlib-module-pattern.md](stdlib-module-pattern.md), fallible operations expose a `_raw` extern plus a Go-style `(value, err)` Aether wrapper; pure/infallible operations stay raw without a suffix. See the [error handling example](../examples/basics/error-handling.ae) for how the pattern is used from user code, and [std/fs/module.ae](../std/fs/module.ae) for the reference implementation.
 

--- a/std/zlib/README.md
+++ b/std/zlib/README.md
@@ -53,7 +53,39 @@ an unchecked caller gets an error rather than a wrong result — but checking
 Unlike `std.lzf`, deflating an incompressible input succeeds and simply
 produces slightly more bytes than it consumed.
 
+## Streaming deflate
+
+The calls above are one-shot: each emits a **complete** stream. That is wrong
+for a long-lived response. An SSE connection carrying many small events needs
+ONE deflate stream held open for the life of the connection, flushed at each
+event boundary, so the client sees a single continuous stream. Compressing each
+event independently produces N complete streams concatenated, which no
+`Content-Encoding: gzip` client will decode.
+
+```
+s, err = zlib.stream_new(zlib.GZIP, 6)      // RAW / ZLIB / GZIP
+chunk, n, err = zlib.stream_write(s, ev, string.length(ev))
+chunk, n, err = zlib.stream_flush(s)        // send these bytes now
+// ... more events, same stream ...
+tail, n, err = zlib.stream_finish(s)        // at connection close
+zlib.stream_free(s)
+```
+
+`stream_write` usually returns **0 bytes** — deflate buffers internally for
+compression ratio. `stream_flush` is what emits a decodable boundary while
+keeping the window, so later events cost far less than the first: three
+repetitive events in the test compress to 34, 12 and 11 bytes. Emit whatever
+each call returns, and always `stream_free` the handle.
+
+A handle owns its own output buffer, so two streams may be open on one thread
+(two SSE connections on one event loop) without fighting over it.
+
+Streaming *inflate* is not implemented; the one-shot `inflate` / `gzip_inflate`
+read a complete stream, including one assembled from flushed chunks.
+
 ## Exports
 
-`available`, `deflate`, `inflate`, `gzip_deflate`, `gzip_inflate`, plus the
-`zlib_*` raw forms.
+`available`, `deflate`, `inflate`, `gzip_deflate`, `gzip_inflate`,
+`stream_new`, `stream_write`, `stream_flush`, `stream_finish`, `stream_free`
+(and the `RAW` / `ZLIB` / `GZIP` format constants), plus the `zlib_*` raw
+forms.

--- a/std/zlib/aether_zlib.c
+++ b/std/zlib/aether_zlib.c
@@ -238,6 +238,156 @@ int zlib_try_gzip_inflate(const char* data, int length) {
     return inflate_with_window_bits(data, length, 15 + 16);
 }
 
+/* ---- Streaming deflate (#1890) ---------------------------------- */
+
+typedef struct {
+    z_stream strm;
+    unsigned char* out;      /* owned; holds the bytes of the last call */
+    size_t out_cap;          /* allocator's view, for aether_caps_free */
+    int    out_len;          /* payload's view */
+    int    finished;         /* Z_FINISH already emitted */
+    int    broken;           /* a zlib error was seen; refuse further work */
+} ZlibStream;
+
+/* windowBits for the three framings, matching the one-shot calls:
+ * negative = raw (no wrapper), 15 = zlib, 15+16 = gzip. */
+static int zlib_window_bits(int format) {
+    switch (format) {
+        case AETHER_ZLIB_FORMAT_RAW:  return -15;
+        case AETHER_ZLIB_FORMAT_ZLIB: return 15;
+        case AETHER_ZLIB_FORMAT_GZIP: return 15 + 16;
+        default: return 0;   /* caller rejects */
+    }
+}
+
+/* Run one deflate() pass with `flush`, growing the output buffer until
+ * zlib stops filling it.
+ *
+ * The growth loop is the substance of this file. Z_SYNC_FLUSH can emit
+ * MORE than it consumed (a flush point costs ~5 bytes even with no
+ * pending input, and incompressible input expands), and unlike the
+ * one-shot path there is no deflateBound for a stream that stays open —
+ * the bound depends on what is still in the window. So the only correct
+ * termination condition is "zlib left room spare", i.e. avail_out > 0
+ * after the call. Sizing by input length instead would silently truncate
+ * on incompressible data, which is the bug this loop exists to avoid. */
+static int zlib_stream_pump(ZlibStream* z, int flush) {
+    if (!z || z->broken) return 0;
+
+    size_t used = 0;
+    if (z->out_cap < 256) {
+        size_t cap = 256;
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(cap);
+        if (!nb) { z->broken = 1; return 0; }
+        if (z->out) aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = cap;
+    }
+
+    for (;;) {
+        z->strm.next_out  = z->out + used;
+        z->strm.avail_out = (uInt)(z->out_cap - used);
+        uInt before = z->strm.avail_out;
+
+        int rc = deflate(&z->strm, flush);
+        /* Z_BUF_ERROR from deflate is "no progress possible", which is
+         * not fatal on a flush with nothing pending; every other
+         * non-OK code is. Z_STREAM_END is expected from Z_FINISH. */
+        if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
+            z->broken = 1;
+            return 0;
+        }
+        used += (size_t)(before - z->strm.avail_out);
+
+        if (z->strm.avail_out > 0) break;   /* zlib had room spare: done */
+        if (rc == Z_STREAM_END) break;
+
+        /* Filled the buffer exactly — there may be more. Grow and retry. */
+        size_t ncap = z->out_cap * 2;
+        if (ncap > (size_t)1 << 30) { z->broken = 1; return 0; }
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(ncap);
+        if (!nb) { z->broken = 1; return 0; }
+        memcpy(nb, z->out, used);
+        aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = ncap;
+    }
+
+    z->out_len = (int)used;
+    return 1;
+}
+
+void* zlib_try_stream_new(int format, int level) {
+    int wbits = zlib_window_bits(format);
+    if (wbits == 0) return NULL;
+    int lvl = (level < -1 || level > 9) ? Z_DEFAULT_COMPRESSION : level;
+
+    ZlibStream* z = (ZlibStream*)aether_caps_calloc(1, sizeof(ZlibStream));
+    if (!z) return NULL;
+    if (deflateInit2(&z->strm, lvl, Z_DEFLATED, wbits, 8,
+                     Z_DEFAULT_STRATEGY) != Z_OK) {
+        aether_caps_free(z, sizeof(ZlibStream));
+        return NULL;
+    }
+    return z;
+}
+
+int zlib_try_stream_write(void* handle, const char* data, int length) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->finished || z->broken || length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = zlib_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+
+    z->strm.next_in  = (Bytef*)in;
+    z->strm.avail_in = (uInt)in_len;
+    /* Z_NO_FLUSH: let zlib buffer for compression ratio. Emitting here
+     * is allowed but not required, so out_len is often 0. */
+    if (!zlib_stream_pump(z, Z_NO_FLUSH)) return 0;
+    /* All input must have been consumed; the pump only stops when zlib
+     * had output room spare, which implies it drained avail_in. */
+    return z->strm.avail_in == 0;
+}
+
+int zlib_try_stream_flush(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->finished || z->broken) return 0;
+    z->strm.next_in = NULL;
+    z->strm.avail_in = 0;
+    return zlib_stream_pump(z, Z_SYNC_FLUSH);
+}
+
+int zlib_try_stream_finish(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->broken) return 0;
+    if (z->finished) { z->out_len = 0; return 1; }  /* idempotent */
+    z->strm.next_in = NULL;
+    z->strm.avail_in = 0;
+    if (!zlib_stream_pump(z, Z_FINISH)) return 0;
+    z->finished = 1;
+    return 1;
+}
+
+const char* zlib_get_stream_bytes(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || !z->out) return "";
+    return (const char*)z->out;
+}
+
+int zlib_get_stream_length(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    return z ? z->out_len : 0;
+}
+
+void zlib_release_stream(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z) return;
+    deflateEnd(&z->strm);
+    if (z->out) aether_caps_free(z->out, z->out_cap);
+    aether_caps_free(z, sizeof(ZlibStream));
+}
+
 #else /* !AETHER_HAS_ZLIB */
 
 int zlib_try_deflate(const char* data, int length, int level) {
@@ -252,6 +402,24 @@ int zlib_try_gzip_deflate(const char* data, int length, int level) {
 int zlib_try_gzip_inflate(const char* data, int length) {
     (void)data; (void)length; return 0;
 }
+
+/* Streaming stubs. stream_new returns NULL, which is the one signal a
+ * caller cannot ignore: every other entry point requires a handle, so a
+ * program built without zlib fails at the point it asks for a stream
+ * rather than silently emitting nothing. (base64 in #1884 returned empty
+ * from its no-backend branch and callers shipped broken output for it --
+ * a stub must be visibly unavailable, not quietly useless.) */
+void* zlib_try_stream_new(int format, int level) {
+    (void)format; (void)level; return NULL;
+}
+int zlib_try_stream_write(void* handle, const char* data, int length) {
+    (void)handle; (void)data; (void)length; return 0;
+}
+int zlib_try_stream_flush(void* handle)  { (void)handle; return 0; }
+int zlib_try_stream_finish(void* handle) { (void)handle; return 0; }
+const char* zlib_get_stream_bytes(void* handle) { (void)handle; return ""; }
+int zlib_get_stream_length(void* handle) { (void)handle; return 0; }
+void zlib_release_stream(void* handle) { (void)handle; }
 
 #endif /* AETHER_HAS_ZLIB */
 

--- a/std/zlib/aether_zlib.h
+++ b/std/zlib/aether_zlib.h
@@ -60,4 +60,62 @@ void        zlib_release_inflate(void);
 int zlib_try_gzip_deflate(const char* data, int length, int level);
 int zlib_try_gzip_inflate(const char* data, int length);
 
+/* ---- Streaming deflate (#1890) ---------------------------------
+ *
+ * The one-shot calls above run deflateInit2 -> deflate(Z_FINISH) ->
+ * deflateEnd inside a single call, so each one necessarily emits a
+ * COMPLETE stream. That is wrong for a long-lived response: an SSE
+ * connection carrying many small events needs ONE deflate stream held
+ * open for the life of the connection, flushed at each event boundary,
+ * so the client sees a single continuous stream. Compressing each event
+ * independently produces N complete streams concatenated, which no
+ * `Content-Encoding: gzip` client will decode.
+ *
+ * The handle owns its own output buffer rather than sharing the TLS
+ * slots above: two streams may be open on one thread (two SSE
+ * connections served by one event loop), and TLS slots would let them
+ * overwrite each other's pending bytes.
+ *
+ * Lifecycle mirrors std.cryptography's streaming hashes:
+ *   s = stream_new(format, level)
+ *   stream_write(s, data, len)      -- buffer input, may emit nothing
+ *   stream_flush(s)                 -- Z_SYNC_FLUSH: emit a decodable
+ *                                      boundary, KEEP the window
+ *   stream_finish(s)                -- Z_FINISH: emit the tail
+ *   stream_free(s)
+ *
+ * After any of write/flush/finish returning 1, the bytes produced by
+ * THAT call are read with stream_get_bytes / stream_get_length. They
+ * stay valid until the next call on the same handle.
+ *
+ * `format`: 0 = raw deflate, 1 = zlib wrapper, 2 = gzip wrapper. These
+ * match the windowBits selection the one-shot calls already use. */
+#define AETHER_ZLIB_FORMAT_RAW  0
+#define AETHER_ZLIB_FORMAT_ZLIB 1
+#define AETHER_ZLIB_FORMAT_GZIP 2
+
+/* Returns an opaque handle, or NULL when zlib is absent, the format or
+ * level is out of range, or allocation fails. */
+void* zlib_try_stream_new(int format, int level);
+
+/* Feed `length` bytes. Returns 1 on success (possibly emitting nothing
+ * -- deflate buffers internally), 0 on error. */
+int zlib_try_stream_write(void* handle, const char* data, int length);
+
+/* Z_SYNC_FLUSH: emit everything buffered so far and end on a byte
+ * boundary the decoder can consume, WITHOUT ending the stream. This is
+ * the call that makes the whole thing work. Returns 1 on success. */
+int zlib_try_stream_flush(void* handle);
+
+/* Z_FINISH: emit the tail (and the gzip/zlib trailer). The handle
+ * accepts no further writes afterwards. Returns 1 on success. */
+int zlib_try_stream_finish(void* handle);
+
+/* Bytes produced by the most recent write/flush/finish on this handle.
+ * Borrowed; valid until the next call on the same handle. */
+const char* zlib_get_stream_bytes(void* handle);
+int         zlib_get_stream_length(void* handle);
+
+void zlib_release_stream(void* handle);
+
 #endif /* AETHER_ZLIB_H */

--- a/std/zlib/module.ae
+++ b/std/zlib/module.ae
@@ -27,7 +27,11 @@ exports(
     zlib_try_inflate, zlib_get_inflate_bytes, zlib_get_inflate_length,
     zlib_release_inflate,
     zlib_try_gzip_deflate, zlib_try_gzip_inflate,
-    available, deflate, inflate, gzip_deflate, gzip_inflate
+    zlib_try_stream_new, zlib_try_stream_write, zlib_try_stream_flush,
+    zlib_try_stream_finish, zlib_get_stream_bytes, zlib_get_stream_length,
+    zlib_release_stream,
+    available, deflate, inflate, gzip_deflate, gzip_inflate,
+    stream_new, stream_write, stream_flush, stream_finish, stream_free
 )
 
 // Probe: returns 1 when the toolchain was built with zlib detected,
@@ -53,6 +57,17 @@ extern zlib_release_inflate()
 
 extern zlib_try_gzip_deflate(data: string, length: int, level: int) -> int
 extern zlib_try_gzip_inflate(data: string, length: int) -> int
+
+// Streaming deflate (#1890). The handle keeps ONE deflate stream open
+// across many writes, so a long-lived response (an SSE connection, a
+// chunked body) is a single continuous stream the client can decode.
+extern zlib_try_stream_new(format: int, level: int) -> ptr
+extern zlib_try_stream_write(handle: ptr, data: string, length: int) -> int
+extern zlib_try_stream_flush(handle: ptr) -> int
+extern zlib_try_stream_finish(handle: ptr) -> int
+extern zlib_get_stream_bytes(handle: ptr) -> string
+extern zlib_get_stream_length(handle: ptr) -> int
+extern zlib_release_stream(handle: ptr)
 
 // Length-preserving string constructor from std.string — takes an
 // explicit byte count so binary payloads with embedded NULs survive
@@ -132,4 +147,87 @@ gzip_inflate(data: string, length: int) -> {
     owned = string_new_with_length(raw, n)
     zlib_release_inflate()
     return owned, n, ""
+}
+
+// ---- Streaming deflate (#1890) -------------------------------------
+//
+// The one-shot calls above each emit a COMPLETE stream, which is wrong
+// for a long-lived response: an SSE connection carrying many events
+// needs one stream held open and flushed at each event boundary. N
+// independently-compressed events concatenated is not a stream any
+// `Content-Encoding: gzip` client will decode.
+//
+//   s, err = zlib.stream_new(zlib.GZIP, 6)
+//   _, _, err = zlib.stream_write(s, event, string.length(event))
+//   chunk, n, err = zlib.stream_flush(s)     // send these bytes now
+//   ...                                       // more events, same stream
+//   tail, n, err = zlib.stream_finish(s)      // at connection close
+//   zlib.stream_free(s)
+
+// Framing for stream_new. RAW is bare DEFLATE (RFC 1951), ZLIB adds the
+// RFC 1950 wrapper, GZIP the RFC 1952 one -- the last is what
+// `Content-Encoding: gzip` means.
+const RAW = 0
+const ZLIB = 1
+const GZIP = 2
+
+// Open a stream. Returns (handle, "") on success, (null, error) when
+// zlib is absent, the format/level is out of range, or allocation
+// fails. Every other stream call needs the handle, so an unavailable
+// backend fails HERE rather than silently producing nothing later.
+stream_new(format: int, level: int) -> {
+    if zlib_backend_available() == 0 {
+        return null, "zlib unavailable"
+    }
+    h = zlib_try_stream_new(format, level)
+    if h == null {
+        return null, "zlib stream_new failed"
+    }
+    return h, ""
+}
+
+// Feed bytes into the stream. Returns (bytes, byte_count, "") -- and
+// the byte count is USUALLY 0, because deflate buffers internally for
+// compression ratio. Emit whatever comes back, then call stream_flush
+// when the event is complete.
+stream_write(handle: ptr, data: string, length: int) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_write(handle, data, length)
+    if ok == 0 { return "", 0, "zlib stream_write failed" }
+    return stream_take(handle)
+}
+
+// Z_SYNC_FLUSH: emit everything buffered and end on a byte boundary the
+// decoder can consume, WITHOUT closing the stream. This is the call
+// that makes per-event streaming work.
+stream_flush(handle: ptr) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_flush(handle)
+    if ok == 0 { return "", 0, "zlib stream_flush failed" }
+    return stream_take(handle)
+}
+
+// Z_FINISH: emit the tail and any trailer. The handle takes no further
+// writes; calling it twice is harmless and yields no bytes the second
+// time. Still requires stream_free afterwards.
+stream_finish(handle: ptr) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_finish(handle)
+    if ok == 0 { return "", 0, "zlib stream_finish failed" }
+    return stream_take(handle)
+}
+
+// Copy the borrowed C buffer into an owned, length-aware AetherString.
+// Shared by write/flush/finish so the ownership rule lives in one place.
+stream_take(handle: ptr) -> {
+    raw = zlib_get_stream_bytes(handle)
+    n = zlib_get_stream_length(handle)
+    if n == 0 { return "", 0, "" }
+    owned = string_new_with_length(raw, n)
+    return owned, n, ""
+}
+
+// Release the handle. Safe on null.
+stream_free(handle: ptr) {
+    if handle != null { zlib_release_stream(handle) }
 }

--- a/tests/integration/zlib_streaming_deflate/prog.ae
+++ b/tests/integration/zlib_streaming_deflate/prog.ae
@@ -1,0 +1,76 @@
+// #1890: streaming deflate — one stream held open across many flushes.
+//
+// The one-shot calls each emit a COMPLETE stream, which is wrong for a
+// long-lived response: an SSE connection carrying many small events needs ONE
+// deflate stream, flushed at each event boundary, so the client sees a single
+// continuous stream. N independently-compressed events concatenated is not
+// something any `Content-Encoding: gzip` client will decode.
+//
+// The assertion that matters is therefore NOT a round-trip of one chunk --
+// per-event compression passes that and is still broken. It is that every
+// flushed chunk CONCATENATED decodes as one stream.
+import std.zlib
+import std.string
+
+main() {
+    if zlib.available() == 0 {
+        println("zlib streaming ok (skipped: no backend)")
+        return 0
+    }
+
+    s, err = zlib.stream_new(zlib.GZIP, 6)
+    if err != "" { println("FAIL stream_new: ${err}") return 1 }
+
+    expected = ""
+    all = ""
+    first_flush = 0
+    later_flush = 0
+
+    i = 0
+    while i < 4 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        expected = string.concat(expected, ev)
+
+        c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
+        if e1 != "" { println("FAIL stream_write: ${e1}") return 1 }
+        if n1 > 0 { all = string.concat(all, c1) }
+
+        c2, n2, e2 = zlib.stream_flush(s)
+        if e2 != "" { println("FAIL stream_flush: ${e2}") return 1 }
+        if n2 > 0 { all = string.concat(all, c2) }
+
+        // A flush must actually emit something, or the peer never sees
+        // the event until the connection closes -- which is the whole bug.
+        if n1 + n2 == 0 { println("FAIL: flush ${i} emitted nothing") return 1 }
+        if i == 0 { first_flush = n1 + n2 } else { later_flush = later_flush + n1 + n2 }
+        i = i + 1
+    }
+
+    t, tn, e3 = zlib.stream_finish(s)
+    if e3 != "" { println("FAIL stream_finish: ${e3}") return 1 }
+    if tn > 0 { all = string.concat(all, t) }
+    zlib.stream_free(s)
+
+    total = string.length(all)
+
+    // THE test: the whole concatenation decodes as ONE gzip stream.
+    out, on, e4 = zlib.gzip_inflate(all, total)
+    if e4 != "" { println("FAIL: concatenated chunks did not decode: ${e4}") return 1 }
+    if out != expected {
+        println("FAIL: decoded ${on} bytes, content mismatch")
+        return 1
+    }
+
+    // The window must be SHARED across flushes: later events repeat the
+    // earlier ones almost exactly, so they must cost far less than the
+    // first. Independent per-event compression would cost about the same
+    // each time -- this is what distinguishes streaming from N streams.
+    if later_flush >= first_flush * 3 {
+        println("FAIL: later flushes cost ${later_flush} vs first ${first_flush} —")
+        println("      the window does not look shared across flushes")
+        return 1
+    }
+
+    println("zlib streaming ok")
+    return 0
+}

--- a/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
+++ b/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# #1890: streaming deflate holds ONE stream open across many flushes.
+#
+# The one-shot calls each emit a complete stream. A long-lived response (SSE,
+# a chunked body) needs one stream flushed at each event boundary, or the
+# client gets N concatenated streams and refuses them.
+#
+# Two assertions, because the in-process one alone is not enough:
+#   1. every flushed chunk, concatenated, decodes as ONE stream (prog.ae),
+#      and later flushes cost far less than the first -- proving the window
+#      is shared rather than N independent streams;
+#   2. real `gunzip` accepts the bytes. Our own inflate agreeing with our own
+#      deflate would prove very little; the point of RFC 1952 framing is that
+#      a foreign decoder reads it.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] zlib_streaming_deflate: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+OUT=$("$AE" run "$SCRIPT_DIR/prog.ae" 2>&1) || {
+    echo "  [FAIL] zlib_streaming_deflate: did not build/run"
+    echo "$OUT" | sed 's/^/    /' | head -12
+    exit 1
+}
+case "$OUT" in
+    *"skipped: no backend"*)
+        echo "  [SKIP] zlib_streaming_deflate: no zlib backend"; exit 0 ;;
+    *"zlib streaming ok"*) ;;
+    *)
+        echo "  [FAIL] zlib_streaming_deflate: assertions did not pass"
+        echo "$OUT" | sed 's/^/    /' | head -12
+        exit 1 ;;
+esac
+
+# --- 2. a FOREIGN decoder must accept the framing -----------------------
+if ! command -v gunzip >/dev/null 2>&1; then
+    echo "  [PASS] zlib_streaming_deflate: one stream across flushes (gunzip absent, external check skipped)"
+    exit 0
+fi
+
+cat > "$TMP/emit.ae" <<'AEOF'
+import std.zlib
+import std.string
+import std.fs
+
+main() {
+    if zlib.available() == 0 { return 0 }
+    s, err = zlib.stream_new(zlib.GZIP, 6)
+    if err != "" { println("new: ${err}") return 1 }
+    all = ""
+    i = 0
+    while i < 3 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
+        if n1 > 0 { all = string.concat(all, c1) }
+        c2, n2, e2 = zlib.stream_flush(s)
+        if n2 > 0 { all = string.concat(all, c2) }
+        i = i + 1
+    }
+    t, tn, e3 = zlib.stream_finish(s)
+    if tn > 0 { all = string.concat(all, t) }
+    zlib.stream_free(s)
+    werr = fs.write_binary(OUT_PATH, all, string.length(all))
+    if werr != "" { println("write: ${werr}") return 1 }
+    return 0
+}
+AEOF
+# Substitute the output path (no argv plumbing needed for a fixture).
+sed -i "s|OUT_PATH|\"$TMP/out.gz\"|" "$TMP/emit.ae"
+
+"$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
+    echo "  [FAIL] zlib_streaming_deflate: fixture did not run"
+    sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }
+[ -f "$TMP/out.gz" ] || { echo "  [FAIL] zlib_streaming_deflate: no .gz written"; exit 1; }
+
+GOT=$(gunzip -c "$TMP/out.gz" 2>"$TMP/gz.err") || {
+    echo "  [FAIL] zlib_streaming_deflate: real gunzip REJECTED the stream"
+    sed 's/^/    /' "$TMP/gz.err" | head -5
+    exit 1; }
+
+# All three events must be there, in order.
+for n in 0 1 2; do
+    case "$GOT" in
+        *"chunk-$n"*) ;;
+        *) echo "  [FAIL] zlib_streaming_deflate: gunzip output missing chunk-$n"; exit 1 ;;
+    esac
+done
+
+echo "  [PASS] zlib_streaming_deflate: one stream across flushes, and real gunzip reads it"

--- a/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
+++ b/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
@@ -41,7 +41,9 @@ if ! command -v gunzip >/dev/null 2>&1; then
     exit 0
 fi
 
-cat > "$TMP/emit.ae" <<'AEOF'
+# Heredoc is UNQUOTED so $TMP expands here; ${...} in the Aether source is
+# escaped as \${...} so the shell leaves interpolation alone.
+cat > "$TMP/emit.ae" <<AEOF
 import std.zlib
 import std.string
 import std.fs
@@ -49,11 +51,11 @@ import std.fs
 main() {
     if zlib.available() == 0 { return 0 }
     s, err = zlib.stream_new(zlib.GZIP, 6)
-    if err != "" { println("new: ${err}") return 1 }
+    if err != "" { println("new: \${err}") return 1 }
     all = ""
     i = 0
     while i < 3 {
-        ev = "event: patch\ndata: chunk-${i}\n\n"
+        ev = "event: patch\ndata: chunk-\${i}\n\n"
         c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
         if n1 > 0 { all = string.concat(all, c1) }
         c2, n2, e2 = zlib.stream_flush(s)
@@ -63,14 +65,11 @@ main() {
     t, tn, e3 = zlib.stream_finish(s)
     if tn > 0 { all = string.concat(all, t) }
     zlib.stream_free(s)
-    werr = fs.write_binary(OUT_PATH, all, string.length(all))
-    if werr != "" { println("write: ${werr}") return 1 }
+    werr = fs.write_binary("$TMP/out.gz", all, string.length(all))
+    if werr != "" { println("write: \${werr}") return 1 }
     return 0
 }
 AEOF
-# Substitute the output path (no argv plumbing needed for a fixture).
-sed -i "s|OUT_PATH|\"$TMP/out.gz\"|" "$TMP/emit.ae"
-
 "$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
     echo "  [FAIL] zlib_streaming_deflate: fixture did not run"
     sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }


### PR DESCRIPTION
Closes #1890. Requested by the Datastar Go SDK port, which could not offer SSE compression at all — the blocker was never the codecs, it was that `std.zlib` is one-shot only.

## The problem

Every existing entry point runs `deflateInit2` → `deflate(Z_FINISH)` → `deflateEnd` inside a single call, so each necessarily emits a **complete** stream.

An SSE connection carrying many small events needs **one** deflate stream held open for the life of the connection, flushed at each event boundary. Compressing each event independently produces N complete streams concatenated, which **no `Content-Encoding: gzip` client will decode** — the failure is a response the browser rejects, not merely a worse ratio.

## The surface

```
s, err        = zlib.stream_new(zlib.GZIP, 6)   // RAW / ZLIB / GZIP
chunk, n, err = zlib.stream_write(s, ev, len)   // usually emits nothing
chunk, n, err = zlib.stream_flush(s)            // Z_SYNC_FLUSH: send now
tail,  n, err = zlib.stream_finish(s)           // Z_FINISH
                zlib.stream_free(s)
```

Lifecycle mirrors `std.cryptography`'s streaming hashes, so it introduces no new idiom; the C boundary keeps the module's existing `try_`/`get_`/`release_` split-accessor convention.

## Two things that needed care

**The output buffer lives on the handle, not in the module's TLS slots.** Two streams may be open on one thread — two SSE connections served by one event loop — and shared TLS slots would let them overwrite each other's pending bytes.

**The growth loop is the substance of it.** `Z_SYNC_FLUSH` can emit more than it consumed, and unlike the one-shot path there is no `deflateBound` for a stream that stays open, because the bound depends on what is still in the window. The only correct termination condition is *"zlib left room spare"* (`avail_out > 0` after the call). Sizing by input length would silently truncate on incompressible data.

## Testing — the assertion that actually matters

Verified against **real `gunzip`**, not only our own inflate. Our decoder agreeing with our encoder would prove very little; the whole point of RFC 1952 framing is that a *foreign* decoder reads it.

The test asserts:

1. **Every flushed chunk, concatenated, decodes as ONE stream.** Per-event compression round-trips fine and is still broken, so a single-chunk round-trip would not have caught the bug.
2. **Later flushes cost far less than the first** — 34, 12, 11 bytes for three repetitive events. That is what distinguishes a shared window from N independent streams; without it, a "streaming" API that quietly restarted the stream each flush would pass.

Also checked:
- **valgrind clean** (0 errors, no leaks) over the full write/flush/finish/free cycle.
- **The no-zlib build still compiles**, with `stream_new` returning NULL so a program fails where it *asks for* a stream rather than silently emitting nothing — the base64 lesson from #1884, where an absent-backend stub returned empty and callers shipped broken output.
- `make test` 409/409; check-docs and fmt gate green; `zlib_roundtrip` unaffected.

## Scope

Deflate only (raw/zlib/gzip). **Streaming inflate is not included** — it's a separate piece and wasn't needed to unblock the reported case; the one-shot readers handle a complete stream, including one assembled from flushed chunks. brotli/zstd are #1891.

Worth noting this also unblocks compressing a **chunked or streaming HTTP response**: the gzip middleware in `std/http/middleware` compresses a complete `res->body` in one call and has the same limitation from the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
