### PR TITLE
feat(compression): streaming deflate, brotli and zstd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ version number before tagging the release.
 
 ### Added
 
+- **`std.zstd` — Zstandard compression (RFC 8878), streaming and one-shot**
+  (#1891). A different *format* from DEFLATE, not a faster zlib: this wraps
+  libzstd and is unrelated to `std.zlib` beyond the similar library name. Its
+  case is strongest away from the browser — archives, logs, snapshots,
+  internal RPC — since `Content-Encoding: zstd` support is thinner than `br`
+  and `gzip`.
+
+  Same streaming surface as `std.zlib` and `std.brotli`, so a caller choosing
+  an encoding writes one shape whichever it picks. The drain loop is the one
+  thing NOT shared: zstd terminates on `ZSTD_compressStream2` returning 0
+  ("bytes remaining to flush"), a third condition distinct from zlib's spare
+  `avail_out` and brotli's `HasMoreOutput` — reusing either would truncate the
+  frame. Level is 1–22 with 3 the default.
+
+  Verified against an **independent** libzstd streaming decoder, and gated by
+  `AETHER_HAS_ZSTD` like the rest; without it, `available()` returns 0 and
+  `stream_new` reports "zstd unavailable".
+
 - **`std.brotli` — Brotli compression (RFC 7932), streaming and one-shot**
   (#1891). `br` is what current browsers actually prefer: every modern browser
   lists it ahead of `gzip` in `Accept-Encoding`, and it typically beats gzip by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ version number before tagging the release.
 
 ### Added
 
+- **`std.brotli` — Brotli compression (RFC 7932), streaming and one-shot**
+  (#1891). `br` is what current browsers actually prefer: every modern browser
+  lists it ahead of `gzip` in `Accept-Encoding`, and it typically beats gzip by
+  15–25% on text at comparable speed.
+
+  The streaming surface deliberately mirrors `std.zlib`'s, so a server
+  negotiating `br` against `gzip` writes the same shape either way:
+  `stream_new` → `stream_write` → `stream_flush` → `stream_finish` →
+  `stream_free`. As there, `stream_write` usually emits nothing and
+  `stream_flush` is what emits a decodable boundary while keeping the window —
+  three repetitive events compress to 31, 13 and 13 bytes.
+
+  This wraps the system **libbrotlienc** rather than vendoring an
+  implementation. The reference encoder carries a mandatory ~120k-line static
+  dictionary that is part of the *format*, so vendoring means carrying that
+  whichever route is taken, plus transliterating ~17k lines of bit-exact
+  entropy coding; the library ships in every mainstream distro and exposes
+  exactly the streaming encoder this needs. Detected by pkg-config as
+  `AETHER_HAS_BROTLI`, the same shape as zlib/nghttp2/PCRE2; without it,
+  `available()` returns 0 and `stream_new` reports "brotli unavailable" so a
+  server falls back to gzip.
+
+  Verified against an **independent** `libbrotlidec` decoder, not our own
+  encoder: the test asserts that every flushed chunk concatenated decodes as
+  one stream, and that later events cost far less than the first — a shared
+  window rather than N independent streams. Compression only; nothing in-tree
+  needs to decode `br`.
+
+### Added
+
 - **Streaming deflate in `std.zlib`** (#1890) — a handle that stays open across
   writes, so a long-lived response is ONE compressed stream rather than many.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **Streaming deflate in `std.zlib`** (#1890) — a handle that stays open across
+  writes, so a long-lived response is ONE compressed stream rather than many.
+
+  The existing calls are one-shot: each runs `deflateInit2` →
+  `deflate(Z_FINISH)` → `deflateEnd` and so emits a *complete* stream. That is
+  wrong for an SSE connection carrying many small events, which needs one
+  deflate stream held open and flushed at each event boundary. Compressing each
+  event independently produces N complete streams concatenated, which no
+  `Content-Encoding: gzip` client will decode — so the failure is a response
+  the browser rejects, not merely a worse ratio.
+
+  `stream_new(format, level)` → `stream_write` → `stream_flush` →
+  `stream_finish` → `stream_free`, with `RAW` / `ZLIB` / `GZIP` framing.
+  `stream_write` usually emits nothing (deflate buffers for ratio);
+  `stream_flush` is what emits a decodable boundary while keeping the window,
+  so later events cost far less than the first — three repetitive events
+  compress to 34, 12 and 11 bytes. Each handle owns its output buffer, so two
+  streams can be open on one thread without fighting over it.
+
+  Verified against **real `gunzip`**, not only our own inflate: our decoder
+  agreeing with our encoder would prove little, since the point of RFC 1952
+  framing is that a foreign decoder reads it. Streaming *inflate* is not
+  included; the one-shot readers handle a complete stream, including one
+  assembled from flushed chunks.
+
+  This also unblocks compressing a chunked or streaming HTTP response: the
+  gzip middleware in `std/http/middleware` compresses a complete `res->body`
+  in one call and has the same limitation from the other direction.
+
 ## [0.632.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -3195,7 +3195,7 @@ ci-riscv64: clean
 	@$(MAKE) compiler ae stdlib \
 	    CC=riscv64-linux-gnu-gcc \
 	    EXTRA_CFLAGS="-march=rv64gc -mabi=lp64d" \
-	    OPENSSL=0 ZLIB=0 NGHTTP2=0 PCRE2=0
+	    OPENSSL=0 ZLIB=0 NGHTTP2=0 PCRE2=0 BROTLI=0 ZSTD=0
 	@echo ""
 	@echo "[2/3] Verifying cross-built binaries are riscv64 ELF..."
 	@file build/aetherc | grep -q "RISC-V" || { echo "  FAIL: aetherc not riscv64 ELF"; file build/aetherc; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,23 @@ ifneq ($(BROTLI_LDFLAGS),)
   BROTLI_CFLAGS += -DAETHER_HAS_BROTLI
 endif
 
+# zstd detection: enables std.zstd (RFC 8878). A different FORMAT from
+# DEFLATE, not a faster zlib -- its case is strongest away from the browser
+# (archives, logs, snapshots, internal RPC), since Content-Encoding: zstd
+# support is thinner than br/gzip. Same pkg-config probe shape as the others;
+# when absent, zstd.stream_new reports "zstd unavailable". Issue #1891.
+ZSTD ?= auto
+ifeq ($(ZSTD),0)
+  ZSTD_CFLAGS :=
+  ZSTD_LDFLAGS :=
+else
+  ZSTD_CFLAGS := $(shell pkg-config --cflags libzstd 2>/dev/null)
+  ZSTD_LDFLAGS := $(shell pkg-config --libs libzstd 2>/dev/null)
+endif
+ifneq ($(ZSTD_LDFLAGS),)
+  ZSTD_CFLAGS += -DAETHER_HAS_ZSTD
+endif
+
 # PCRE2 detection: enables std.regex (full Perl-compatible regex —
 # captures, $-substitutions, Unicode, look-around, etc.). A system
 # libpcre2-8 found by pkg-config is preferred (distro security updates
@@ -546,6 +563,7 @@ ZLIB_LDFLAGS    := $(call cellar_to_opt,$(ZLIB_LDFLAGS))
 NGHTTP2_LDFLAGS := $(call cellar_to_opt,$(NGHTTP2_LDFLAGS))
 PCRE2_LDFLAGS   := $(call cellar_to_opt,$(PCRE2_LDFLAGS))
 BROTLI_LDFLAGS  := $(call cellar_to_opt,$(BROTLI_LDFLAGS))
+ZSTD_LDFLAGS    := $(call cellar_to_opt,$(ZSTD_LDFLAGS))
 YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 
 # -fPIC on every runtime/stdlib object so the precompiled `build/libaether.a`
@@ -578,7 +596,7 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 #
 # Recipes use `$(AETHER_REQUIRED_CFLAGS) $(CFLAGS)` so tuning one cannot
 # silently delete the other.
-AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS)
+AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) $(ZSTD_CFLAGS)
 
 CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
@@ -626,7 +644,7 @@ ifeq ($(FREEBSD),1)
 # (which would pull the host's -lm / -pthread / globbed host casper libs).
 AETHER_REQUIRED_LDFLAGS = $(FREEBSD_LDFLAGS)
 else
-AETHER_REQUIRED_LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS) $(BROTLI_LDFLAGS)
+AETHER_REQUIRED_LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS) $(BROTLI_LDFLAGS) $(ZSTD_LDFLAGS)
 endif
 
 # Tunable link flags: sanitizers and anything else a caller passes. Empty by
@@ -697,7 +715,7 @@ endif
 COMPILER_SRC = compiler/aetherc.c compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/contract_eval.c compiler/analysis/derive.c compiler/analysis/actor_reply.c compiler/aether_defines.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 COMPILER_LIB_SRC = compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/contract_eval.c compiler/analysis/derive.c compiler/analysis/actor_reply.c compiler/aether_defines.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 RUNTIME_SRC = $(SCHEDULER_SRC) runtime/scheduler/scheduler_optimizations.c runtime/scheduler/aether_io_poller_epoll.c runtime/scheduler/aether_io_poller_kqueue.c runtime/scheduler/aether_io_poller_poll.c runtime/config/aether_optimization_config.c runtime/memory/aether_arena.c runtime/memory/aether_pool.c runtime/memory/aether_memory_stats.c runtime/utils/aether_trace.c runtime/utils/aether_bounds_check.c runtime/utils/aether_test.c runtime/memory/aether_arena_optimized.c runtime/aether_runtime_types.c runtime/aether_locale_num.c runtime/utils/aether_cpu_detect.c runtime/utils/aether_simd_vectorized.c runtime/aether_runtime.c runtime/aether_numa.c runtime/aether_sandbox.c runtime/sandbox/spawn_sandboxed_linux.c runtime/sandbox/spawn_sandboxed_bsd.c runtime/sandbox/spawn_sandboxed_stub.c runtime/sandbox/capsicum_autosandbox.c runtime/sandbox/aether_audit.c runtime/aether_shared_map.c runtime/aether_host.c runtime/aether_resource_caps.c runtime/libaether_caps.c runtime/actors/aether_send_buffer.c runtime/actors/aether_send_message.c runtime/actors/aether_actor_thread.c runtime/actors/aether_panic.c runtime/actors/aether_unwind.c
-STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_http_pool.c std/net/aether_http_park.c std/net/aether_http_evloop.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/yaml/aether_yaml.c std/xml/aether_xml.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/cryptography/aes/aether_aes.c std/zlib/aether_zlib.c std/brotli/aether_brotli.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/bytes/cursor/aether_bytes_cursor.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c std/regex/aether_regex.c std/regex/aether_pcre2_vendored.c std/capsicum/aether_capsicum.c std/casper/aether_casper.c std/snapshot/aether_snapshot.c std/audio/aether_audio.c std/worker/aether_worker.c std/alloc/aether_alloc.c std/tracking/aether_tracking.c std/tar/aether_tar.c
+STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_http_pool.c std/net/aether_http_park.c std/net/aether_http_evloop.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/yaml/aether_yaml.c std/xml/aether_xml.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/cryptography/aes/aether_aes.c std/zlib/aether_zlib.c std/brotli/aether_brotli.c std/zstd/aether_zstd.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/bytes/cursor/aether_bytes_cursor.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c std/regex/aether_regex.c std/regex/aether_pcre2_vendored.c std/capsicum/aether_capsicum.c std/casper/aether_casper.c std/snapshot/aether_snapshot.c std/audio/aether_audio.c std/worker/aether_worker.c std/alloc/aether_alloc.c std/tracking/aether_tracking.c std/tar/aether_tar.c
 # Stdlib sources that reference scheduler internals (scheduler_io_register,
 # g_sync_step_actor, current_core_id). Excluded from the compiler binary
 # because aetherc does not link the runtime scheduler, but included in
@@ -727,6 +745,7 @@ TOOLS_CFLAGS = -O2 -Itools -MMD -MP \
     -DAETHER_CASPER_LIBS='"$(CASPER_LDFLAGS)"' \
     -DAETHER_AUDIO_LIBS='"$(AUDIO_LDFLAGS)"' \
     -DAETHER_BROTLI_LIBS='"$(BROTLI_LDFLAGS)"' \
+    -DAETHER_ZSTD_LIBS='"$(ZSTD_LDFLAGS)"' \
     $(if $(AETHER_ENABLE_LLM),-DAETHER_ENABLE_LLM=1)
 TOOLS_SRC = tools/ae.c tools/ae_help.c tools/ae_fmt.c tools/ae_bindgen.c \
             tools/ae_cross.c tools/ae_repl.c tools/ae_version.c \
@@ -826,7 +845,7 @@ endif
 all: compiler ae stdlib
 
 # Create object directories
-$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime $(OBJ_DIR)/tools $(OBJ_DIR)/tools/apkg:
+$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/zstd $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime $(OBJ_DIR)/tools $(OBJ_DIR)/tools/apkg:
 ifdef WINDOWS_NATIVE
 	@if not exist "$(subst /,\,$@)" mkdir "$(subst /,\,$@)"
 else
@@ -866,7 +885,7 @@ $(BUILD_FLAGS_STAMP): build-flags-force
 	    printf '%s' "$$digest" > "$@"; \
 	  fi
 
-$(OBJ_DIR)/%.o: %.c $(BUILD_FLAGS_STAMP) | $(STDLIB_SYMS_HEADER) $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
+$(OBJ_DIR)/%.o: %.c $(BUILD_FLAGS_STAMP) | $(STDLIB_SYMS_HEADER) $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/zstd $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
 	@echo "Compiling $<..."
 	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) -c $< -o $@
 
@@ -1994,7 +2013,7 @@ release: clean $(STDLIB_SYMS_HEADER)
 	@# is what surfaced this. The matching LDFLAGS are already in $(LDFLAGS).
 	@$(CC) -O3 -DNDEBUG $(LTO_FLAG) -Werror -Icompiler -Iruntime -Istd -Istd/collections \
 		-DAETHER_VERSION=\"$(VERSION)\" \
-		$(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) \
+		$(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) $(ZSTD_CFLAGS) \
 		$(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) runtime/aether_resource_caps.c \
 		runtime/aether_locale_num.c \
 		-o build/aetherc-release$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,8 @@ ifeq ($(FREEBSD),1)
   NGHTTP2 := 0
   PCRE2 := 0
   YAML := 0
+  BROTLI := 0
+  ZSTD := 0
   # Link the FreeBSD-only libraries from the base sysroot. Zig supplies the
   # CRT and libc for this target; adding the base's startup objects as well
   # would duplicate `_start`. Overrides the native LDFLAGS assembly below.
@@ -315,6 +317,11 @@ ifeq ($(WINDOWS),1)
   ZLIB := 0
   NGHTTP2 := 0
   YAML := 0
+  # Same reason as the four above: the HOST's pkg-config would happily report
+  # a libbrotlienc/libzstd that the cross toolchain has no headers for, and
+  # the source then #includes a header zig cannot find. Both stub cleanly.
+  BROTLI := 0
+  ZSTD := 0
   # PCRE2 has a vendored in-tree fallback (no host library involved), so
   # std.regex survives the cross build.
   PCRE2 := vendored

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,13 @@ ifeq ($(BROTLI),0)
   BROTLI_LDFLAGS :=
 else
   BROTLI_CFLAGS := $(shell pkg-config --cflags libbrotlienc 2>/dev/null)
-  BROTLI_LDFLAGS := $(shell pkg-config --libs libbrotlienc 2>/dev/null)
+  # --static so libbrotlicommon comes with it. It is a Requires.private of
+  # libbrotlienc, so a plain --libs omits it -- fine when the loader resolves
+  # a shared object, fatal on a static link: MinGW's ld then reports a wall of
+  # undefined BrotliGetDictionary / BrotliDefaultAllocFunc / _kBrotli*
+  # references from inside libbrotlienc.a itself. Found on a real MSYS2 box;
+  # a Linux shared link hides it entirely.
+  BROTLI_LDFLAGS := $(shell pkg-config --static --libs libbrotlienc 2>/dev/null)
 endif
 ifneq ($(BROTLI_LDFLAGS),)
   BROTLI_CFLAGS += -DAETHER_HAS_BROTLI

--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,23 @@ ifneq ($(NGHTTP2_LDFLAGS),)
   NGHTTP2_CFLAGS += -DAETHER_HAS_NGHTTP2
 endif
 
+# Brotli detection: enables std.brotli (RFC 7932). `br` is what current
+# browsers actually prefer over gzip in Accept-Encoding, so this is the
+# higher-value codec for HTTP specifically. Same pkg-config probe shape as
+# zlib/nghttp2; when absent, brotli.stream_new reports "brotli unavailable"
+# and a server negotiating content-encoding falls back to gzip. Issue #1891.
+BROTLI ?= auto
+ifeq ($(BROTLI),0)
+  BROTLI_CFLAGS :=
+  BROTLI_LDFLAGS :=
+else
+  BROTLI_CFLAGS := $(shell pkg-config --cflags libbrotlienc 2>/dev/null)
+  BROTLI_LDFLAGS := $(shell pkg-config --libs libbrotlienc 2>/dev/null)
+endif
+ifneq ($(BROTLI_LDFLAGS),)
+  BROTLI_CFLAGS += -DAETHER_HAS_BROTLI
+endif
+
 # PCRE2 detection: enables std.regex (full Perl-compatible regex —
 # captures, $-substitutions, Unicode, look-around, etc.). A system
 # libpcre2-8 found by pkg-config is preferred (distro security updates
@@ -528,6 +545,7 @@ OPENSSL_LDFLAGS := $(call cellar_to_opt,$(OPENSSL_LDFLAGS))
 ZLIB_LDFLAGS    := $(call cellar_to_opt,$(ZLIB_LDFLAGS))
 NGHTTP2_LDFLAGS := $(call cellar_to_opt,$(NGHTTP2_LDFLAGS))
 PCRE2_LDFLAGS   := $(call cellar_to_opt,$(PCRE2_LDFLAGS))
+BROTLI_LDFLAGS  := $(call cellar_to_opt,$(BROTLI_LDFLAGS))
 YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 
 # -fPIC on every runtime/stdlib object so the precompiled `build/libaether.a`
@@ -560,7 +578,7 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 #
 # Recipes use `$(AETHER_REQUIRED_CFLAGS) $(CFLAGS)` so tuning one cannot
 # silently delete the other.
-AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS)
+AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS)
 
 CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
@@ -608,7 +626,7 @@ ifeq ($(FREEBSD),1)
 # (which would pull the host's -lm / -pthread / globbed host casper libs).
 AETHER_REQUIRED_LDFLAGS = $(FREEBSD_LDFLAGS)
 else
-AETHER_REQUIRED_LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS)
+AETHER_REQUIRED_LDFLAGS = -lm $(OPENSSL_LDFLAGS) $(ZLIB_LDFLAGS) $(NGHTTP2_LDFLAGS) $(PCRE2_LDFLAGS) $(YAML_LDFLAGS) $(CASPER_LDFLAGS) $(AUDIO_LDFLAGS) $(BROTLI_LDFLAGS)
 endif
 
 # Tunable link flags: sanitizers and anything else a caller passes. Empty by
@@ -679,7 +697,7 @@ endif
 COMPILER_SRC = compiler/aetherc.c compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/contract_eval.c compiler/analysis/derive.c compiler/analysis/actor_reply.c compiler/aether_defines.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 COMPILER_LIB_SRC = compiler/parser/lexer.c compiler/parser/parser.c compiler/ast.c compiler/analysis/typechecker.c compiler/analysis/contract_eval.c compiler/analysis/derive.c compiler/analysis/actor_reply.c compiler/aether_defines.c compiler/codegen/codegen.c compiler/codegen/codegen_expr.c compiler/codegen/codegen_stmt.c compiler/codegen/codegen_actor.c compiler/codegen/codegen_func.c compiler/aether_error.c compiler/aether_module.c compiler/analysis/type_inference.c compiler/codegen/optimizer.c compiler/aether_diagnostics.c runtime/actors/aether_message_registry.c lsp/aether_lsp.c
 RUNTIME_SRC = $(SCHEDULER_SRC) runtime/scheduler/scheduler_optimizations.c runtime/scheduler/aether_io_poller_epoll.c runtime/scheduler/aether_io_poller_kqueue.c runtime/scheduler/aether_io_poller_poll.c runtime/config/aether_optimization_config.c runtime/memory/aether_arena.c runtime/memory/aether_pool.c runtime/memory/aether_memory_stats.c runtime/utils/aether_trace.c runtime/utils/aether_bounds_check.c runtime/utils/aether_test.c runtime/memory/aether_arena_optimized.c runtime/aether_runtime_types.c runtime/aether_locale_num.c runtime/utils/aether_cpu_detect.c runtime/utils/aether_simd_vectorized.c runtime/aether_runtime.c runtime/aether_numa.c runtime/aether_sandbox.c runtime/sandbox/spawn_sandboxed_linux.c runtime/sandbox/spawn_sandboxed_bsd.c runtime/sandbox/spawn_sandboxed_stub.c runtime/sandbox/capsicum_autosandbox.c runtime/sandbox/aether_audit.c runtime/aether_shared_map.c runtime/aether_host.c runtime/aether_resource_caps.c runtime/libaether_caps.c runtime/actors/aether_send_buffer.c runtime/actors/aether_send_message.c runtime/actors/aether_actor_thread.c runtime/actors/aether_panic.c runtime/actors/aether_unwind.c
-STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_http_pool.c std/net/aether_http_park.c std/net/aether_http_evloop.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/yaml/aether_yaml.c std/xml/aether_xml.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/cryptography/aes/aether_aes.c std/zlib/aether_zlib.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/bytes/cursor/aether_bytes_cursor.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c std/regex/aether_regex.c std/regex/aether_pcre2_vendored.c std/capsicum/aether_capsicum.c std/casper/aether_casper.c std/snapshot/aether_snapshot.c std/audio/aether_audio.c std/worker/aether_worker.c std/alloc/aether_alloc.c std/tracking/aether_tracking.c std/tar/aether_tar.c
+STD_SRC = std/string/aether_string.c std/math/aether_math.c std/net/aether_http.c std/net/aether_http_server.c std/net/aether_http_pool.c std/net/aether_http_park.c std/net/aether_http_evloop.c std/net/aether_net.c std/collections/aether_collections.c std/json/aether_json.c std/yaml/aether_yaml.c std/xml/aether_xml.c std/fs/aether_fs.c std/log/aether_log.c std/io/aether_io.c std/os/aether_os.c std/ipc/aether_ipc.c std/mem/aether_mem.c std/cryptography/aether_cryptography.c std/cryptography/aes/aether_aes.c std/zlib/aether_zlib.c std/brotli/aether_brotli.c std/lzf/lzf_c.c std/lzf/lzf_d.c std/lzf/aether_lzf.c std/dl/aether_dl.c std/http/middleware/aether_middleware.c std/http/server/h2/aether_h2.c std/http/proxy/aether_proxy_pool.c std/http/proxy/aether_proxy_lb.c std/http/proxy/aether_proxy_breaker.c std/http/proxy/aether_proxy_health.c std/http/proxy/aether_proxy_cache.c std/http/proxy/aether_proxy_opts.c std/http/proxy/aether_proxy_metrics.c std/http/proxy/aether_proxy_middleware.c std/http/script_gateway/aether_script_gateway.c std/bytes/aether_bytes.c std/bytes/cursor/aether_bytes_cursor.c std/strbuilder/aether_strbuilder.c std/config/aether_config.c std/actors/aether_actor_registry.c std/regex/aether_regex.c std/regex/aether_pcre2_vendored.c std/capsicum/aether_capsicum.c std/casper/aether_casper.c std/snapshot/aether_snapshot.c std/audio/aether_audio.c std/worker/aether_worker.c std/alloc/aether_alloc.c std/tracking/aether_tracking.c std/tar/aether_tar.c
 # Stdlib sources that reference scheduler internals (scheduler_io_register,
 # g_sync_step_actor, current_core_id). Excluded from the compiler binary
 # because aetherc does not link the runtime scheduler, but included in
@@ -708,6 +726,7 @@ TOOLS_CFLAGS = -O2 -Itools -MMD -MP \
     -DAETHER_YAML_LIBS='"$(YAML_LDFLAGS)"' \
     -DAETHER_CASPER_LIBS='"$(CASPER_LDFLAGS)"' \
     -DAETHER_AUDIO_LIBS='"$(AUDIO_LDFLAGS)"' \
+    -DAETHER_BROTLI_LIBS='"$(BROTLI_LDFLAGS)"' \
     $(if $(AETHER_ENABLE_LLM),-DAETHER_ENABLE_LLM=1)
 TOOLS_SRC = tools/ae.c tools/ae_help.c tools/ae_fmt.c tools/ae_bindgen.c \
             tools/ae_cross.c tools/ae_repl.c tools/ae_version.c \
@@ -807,7 +826,7 @@ endif
 all: compiler ae stdlib
 
 # Create object directories
-$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime $(OBJ_DIR)/tools $(OBJ_DIR)/tools/apkg:
+$(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime $(OBJ_DIR)/tools $(OBJ_DIR)/tools/apkg:
 ifdef WINDOWS_NATIVE
 	@if not exist "$(subst /,\,$@)" mkdir "$(subst /,\,$@)"
 else
@@ -847,7 +866,7 @@ $(BUILD_FLAGS_STAMP): build-flags-force
 	    printf '%s' "$$digest" > "$@"; \
 	  fi
 
-$(OBJ_DIR)/%.o: %.c $(BUILD_FLAGS_STAMP) | $(STDLIB_SYMS_HEADER) $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
+$(OBJ_DIR)/%.o: %.c $(BUILD_FLAGS_STAMP) | $(STDLIB_SYMS_HEADER) $(OBJ_DIR)/compiler $(OBJ_DIR)/compiler/parser $(OBJ_DIR)/compiler/codegen $(OBJ_DIR)/compiler/analysis $(OBJ_DIR)/runtime $(OBJ_DIR)/runtime/actors $(OBJ_DIR)/runtime/sandbox $(OBJ_DIR)/runtime/scheduler $(OBJ_DIR)/runtime/memory $(OBJ_DIR)/runtime/config $(OBJ_DIR)/runtime/simd $(OBJ_DIR)/runtime/utils $(OBJ_DIR)/std $(OBJ_DIR)/std/string $(OBJ_DIR)/std/io $(OBJ_DIR)/std/math $(OBJ_DIR)/std/net $(OBJ_DIR)/std/fs $(OBJ_DIR)/std/log $(OBJ_DIR)/std/collections $(OBJ_DIR)/std/json $(OBJ_DIR)/std/yaml $(OBJ_DIR)/std/xml $(OBJ_DIR)/std/os $(OBJ_DIR)/std/ipc $(OBJ_DIR)/std/mem $(OBJ_DIR)/std/cryptography $(OBJ_DIR)/std/cryptography/aes $(OBJ_DIR)/std/zlib $(OBJ_DIR)/std/brotli $(OBJ_DIR)/std/lzf $(OBJ_DIR)/std/dl $(OBJ_DIR)/std/bytes $(OBJ_DIR)/std/bytes/cursor $(OBJ_DIR)/std/strbuilder $(OBJ_DIR)/std/config $(OBJ_DIR)/std/actors $(OBJ_DIR)/std/capsicum $(OBJ_DIR)/std/casper $(OBJ_DIR)/std/snapshot $(OBJ_DIR)/std/audio $(OBJ_DIR)/std/worker $(OBJ_DIR)/std/alloc $(OBJ_DIR)/std/tracking $(OBJ_DIR)/std/tar $(OBJ_DIR)/std/http $(OBJ_DIR)/std/http/middleware $(OBJ_DIR)/std/http/proxy $(OBJ_DIR)/std/http/script_gateway $(OBJ_DIR)/std/http/server $(OBJ_DIR)/std/http/server/h2 $(OBJ_DIR)/std/regex $(OBJ_DIR)/lsp $(OBJ_DIR)/tests $(OBJ_DIR)/tests/compiler $(OBJ_DIR)/tests/memory $(OBJ_DIR)/tests/runtime
 	@echo "Compiling $<..."
 	@$(CC) $(AETHER_REQUIRED_CFLAGS) $(CFLAGS) -c $< -o $@
 
@@ -1975,7 +1994,7 @@ release: clean $(STDLIB_SYMS_HEADER)
 	@# is what surfaced this. The matching LDFLAGS are already in $(LDFLAGS).
 	@$(CC) -O3 -DNDEBUG $(LTO_FLAG) -Werror -Icompiler -Iruntime -Istd -Istd/collections \
 		-DAETHER_VERSION=\"$(VERSION)\" \
-		$(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) \
+		$(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) \
 		$(COMPILER_SRC) $(STD_SRC) $(COLLECTIONS_SRC) runtime/aether_resource_caps.c \
 		runtime/aether_locale_num.c \
 		-o build/aetherc-release$(EXE_EXT) $(AETHER_REQUIRED_LDFLAGS) $(LDFLAGS)

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -7,7 +7,7 @@ cannot leave the index behind. The sections after it cover the most-used
 modules in depth; for the others the index links to the module source, whose
 header comment is the authoritative description.
 
-## Module index (72 modules)
+## Module index (73 modules)
 
 | Module | Purpose | Exports | Detail |
 |---|---|---:|---|
@@ -83,6 +83,7 @@ header comment is the authoritative description.
 | `std.yaml` | YAML parsing and emitting. | 16 | [guide](../std/yaml/README.md) · [source](../std/yaml/module.ae) |
 | `std.zlib` | One-shot zlib and gzip deflate and inflate. | 28 | [full section](#compression-stdzlib) |
 | `std.brotli` | Brotli compression, streaming and one-shot, for `Content-Encoding: br`. | 19 | — |
+| `std.zstd` | Zstandard compression, streaming and one-shot, for archives and internal transports. | 19 | — |
 
 > **Note:** The standard library follows the canonical module pattern in [stdlib-module-pattern.md](stdlib-module-pattern.md), fallible operations expose a `_raw` extern plus a Go-style `(value, err)` Aether wrapper; pure/infallible operations stay raw without a suffix. See the [error handling example](../examples/basics/error-handling.ae) for how the pattern is used from user code, and [std/fs/module.ae](../std/fs/module.ae) for the reference implementation.
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -7,7 +7,7 @@ cannot leave the index behind. The sections after it cover the most-used
 modules in depth; for the others the index links to the module source, whose
 header comment is the authoritative description.
 
-## Module index (71 modules)
+## Module index (72 modules)
 
 | Module | Purpose | Exports | Detail |
 |---|---|---:|---|
@@ -82,6 +82,7 @@ header comment is the authoritative description.
 | `std.xml` | XML pull parsing and document writing. | 45 | [full section](#xml-stdxml) |
 | `std.yaml` | YAML parsing and emitting. | 16 | [guide](../std/yaml/README.md) · [source](../std/yaml/module.ae) |
 | `std.zlib` | One-shot zlib and gzip deflate and inflate. | 28 | [full section](#compression-stdzlib) |
+| `std.brotli` | Brotli compression, streaming and one-shot, for `Content-Encoding: br`. | 19 | — |
 
 > **Note:** The standard library follows the canonical module pattern in [stdlib-module-pattern.md](stdlib-module-pattern.md), fallible operations expose a `_raw` extern plus a Go-style `(value, err)` Aether wrapper; pure/infallible operations stay raw without a suffix. See the [error handling example](../examples/basics/error-handling.ae) for how the pattern is used from user code, and [std/fs/module.ae](../std/fs/module.ae) for the reference implementation.
 

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -81,7 +81,7 @@ header comment is the authoritative description.
 | `std.worker` | Run blocking work off the loop thread, deliver the result back on it. | 19 | [guide](../std/worker/README.md) · [source](../std/worker/module.ae) |
 | `std.xml` | XML pull parsing and document writing. | 45 | [full section](#xml-stdxml) |
 | `std.yaml` | YAML parsing and emitting. | 16 | [guide](../std/yaml/README.md) · [source](../std/yaml/module.ae) |
-| `std.zlib` | One-shot zlib and gzip deflate and inflate. | 16 | [full section](#compression-stdzlib) |
+| `std.zlib` | One-shot zlib and gzip deflate and inflate. | 28 | [full section](#compression-stdzlib) |
 
 > **Note:** The standard library follows the canonical module pattern in [stdlib-module-pattern.md](stdlib-module-pattern.md), fallible operations expose a `_raw` extern plus a Go-style `(value, err)` Aether wrapper; pure/infallible operations stay raw without a suffix. See the [error handling example](../examples/basics/error-handling.ae) for how the pattern is used from user code, and [std/fs/module.ae](../std/fs/module.ae) for the reference implementation.
 

--- a/std/brotli/README.md
+++ b/std/brotli/README.md
@@ -1,0 +1,60 @@
+# std.brotli
+
+Brotli compression (RFC 7932) — streaming and one-shot.
+
+`br` is what current browsers actually prefer: every modern browser lists it
+ahead of `gzip` in `Accept-Encoding`, and it typically beats gzip by 15–25% on
+text at comparable speed. This module wraps the system **libbrotlienc**
+(`apt install libbrotli-dev`, `brew install brotli`).
+
+Compression only. An HTTP server compresses responses; nothing in-tree needs to
+*decode* `br`, and a decoder is separate work.
+
+## Streaming
+
+The surface deliberately mirrors `std.zlib`'s streaming deflate, so a server
+negotiating `br` against `gzip` writes the same shape either way:
+
+```
+s, err        = brotli.stream_new(brotli.FAST_QUALITY, 0)
+chunk, n, err = brotli.stream_write(s, ev, string.length(ev))
+chunk, n, err = brotli.stream_flush(s)      // send these bytes now
+tail,  n, err = brotli.stream_finish(s)     // at connection close
+                brotli.stream_free(s)
+```
+
+`stream_write` usually returns **0 bytes** — the encoder buffers internally for
+compression ratio. `stream_flush` is what emits a decodable boundary while
+keeping the window, so later events cost far less than the first: three
+repetitive events compress to 31, 13 and 13 bytes.
+
+A handle owns its output buffer, so two streams may be open on one thread (two
+SSE connections on one event loop) without fighting over it. Always
+`stream_free`.
+
+## Quality
+
+`quality` is 0–11. **11 is the library default and is slow** — `FAST_QUALITY`
+(5) is the usual choice for a live HTTP response. `window` is the lg2 window
+size (10–24); pass 0 for the library default. Both are clamped rather than
+rejected, matching how `std.zlib` treats `level`.
+
+## One-shot
+
+```
+packed, n, err = brotli.compress(body, string.length(body), brotli.FAST_QUALITY)
+```
+
+## When the backend is absent
+
+Built without libbrotlienc, `available()` returns 0 and `stream_new` returns
+`(null, "brotli unavailable")`. Every other stream call needs the handle, so a
+program fails where it *asks for* a stream rather than silently emitting
+nothing. A server negotiating content-encoding should check `available()` and
+fall back to gzip.
+
+## Exports
+
+`available`, `compress`, `stream_new`, `stream_write`, `stream_flush`,
+`stream_finish`, `stream_free` (and the `MIN_QUALITY` / `MAX_QUALITY` /
+`DEFAULT_QUALITY` / `FAST_QUALITY` constants), plus the `brotli_*` raw forms.

--- a/std/brotli/aether_brotli.c
+++ b/std/brotli/aether_brotli.c
@@ -1,0 +1,235 @@
+#include "aether_brotli.h"
+#include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef AETHER_HAS_BROTLI
+#include <brotli/encode.h>
+#endif
+
+/* Unwrap a `data` argument that may be an AetherString* or a plain char*.
+ * Same helper shape as std/zlib and std/fs — without this dispatch a
+ * length-aware AetherString would leak its struct header into the stream. */
+static inline const unsigned char* brotli_unwrap_bytes(const char* data, int length,
+                                                       size_t* out_len) {
+    if (!data) { *out_len = 0; return NULL; }
+    if (is_aether_string(data)) {
+        const AetherString* s = (const AetherString*)data;
+        *out_len = (length >= 0) ? (size_t)length : s->length;
+        return (const unsigned char*)s->data;
+    }
+    *out_len = (length >= 0) ? (size_t)length : strlen(data);
+    return (const unsigned char*)data;
+}
+
+/* One-shot output slot, thread-local like std.zlib's. The STREAMING output
+ * lives on the handle instead; see the header. */
+static _Thread_local unsigned char* tls_comp_buf = NULL;
+static _Thread_local size_t         tls_comp_cap = 0;
+static _Thread_local int            tls_comp_len = 0;
+
+static void free_comp_tls(void) {
+    if (tls_comp_buf) {
+        aether_caps_free(tls_comp_buf, tls_comp_cap);
+        tls_comp_buf = NULL;
+    }
+    tls_comp_cap = 0;
+    tls_comp_len = 0;
+}
+
+int brotli_backend_available(void) {
+#ifdef AETHER_HAS_BROTLI
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+#ifdef AETHER_HAS_BROTLI
+
+typedef struct {
+    BrotliEncoderState* enc;
+    unsigned char* out;     /* owned; bytes of the most recent call */
+    size_t out_cap;         /* allocator's view, for aether_caps_free */
+    int    out_len;         /* payload's view */
+    int    finished;
+    int    broken;
+} BrotliStream;
+
+static int clamp_quality(int q) {
+    if (q < BROTLI_MIN_QUALITY) return BROTLI_DEFAULT_QUALITY;
+    if (q > BROTLI_MAX_QUALITY) return BROTLI_MAX_QUALITY;
+    return q;
+}
+
+/* Run one BrotliEncoderCompressStream pass and drain everything it produced.
+ *
+ * The drain differs from zlib's in a way worth stating: brotli reports
+ * "more output pending" explicitly via BrotliEncoderHasMoreOutput, so the
+ * loop condition is that flag plus a non-empty input, rather than zlib's
+ * "did it leave avail_out spare". Copying zlib's shape here would stop early
+ * whenever the output happened to land exactly on the buffer boundary.
+ *
+ * `in`/`in_len` may be NULL/0 for a flush or finish. */
+static int brotli_pump(BrotliStream* z, BrotliEncoderOperation op,
+                       const unsigned char* in, size_t in_len) {
+    if (!z || z->broken) return 0;
+
+    size_t avail_in = in_len;
+    const uint8_t* next_in = (const uint8_t*)in;
+    size_t used = 0;
+
+    if (z->out_cap < 256) {
+        size_t cap = 256;
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(cap);
+        if (!nb) { z->broken = 1; return 0; }
+        if (z->out) aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = cap;
+    }
+
+    for (;;) {
+        size_t avail_out = z->out_cap - used;
+        uint8_t* next_out = (uint8_t*)(z->out + used);
+
+        if (!BrotliEncoderCompressStream(z->enc, op, &avail_in, &next_in,
+                                         &avail_out, &next_out, NULL)) {
+            z->broken = 1;
+            return 0;
+        }
+        used = z->out_cap - avail_out;
+
+        /* Done when brotli has consumed the input and says nothing is
+         * pending. Otherwise grow and go round again. */
+        if (avail_in == 0 && !BrotliEncoderHasMoreOutput(z->enc)) break;
+
+        size_t ncap = z->out_cap * 2;
+        if (ncap > (size_t)1 << 30) { z->broken = 1; return 0; }
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(ncap);
+        if (!nb) { z->broken = 1; return 0; }
+        memcpy(nb, z->out, used);
+        aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = ncap;
+    }
+
+    z->out_len = (int)used;
+    return 1;
+}
+
+void* brotli_try_stream_new(int quality, int window) {
+    BrotliStream* z = (BrotliStream*)aether_caps_calloc(1, sizeof(BrotliStream));
+    if (!z) return NULL;
+    z->enc = BrotliEncoderCreateInstance(NULL, NULL, NULL);
+    if (!z->enc) {
+        aether_caps_free(z, sizeof(BrotliStream));
+        return NULL;
+    }
+    BrotliEncoderSetParameter(z->enc, BROTLI_PARAM_QUALITY,
+                              (uint32_t)clamp_quality(quality));
+    if (window >= BROTLI_MIN_WINDOW_BITS && window <= BROTLI_MAX_WINDOW_BITS) {
+        BrotliEncoderSetParameter(z->enc, BROTLI_PARAM_LGWIN, (uint32_t)window);
+    }
+    return z;
+}
+
+int brotli_try_stream_write(void* handle, const char* data, int length) {
+    BrotliStream* z = (BrotliStream*)handle;
+    if (!z || z->finished || z->broken || length < 0) return 0;
+    size_t in_len;
+    const unsigned char* in = brotli_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+    return brotli_pump(z, BROTLI_OPERATION_PROCESS, in, in_len);
+}
+
+int brotli_try_stream_flush(void* handle) {
+    BrotliStream* z = (BrotliStream*)handle;
+    if (!z || z->finished || z->broken) return 0;
+    return brotli_pump(z, BROTLI_OPERATION_FLUSH, NULL, 0);
+}
+
+int brotli_try_stream_finish(void* handle) {
+    BrotliStream* z = (BrotliStream*)handle;
+    if (!z || z->broken) return 0;
+    if (z->finished) { z->out_len = 0; return 1; }   /* idempotent */
+    if (!brotli_pump(z, BROTLI_OPERATION_FINISH, NULL, 0)) return 0;
+    z->finished = 1;
+    return 1;
+}
+
+const char* brotli_get_stream_bytes(void* handle) {
+    BrotliStream* z = (BrotliStream*)handle;
+    if (!z || !z->out) return "";
+    return (const char*)z->out;
+}
+
+int brotli_get_stream_length(void* handle) {
+    BrotliStream* z = (BrotliStream*)handle;
+    return z ? z->out_len : 0;
+}
+
+void brotli_release_stream(void* handle) {
+    BrotliStream* z = (BrotliStream*)handle;
+    if (!z) return;
+    if (z->enc) BrotliEncoderDestroyInstance(z->enc);
+    if (z->out) aether_caps_free(z->out, z->out_cap);
+    aether_caps_free(z, sizeof(BrotliStream));
+}
+
+int brotli_try_compress(const char* data, int length, int quality) {
+    free_comp_tls();
+    if (length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = brotli_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+
+    size_t bound = BrotliEncoderMaxCompressedSize(in_len);
+    if (bound == 0) bound = 1;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(bound);
+    if (!out) return 0;
+
+    size_t out_size = bound;
+    if (!BrotliEncoderCompress(clamp_quality(quality), BROTLI_DEFAULT_WINDOW,
+                               BROTLI_MODE_GENERIC, in_len, in, &out_size, out)) {
+        aether_caps_free(out, bound);
+        return 0;
+    }
+    tls_comp_buf = out;
+    tls_comp_cap = bound;
+    tls_comp_len = (int)out_size;
+    return 1;
+}
+
+#else /* !AETHER_HAS_BROTLI */
+
+/* stream_new returning NULL is the one signal a caller cannot ignore: every
+ * other stream entry point needs a handle, so a program built without brotli
+ * fails where it asks for a stream rather than silently emitting nothing.
+ * (base64 in #1884 returned empty from its no-backend branch and callers
+ * shipped broken output for it.) */
+void* brotli_try_stream_new(int quality, int window) {
+    (void)quality; (void)window; return NULL;
+}
+int brotli_try_stream_write(void* handle, const char* data, int length) {
+    (void)handle; (void)data; (void)length; return 0;
+}
+int brotli_try_stream_flush(void* handle)  { (void)handle; return 0; }
+int brotli_try_stream_finish(void* handle) { (void)handle; return 0; }
+const char* brotli_get_stream_bytes(void* handle) { (void)handle; return ""; }
+int brotli_get_stream_length(void* handle) { (void)handle; return 0; }
+void brotli_release_stream(void* handle) { (void)handle; }
+
+int brotli_try_compress(const char* data, int length, int quality) {
+    (void)data; (void)length; (void)quality; return 0;
+}
+
+#endif /* AETHER_HAS_BROTLI */
+
+const char* brotli_get_compress_bytes(void) {
+    return (const char*)(tls_comp_buf ? tls_comp_buf : (unsigned char*)"");
+}
+int  brotli_get_compress_length(void) { return tls_comp_len; }
+void brotli_release_compress(void)    { free_comp_tls(); }

--- a/std/brotli/aether_brotli.h
+++ b/std/brotli/aether_brotli.h
@@ -1,0 +1,72 @@
+/* std.brotli — Brotli compression (RFC 7932), streaming and one-shot.
+ *
+ * Brotli is what browsers actually prefer over gzip today: `Accept-Encoding`
+ * lists `br` ahead of `gzip` in every current browser, and it typically beats
+ * gzip by 15-25% on text at comparable speed. This module wraps the system
+ * libbrotlienc (apt: libbrotli-dev, brew: brotli) rather than vendoring an
+ * implementation — see the note at the foot of this header.
+ *
+ * The surface deliberately mirrors std.zlib's streaming deflate (#1890), so a
+ * caller negotiating `br` vs `gzip` writes the same shape either way:
+ *
+ *   s = stream_new(quality, window)
+ *   stream_write(s, data, len)   -- buffer input, may emit nothing
+ *   stream_flush(s)              -- emit a decodable boundary, KEEP the window
+ *   stream_finish(s)             -- emit the tail
+ *   stream_free(s)
+ *
+ * As with zlib, the handle owns its output buffer rather than sharing a
+ * thread-local slot: two streams may be open on one thread (two SSE
+ * connections on one event loop) and TLS slots would let them overwrite each
+ * other's pending bytes.
+ *
+ * When built without libbrotlienc (AETHER_HAS_BROTLI undefined),
+ * brotli_try_stream_new returns NULL and the one-shot try_ entry points
+ * return 0, so a caller sees "brotli unavailable" rather than silently
+ * shipping empty output.
+ */
+
+#ifndef AETHER_BROTLI_H
+#define AETHER_BROTLI_H
+
+/* 1 when the toolchain was built with libbrotlienc detected. Callers use it
+ * to distinguish "no backend" from "backend failed", and tests to choose SKIP
+ * over FAIL. Named _backend_available so it doesn't collide with the
+ * Aether-side `brotli.available()` wrapper's mangled name. */
+int brotli_backend_available(void);
+
+/* Quality is 0..11 (libbrotli's own range; 11 is the default and is slow —
+ * 4..6 is the usual choice for a live HTTP response). `window` is the lg2
+ * window size, 10..24; pass 0 for the library default. Out-of-range values
+ * are clamped rather than rejected, matching how std.zlib treats `level`. */
+void* brotli_try_stream_new(int quality, int window);
+int   brotli_try_stream_write(void* handle, const char* data, int length);
+int   brotli_try_stream_flush(void* handle);
+int   brotli_try_stream_finish(void* handle);
+
+/* Bytes produced by the most recent write/flush/finish on this handle.
+ * Borrowed; valid until the next call on the same handle. */
+const char* brotli_get_stream_bytes(void* handle);
+int         brotli_get_stream_length(void* handle);
+void        brotli_release_stream(void* handle);
+
+/* One-shot compression, for a body already in memory. Uses the same
+ * split-accessor shape as std.zlib: try_ performs the work and stashes the
+ * result, get_ reads it borrowed, release_ frees early. */
+int         brotli_try_compress(const char* data, int length, int quality);
+const char* brotli_get_compress_bytes(void);
+int         brotli_get_compress_length(void);
+void        brotli_release_compress(void);
+
+/* Why a system library rather than a vendored implementation:
+ * libbrotlienc ships in every mainstream distro (apt libbrotli-dev, brew
+ * brotli) and exposes exactly the streaming encoder this needs
+ * (BrotliEncoderCompressStream with BROTLI_OPERATION_FLUSH). The reference
+ * implementation carries a mandatory ~120k-line static dictionary that is
+ * part of the FORMAT, so vendoring means carrying that whichever route is
+ * taken; binding the system library avoids transliterating ~17k lines of
+ * bit-exact entropy coding as well. Decompression is deliberately absent for
+ * now: an HTTP server compresses responses, and nothing in-tree needs to
+ * decode br. */
+
+#endif /* AETHER_BROTLI_H */

--- a/std/brotli/module.ae
+++ b/std/brotli/module.ae
@@ -1,0 +1,135 @@
+// std.brotli — Brotli compression (RFC 7932), streaming and one-shot.
+//
+// `br` is what current browsers actually prefer over gzip: every modern
+// browser lists it ahead of gzip in Accept-Encoding, and it typically beats
+// gzip by 15-25% on text at comparable speed. This module wraps the system
+// libbrotlienc (apt: libbrotli-dev, brew: brotli).
+//
+// The streaming surface deliberately mirrors std.zlib's, so a server
+// negotiating `br` vs `gzip` writes the same shape either way:
+//
+//   s, err = brotli.stream_new(5, 0)
+//   chunk, n, err = brotli.stream_write(s, ev, string.length(ev))
+//   chunk, n, err = brotli.stream_flush(s)     // send these bytes now
+//   tail,  n, err = brotli.stream_finish(s)    // at connection close
+//   brotli.stream_free(s)
+//
+// Compression only. An HTTP server compresses responses; nothing in-tree
+// needs to DECODE br, and a decoder is a separate piece of work.
+
+exports(
+    brotli_backend_available,
+    brotli_try_stream_new, brotli_try_stream_write, brotli_try_stream_flush,
+    brotli_try_stream_finish, brotli_get_stream_bytes, brotli_get_stream_length,
+    brotli_release_stream,
+    brotli_try_compress, brotli_get_compress_bytes, brotli_get_compress_length,
+    brotli_release_compress,
+    available, compress,
+    stream_new, stream_write, stream_flush, stream_finish, stream_free
+)
+
+extern brotli_backend_available() -> int
+
+extern brotli_try_stream_new(quality: int, window: int) -> ptr
+extern brotli_try_stream_write(handle: ptr, data: string, length: int) -> int
+extern brotli_try_stream_flush(handle: ptr) -> int
+extern brotli_try_stream_finish(handle: ptr) -> int
+extern brotli_get_stream_bytes(handle: ptr) -> string
+extern brotli_get_stream_length(handle: ptr) -> int
+extern brotli_release_stream(handle: ptr)
+
+extern brotli_try_compress(data: string, length: int, quality: int) -> int
+extern brotli_get_compress_bytes() -> string
+extern brotli_get_compress_length() -> int
+extern brotli_release_compress()
+
+// Length-preserving string constructor from std.string — takes an explicit
+// byte count so binary payloads with embedded NULs survive the copy out of
+// the borrowed C buffer into an owned AetherString.
+extern string_new_with_length(data: string, length: int) -> ptr
+
+// Quality bounds, matching libbrotli's own range. 11 is the library default
+// and is SLOW; 4..6 is the usual choice for a live HTTP response.
+const MIN_QUALITY = 0
+const MAX_QUALITY = 11
+const DEFAULT_QUALITY = 11
+const FAST_QUALITY = 5
+
+// 1 when the toolchain was built with libbrotlienc detected. Use it to skip a
+// test or pick a fallback encoding rather than threading an error everywhere.
+available() -> int { return brotli_backend_available() }
+
+// One-shot: compress a body already in memory. Returns (bytes, count, "") on
+// success, ("", 0, error) otherwise. Quality out of range is clamped.
+compress(data: string, length: int, quality: int) -> {
+    if brotli_backend_available() == 0 {
+        return "", 0, "brotli unavailable"
+    }
+    ok = brotli_try_compress(data, length, quality)
+    if ok == 0 {
+        return "", 0, "brotli compress failed"
+    }
+    raw = brotli_get_compress_bytes()
+    n = brotli_get_compress_length()
+    owned = string_new_with_length(raw, n)
+    brotli_release_compress()
+    return owned, n, ""
+}
+
+// Open a stream. `window` is the lg2 window size (10..24); pass 0 for the
+// library default. Returns (handle, "") or (null, error) — an unavailable
+// backend fails HERE, not silently later, because every other stream call
+// needs the handle.
+stream_new(quality: int, window: int) -> {
+    if brotli_backend_available() == 0 {
+        return null, "brotli unavailable"
+    }
+    h = brotli_try_stream_new(quality, window)
+    if h == null {
+        return null, "brotli stream_new failed"
+    }
+    return h, ""
+}
+
+// Feed bytes. Returns (bytes, count, "") — the count is usually 0, because
+// the encoder buffers internally for compression ratio. Emit whatever comes
+// back, then stream_flush when the event is complete.
+stream_write(handle: ptr, data: string, length: int) -> {
+    if handle == null { return "", 0, "brotli stream: null handle" }
+    ok = brotli_try_stream_write(handle, data, length)
+    if ok == 0 { return "", 0, "brotli stream_write failed" }
+    return stream_take(handle)
+}
+
+// Emit everything buffered so far at a boundary the decoder can consume,
+// WITHOUT ending the stream. This is what makes per-event streaming work.
+stream_flush(handle: ptr) -> {
+    if handle == null { return "", 0, "brotli stream: null handle" }
+    ok = brotli_try_stream_flush(handle)
+    if ok == 0 { return "", 0, "brotli stream_flush failed" }
+    return stream_take(handle)
+}
+
+// Emit the tail. The handle takes no further writes; calling it twice is
+// harmless and yields no bytes the second time. Still needs stream_free.
+stream_finish(handle: ptr) -> {
+    if handle == null { return "", 0, "brotli stream: null handle" }
+    ok = brotli_try_stream_finish(handle)
+    if ok == 0 { return "", 0, "brotli stream_finish failed" }
+    return stream_take(handle)
+}
+
+// Copy the borrowed C buffer into an owned, length-aware AetherString.
+// Shared by write/flush/finish so the ownership rule lives in one place.
+stream_take(handle: ptr) -> {
+    raw = brotli_get_stream_bytes(handle)
+    n = brotli_get_stream_length(handle)
+    if n == 0 { return "", 0, "" }
+    owned = string_new_with_length(raw, n)
+    return owned, n, ""
+}
+
+// Release the handle. Safe on null.
+stream_free(handle: ptr) {
+    if handle != null { brotli_release_stream(handle) }
+}

--- a/std/zlib/README.md
+++ b/std/zlib/README.md
@@ -53,7 +53,39 @@ an unchecked caller gets an error rather than a wrong result — but checking
 Unlike `std.lzf`, deflating an incompressible input succeeds and simply
 produces slightly more bytes than it consumed.
 
+## Streaming deflate
+
+The calls above are one-shot: each emits a **complete** stream. That is wrong
+for a long-lived response. An SSE connection carrying many small events needs
+ONE deflate stream held open for the life of the connection, flushed at each
+event boundary, so the client sees a single continuous stream. Compressing each
+event independently produces N complete streams concatenated, which no
+`Content-Encoding: gzip` client will decode.
+
+```
+s, err = zlib.stream_new(zlib.GZIP, 6)      // RAW / ZLIB / GZIP
+chunk, n, err = zlib.stream_write(s, ev, string.length(ev))
+chunk, n, err = zlib.stream_flush(s)        // send these bytes now
+// ... more events, same stream ...
+tail, n, err = zlib.stream_finish(s)        // at connection close
+zlib.stream_free(s)
+```
+
+`stream_write` usually returns **0 bytes** — deflate buffers internally for
+compression ratio. `stream_flush` is what emits a decodable boundary while
+keeping the window, so later events cost far less than the first: three
+repetitive events in the test compress to 34, 12 and 11 bytes. Emit whatever
+each call returns, and always `stream_free` the handle.
+
+A handle owns its own output buffer, so two streams may be open on one thread
+(two SSE connections on one event loop) without fighting over it.
+
+Streaming *inflate* is not implemented; the one-shot `inflate` / `gzip_inflate`
+read a complete stream, including one assembled from flushed chunks.
+
 ## Exports
 
-`available`, `deflate`, `inflate`, `gzip_deflate`, `gzip_inflate`, plus the
-`zlib_*` raw forms.
+`available`, `deflate`, `inflate`, `gzip_deflate`, `gzip_inflate`,
+`stream_new`, `stream_write`, `stream_flush`, `stream_finish`, `stream_free`
+(and the `RAW` / `ZLIB` / `GZIP` format constants), plus the `zlib_*` raw
+forms.

--- a/std/zlib/aether_zlib.c
+++ b/std/zlib/aether_zlib.c
@@ -238,6 +238,156 @@ int zlib_try_gzip_inflate(const char* data, int length) {
     return inflate_with_window_bits(data, length, 15 + 16);
 }
 
+/* ---- Streaming deflate (#1890) ---------------------------------- */
+
+typedef struct {
+    z_stream strm;
+    unsigned char* out;      /* owned; holds the bytes of the last call */
+    size_t out_cap;          /* allocator's view, for aether_caps_free */
+    int    out_len;          /* payload's view */
+    int    finished;         /* Z_FINISH already emitted */
+    int    broken;           /* a zlib error was seen; refuse further work */
+} ZlibStream;
+
+/* windowBits for the three framings, matching the one-shot calls:
+ * negative = raw (no wrapper), 15 = zlib, 15+16 = gzip. */
+static int zlib_window_bits(int format) {
+    switch (format) {
+        case AETHER_ZLIB_FORMAT_RAW:  return -15;
+        case AETHER_ZLIB_FORMAT_ZLIB: return 15;
+        case AETHER_ZLIB_FORMAT_GZIP: return 15 + 16;
+        default: return 0;   /* caller rejects */
+    }
+}
+
+/* Run one deflate() pass with `flush`, growing the output buffer until
+ * zlib stops filling it.
+ *
+ * The growth loop is the substance of this file. Z_SYNC_FLUSH can emit
+ * MORE than it consumed (a flush point costs ~5 bytes even with no
+ * pending input, and incompressible input expands), and unlike the
+ * one-shot path there is no deflateBound for a stream that stays open —
+ * the bound depends on what is still in the window. So the only correct
+ * termination condition is "zlib left room spare", i.e. avail_out > 0
+ * after the call. Sizing by input length instead would silently truncate
+ * on incompressible data, which is the bug this loop exists to avoid. */
+static int zlib_stream_pump(ZlibStream* z, int flush) {
+    if (!z || z->broken) return 0;
+
+    size_t used = 0;
+    if (z->out_cap < 256) {
+        size_t cap = 256;
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(cap);
+        if (!nb) { z->broken = 1; return 0; }
+        if (z->out) aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = cap;
+    }
+
+    for (;;) {
+        z->strm.next_out  = z->out + used;
+        z->strm.avail_out = (uInt)(z->out_cap - used);
+        uInt before = z->strm.avail_out;
+
+        int rc = deflate(&z->strm, flush);
+        /* Z_BUF_ERROR from deflate is "no progress possible", which is
+         * not fatal on a flush with nothing pending; every other
+         * non-OK code is. Z_STREAM_END is expected from Z_FINISH. */
+        if (rc != Z_OK && rc != Z_STREAM_END && rc != Z_BUF_ERROR) {
+            z->broken = 1;
+            return 0;
+        }
+        used += (size_t)(before - z->strm.avail_out);
+
+        if (z->strm.avail_out > 0) break;   /* zlib had room spare: done */
+        if (rc == Z_STREAM_END) break;
+
+        /* Filled the buffer exactly — there may be more. Grow and retry. */
+        size_t ncap = z->out_cap * 2;
+        if (ncap > (size_t)1 << 30) { z->broken = 1; return 0; }
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(ncap);
+        if (!nb) { z->broken = 1; return 0; }
+        memcpy(nb, z->out, used);
+        aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = ncap;
+    }
+
+    z->out_len = (int)used;
+    return 1;
+}
+
+void* zlib_try_stream_new(int format, int level) {
+    int wbits = zlib_window_bits(format);
+    if (wbits == 0) return NULL;
+    int lvl = (level < -1 || level > 9) ? Z_DEFAULT_COMPRESSION : level;
+
+    ZlibStream* z = (ZlibStream*)aether_caps_calloc(1, sizeof(ZlibStream));
+    if (!z) return NULL;
+    if (deflateInit2(&z->strm, lvl, Z_DEFLATED, wbits, 8,
+                     Z_DEFAULT_STRATEGY) != Z_OK) {
+        aether_caps_free(z, sizeof(ZlibStream));
+        return NULL;
+    }
+    return z;
+}
+
+int zlib_try_stream_write(void* handle, const char* data, int length) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->finished || z->broken || length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = zlib_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+
+    z->strm.next_in  = (Bytef*)in;
+    z->strm.avail_in = (uInt)in_len;
+    /* Z_NO_FLUSH: let zlib buffer for compression ratio. Emitting here
+     * is allowed but not required, so out_len is often 0. */
+    if (!zlib_stream_pump(z, Z_NO_FLUSH)) return 0;
+    /* All input must have been consumed; the pump only stops when zlib
+     * had output room spare, which implies it drained avail_in. */
+    return z->strm.avail_in == 0;
+}
+
+int zlib_try_stream_flush(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->finished || z->broken) return 0;
+    z->strm.next_in = NULL;
+    z->strm.avail_in = 0;
+    return zlib_stream_pump(z, Z_SYNC_FLUSH);
+}
+
+int zlib_try_stream_finish(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || z->broken) return 0;
+    if (z->finished) { z->out_len = 0; return 1; }  /* idempotent */
+    z->strm.next_in = NULL;
+    z->strm.avail_in = 0;
+    if (!zlib_stream_pump(z, Z_FINISH)) return 0;
+    z->finished = 1;
+    return 1;
+}
+
+const char* zlib_get_stream_bytes(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z || !z->out) return "";
+    return (const char*)z->out;
+}
+
+int zlib_get_stream_length(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    return z ? z->out_len : 0;
+}
+
+void zlib_release_stream(void* handle) {
+    ZlibStream* z = (ZlibStream*)handle;
+    if (!z) return;
+    deflateEnd(&z->strm);
+    if (z->out) aether_caps_free(z->out, z->out_cap);
+    aether_caps_free(z, sizeof(ZlibStream));
+}
+
 #else /* !AETHER_HAS_ZLIB */
 
 int zlib_try_deflate(const char* data, int length, int level) {
@@ -252,6 +402,24 @@ int zlib_try_gzip_deflate(const char* data, int length, int level) {
 int zlib_try_gzip_inflate(const char* data, int length) {
     (void)data; (void)length; return 0;
 }
+
+/* Streaming stubs. stream_new returns NULL, which is the one signal a
+ * caller cannot ignore: every other entry point requires a handle, so a
+ * program built without zlib fails at the point it asks for a stream
+ * rather than silently emitting nothing. (base64 in #1884 returned empty
+ * from its no-backend branch and callers shipped broken output for it --
+ * a stub must be visibly unavailable, not quietly useless.) */
+void* zlib_try_stream_new(int format, int level) {
+    (void)format; (void)level; return NULL;
+}
+int zlib_try_stream_write(void* handle, const char* data, int length) {
+    (void)handle; (void)data; (void)length; return 0;
+}
+int zlib_try_stream_flush(void* handle)  { (void)handle; return 0; }
+int zlib_try_stream_finish(void* handle) { (void)handle; return 0; }
+const char* zlib_get_stream_bytes(void* handle) { (void)handle; return ""; }
+int zlib_get_stream_length(void* handle) { (void)handle; return 0; }
+void zlib_release_stream(void* handle) { (void)handle; }
 
 #endif /* AETHER_HAS_ZLIB */
 

--- a/std/zlib/aether_zlib.h
+++ b/std/zlib/aether_zlib.h
@@ -60,4 +60,62 @@ void        zlib_release_inflate(void);
 int zlib_try_gzip_deflate(const char* data, int length, int level);
 int zlib_try_gzip_inflate(const char* data, int length);
 
+/* ---- Streaming deflate (#1890) ---------------------------------
+ *
+ * The one-shot calls above run deflateInit2 -> deflate(Z_FINISH) ->
+ * deflateEnd inside a single call, so each one necessarily emits a
+ * COMPLETE stream. That is wrong for a long-lived response: an SSE
+ * connection carrying many small events needs ONE deflate stream held
+ * open for the life of the connection, flushed at each event boundary,
+ * so the client sees a single continuous stream. Compressing each event
+ * independently produces N complete streams concatenated, which no
+ * `Content-Encoding: gzip` client will decode.
+ *
+ * The handle owns its own output buffer rather than sharing the TLS
+ * slots above: two streams may be open on one thread (two SSE
+ * connections served by one event loop), and TLS slots would let them
+ * overwrite each other's pending bytes.
+ *
+ * Lifecycle mirrors std.cryptography's streaming hashes:
+ *   s = stream_new(format, level)
+ *   stream_write(s, data, len)      -- buffer input, may emit nothing
+ *   stream_flush(s)                 -- Z_SYNC_FLUSH: emit a decodable
+ *                                      boundary, KEEP the window
+ *   stream_finish(s)                -- Z_FINISH: emit the tail
+ *   stream_free(s)
+ *
+ * After any of write/flush/finish returning 1, the bytes produced by
+ * THAT call are read with stream_get_bytes / stream_get_length. They
+ * stay valid until the next call on the same handle.
+ *
+ * `format`: 0 = raw deflate, 1 = zlib wrapper, 2 = gzip wrapper. These
+ * match the windowBits selection the one-shot calls already use. */
+#define AETHER_ZLIB_FORMAT_RAW  0
+#define AETHER_ZLIB_FORMAT_ZLIB 1
+#define AETHER_ZLIB_FORMAT_GZIP 2
+
+/* Returns an opaque handle, or NULL when zlib is absent, the format or
+ * level is out of range, or allocation fails. */
+void* zlib_try_stream_new(int format, int level);
+
+/* Feed `length` bytes. Returns 1 on success (possibly emitting nothing
+ * -- deflate buffers internally), 0 on error. */
+int zlib_try_stream_write(void* handle, const char* data, int length);
+
+/* Z_SYNC_FLUSH: emit everything buffered so far and end on a byte
+ * boundary the decoder can consume, WITHOUT ending the stream. This is
+ * the call that makes the whole thing work. Returns 1 on success. */
+int zlib_try_stream_flush(void* handle);
+
+/* Z_FINISH: emit the tail (and the gzip/zlib trailer). The handle
+ * accepts no further writes afterwards. Returns 1 on success. */
+int zlib_try_stream_finish(void* handle);
+
+/* Bytes produced by the most recent write/flush/finish on this handle.
+ * Borrowed; valid until the next call on the same handle. */
+const char* zlib_get_stream_bytes(void* handle);
+int         zlib_get_stream_length(void* handle);
+
+void zlib_release_stream(void* handle);
+
 #endif /* AETHER_ZLIB_H */

--- a/std/zlib/module.ae
+++ b/std/zlib/module.ae
@@ -27,7 +27,11 @@ exports(
     zlib_try_inflate, zlib_get_inflate_bytes, zlib_get_inflate_length,
     zlib_release_inflate,
     zlib_try_gzip_deflate, zlib_try_gzip_inflate,
-    available, deflate, inflate, gzip_deflate, gzip_inflate
+    zlib_try_stream_new, zlib_try_stream_write, zlib_try_stream_flush,
+    zlib_try_stream_finish, zlib_get_stream_bytes, zlib_get_stream_length,
+    zlib_release_stream,
+    available, deflate, inflate, gzip_deflate, gzip_inflate,
+    stream_new, stream_write, stream_flush, stream_finish, stream_free
 )
 
 // Probe: returns 1 when the toolchain was built with zlib detected,
@@ -53,6 +57,17 @@ extern zlib_release_inflate()
 
 extern zlib_try_gzip_deflate(data: string, length: int, level: int) -> int
 extern zlib_try_gzip_inflate(data: string, length: int) -> int
+
+// Streaming deflate (#1890). The handle keeps ONE deflate stream open
+// across many writes, so a long-lived response (an SSE connection, a
+// chunked body) is a single continuous stream the client can decode.
+extern zlib_try_stream_new(format: int, level: int) -> ptr
+extern zlib_try_stream_write(handle: ptr, data: string, length: int) -> int
+extern zlib_try_stream_flush(handle: ptr) -> int
+extern zlib_try_stream_finish(handle: ptr) -> int
+extern zlib_get_stream_bytes(handle: ptr) -> string
+extern zlib_get_stream_length(handle: ptr) -> int
+extern zlib_release_stream(handle: ptr)
 
 // Length-preserving string constructor from std.string — takes an
 // explicit byte count so binary payloads with embedded NULs survive
@@ -132,4 +147,87 @@ gzip_inflate(data: string, length: int) -> {
     owned = string_new_with_length(raw, n)
     zlib_release_inflate()
     return owned, n, ""
+}
+
+// ---- Streaming deflate (#1890) -------------------------------------
+//
+// The one-shot calls above each emit a COMPLETE stream, which is wrong
+// for a long-lived response: an SSE connection carrying many events
+// needs one stream held open and flushed at each event boundary. N
+// independently-compressed events concatenated is not a stream any
+// `Content-Encoding: gzip` client will decode.
+//
+//   s, err = zlib.stream_new(zlib.GZIP, 6)
+//   _, _, err = zlib.stream_write(s, event, string.length(event))
+//   chunk, n, err = zlib.stream_flush(s)     // send these bytes now
+//   ...                                       // more events, same stream
+//   tail, n, err = zlib.stream_finish(s)      // at connection close
+//   zlib.stream_free(s)
+
+// Framing for stream_new. RAW is bare DEFLATE (RFC 1951), ZLIB adds the
+// RFC 1950 wrapper, GZIP the RFC 1952 one -- the last is what
+// `Content-Encoding: gzip` means.
+const RAW = 0
+const ZLIB = 1
+const GZIP = 2
+
+// Open a stream. Returns (handle, "") on success, (null, error) when
+// zlib is absent, the format/level is out of range, or allocation
+// fails. Every other stream call needs the handle, so an unavailable
+// backend fails HERE rather than silently producing nothing later.
+stream_new(format: int, level: int) -> {
+    if zlib_backend_available() == 0 {
+        return null, "zlib unavailable"
+    }
+    h = zlib_try_stream_new(format, level)
+    if h == null {
+        return null, "zlib stream_new failed"
+    }
+    return h, ""
+}
+
+// Feed bytes into the stream. Returns (bytes, byte_count, "") -- and
+// the byte count is USUALLY 0, because deflate buffers internally for
+// compression ratio. Emit whatever comes back, then call stream_flush
+// when the event is complete.
+stream_write(handle: ptr, data: string, length: int) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_write(handle, data, length)
+    if ok == 0 { return "", 0, "zlib stream_write failed" }
+    return stream_take(handle)
+}
+
+// Z_SYNC_FLUSH: emit everything buffered and end on a byte boundary the
+// decoder can consume, WITHOUT closing the stream. This is the call
+// that makes per-event streaming work.
+stream_flush(handle: ptr) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_flush(handle)
+    if ok == 0 { return "", 0, "zlib stream_flush failed" }
+    return stream_take(handle)
+}
+
+// Z_FINISH: emit the tail and any trailer. The handle takes no further
+// writes; calling it twice is harmless and yields no bytes the second
+// time. Still requires stream_free afterwards.
+stream_finish(handle: ptr) -> {
+    if handle == null { return "", 0, "zlib stream: null handle" }
+    ok = zlib_try_stream_finish(handle)
+    if ok == 0 { return "", 0, "zlib stream_finish failed" }
+    return stream_take(handle)
+}
+
+// Copy the borrowed C buffer into an owned, length-aware AetherString.
+// Shared by write/flush/finish so the ownership rule lives in one place.
+stream_take(handle: ptr) -> {
+    raw = zlib_get_stream_bytes(handle)
+    n = zlib_get_stream_length(handle)
+    if n == 0 { return "", 0, "" }
+    owned = string_new_with_length(raw, n)
+    return owned, n, ""
+}
+
+// Release the handle. Safe on null.
+stream_free(handle: ptr) {
+    if handle != null { zlib_release_stream(handle) }
 }

--- a/std/zstd/README.md
+++ b/std/zstd/README.md
@@ -1,0 +1,61 @@
+# std.zstd
+
+Zstandard compression (RFC 8878) — streaming and one-shot.
+
+Zstandard is a different **format** from DEFLATE, not a faster implementation
+of it: this wraps **libzstd** (`apt install libzstd-dev`, `brew install zstd`)
+and has nothing to do with `std.zlib` beyond the similar library name.
+
+Its case is strongest away from the browser — archives, logs, snapshots,
+internal RPC — because `Content-Encoding: zstd` support is still thinner than
+`br` and `gzip`. It compresses harder than gzip at comparable speed, and
+decompresses faster than both.
+
+Compression only. Nothing in-tree needs to *decode* zstd, and a decoder is
+separate work.
+
+## Streaming
+
+The surface mirrors `std.zlib`'s and `std.brotli`'s, so a caller choosing an
+encoding writes the same shape whichever it picks:
+
+```
+s, err        = zstd.stream_new(zstd.DEFAULT_LEVEL)
+chunk, n, err = zstd.stream_write(s, ev, string.length(ev))
+chunk, n, err = zstd.stream_flush(s)      // send these bytes now
+tail,  n, err = zstd.stream_finish(s)     // close the frame
+                zstd.stream_free(s)
+```
+
+`stream_write` usually returns **0 bytes** — the encoder buffers internally for
+compression ratio. `stream_flush` emits a decodable boundary while keeping the
+window, so later events cost far less than the first: three repetitive events
+compress to 37, 12 and 13 bytes.
+
+A handle owns its output buffer, so two streams may be open on one thread
+without fighting over it. Always `stream_free`.
+
+## Level
+
+`level` is 1–22; **3 is libzstd's default** and a good general choice. Higher
+levels cost markedly more time for modest gains. Out-of-range values are
+clamped rather than rejected, matching `std.zlib`'s treatment of `level`.
+
+## One-shot
+
+```
+packed, n, err = zstd.compress(body, string.length(body), zstd.DEFAULT_LEVEL)
+```
+
+## When the backend is absent
+
+Built without libzstd, `available()` returns 0 and `stream_new` returns
+`(null, "zstd unavailable")`. Every other stream call needs the handle, so a
+program fails where it *asks for* a stream rather than silently emitting
+nothing.
+
+## Exports
+
+`available`, `compress`, `stream_new`, `stream_write`, `stream_flush`,
+`stream_finish`, `stream_free` (and the `MIN_LEVEL` / `MAX_LEVEL` /
+`DEFAULT_LEVEL` constants), plus the `zstd_*` raw forms.

--- a/std/zstd/aether_zstd.c
+++ b/std/zstd/aether_zstd.c
@@ -1,0 +1,226 @@
+#include "aether_zstd.h"
+#include "../string/aether_string.h"
+#include "../../runtime/aether_resource_caps.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef AETHER_HAS_ZSTD
+#include <zstd.h>
+#endif
+
+/* Unwrap a `data` argument that may be an AetherString* or a plain char*.
+ * Same helper shape as std/zlib, std/brotli and std/fs -- without this
+ * dispatch a length-aware AetherString leaks its struct header into the
+ * stream. */
+static inline const unsigned char* zstd_unwrap_bytes(const char* data, int length,
+                                                     size_t* out_len) {
+    if (!data) { *out_len = 0; return NULL; }
+    if (is_aether_string(data)) {
+        const AetherString* s = (const AetherString*)data;
+        *out_len = (length >= 0) ? (size_t)length : s->length;
+        return (const unsigned char*)s->data;
+    }
+    *out_len = (length >= 0) ? (size_t)length : strlen(data);
+    return (const unsigned char*)data;
+}
+
+/* One-shot output slot, thread-local like std.zlib's. Streaming output lives
+ * on the handle; see the header. */
+static _Thread_local unsigned char* tls_comp_buf = NULL;
+static _Thread_local size_t         tls_comp_cap = 0;
+static _Thread_local int            tls_comp_len = 0;
+
+static void free_comp_tls(void) {
+    if (tls_comp_buf) {
+        aether_caps_free(tls_comp_buf, tls_comp_cap);
+        tls_comp_buf = NULL;
+    }
+    tls_comp_cap = 0;
+    tls_comp_len = 0;
+}
+
+int zstd_backend_available(void) {
+#ifdef AETHER_HAS_ZSTD
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+#ifdef AETHER_HAS_ZSTD
+
+typedef struct {
+    ZSTD_CCtx* cctx;
+    unsigned char* out;     /* owned; bytes of the most recent call */
+    size_t out_cap;         /* allocator's view, for aether_caps_free */
+    int    out_len;         /* payload's view */
+    int    finished;
+    int    broken;
+} ZstdStream;
+
+static int clamp_level(int level) {
+    int lo = ZSTD_minCLevel();
+    int hi = ZSTD_maxCLevel();
+    if (level < lo || level > hi) return ZSTD_defaultCLevel();
+    return level;
+}
+
+/* Run ZSTD_compressStream2 with `op` until the input is consumed and zstd
+ * reports nothing left to flush.
+ *
+ * The termination condition is zstd's own and is a THIRD shape, different from
+ * both siblings: zlib stops when it left avail_out spare, brotli when
+ * BrotliEncoderHasMoreOutput goes false, and zstd when the call RETURNS 0 --
+ * "@return provides a minimum amount of data remaining to be flushed", so
+ * nonzero means go round again. Reusing either sibling's condition here would
+ * stop early and truncate the frame. */
+static int zstd_pump(ZstdStream* z, ZSTD_EndDirective op,
+                     const unsigned char* in, size_t in_len) {
+    if (!z || z->broken) return 0;
+
+    ZSTD_inBuffer inb = { in, in_len, 0 };
+    size_t used = 0;
+
+    if (z->out_cap < 256) {
+        size_t cap = ZSTD_CStreamOutSize();
+        if (cap < 256) cap = 256;
+        unsigned char* nb = (unsigned char*)aether_caps_malloc(cap);
+        if (!nb) { z->broken = 1; return 0; }
+        if (z->out) aether_caps_free(z->out, z->out_cap);
+        z->out = nb;
+        z->out_cap = cap;
+    }
+
+    for (;;) {
+        ZSTD_outBuffer outb = { z->out, z->out_cap, used };
+        size_t remaining = ZSTD_compressStream2(z->cctx, &outb, &inb, op);
+        if (ZSTD_isError(remaining)) { z->broken = 1; return 0; }
+        used = outb.pos;
+
+        /* Done when the input is drained and zstd says nothing is pending. */
+        if (inb.pos == inb.size && remaining == 0) break;
+
+        /* Only grow when the buffer is actually full; otherwise zstd simply
+         * wants another pass with the room it already has. */
+        if (outb.pos == outb.size) {
+            size_t ncap = z->out_cap * 2;
+            if (ncap > (size_t)1 << 30) { z->broken = 1; return 0; }
+            unsigned char* nb = (unsigned char*)aether_caps_malloc(ncap);
+            if (!nb) { z->broken = 1; return 0; }
+            memcpy(nb, z->out, used);
+            aether_caps_free(z->out, z->out_cap);
+            z->out = nb;
+            z->out_cap = ncap;
+        }
+    }
+
+    z->out_len = (int)used;
+    return 1;
+}
+
+void* zstd_try_stream_new(int level) {
+    ZstdStream* z = (ZstdStream*)aether_caps_calloc(1, sizeof(ZstdStream));
+    if (!z) return NULL;
+    z->cctx = ZSTD_createCCtx();
+    if (!z->cctx) {
+        aether_caps_free(z, sizeof(ZstdStream));
+        return NULL;
+    }
+    ZSTD_CCtx_setParameter(z->cctx, ZSTD_c_compressionLevel, clamp_level(level));
+    return z;
+}
+
+int zstd_try_stream_write(void* handle, const char* data, int length) {
+    ZstdStream* z = (ZstdStream*)handle;
+    if (!z || z->finished || z->broken || length < 0) return 0;
+    size_t in_len;
+    const unsigned char* in = zstd_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+    return zstd_pump(z, ZSTD_e_continue, in, in_len);
+}
+
+int zstd_try_stream_flush(void* handle) {
+    ZstdStream* z = (ZstdStream*)handle;
+    if (!z || z->finished || z->broken) return 0;
+    return zstd_pump(z, ZSTD_e_flush, NULL, 0);
+}
+
+int zstd_try_stream_finish(void* handle) {
+    ZstdStream* z = (ZstdStream*)handle;
+    if (!z || z->broken) return 0;
+    if (z->finished) { z->out_len = 0; return 1; }   /* idempotent */
+    if (!zstd_pump(z, ZSTD_e_end, NULL, 0)) return 0;
+    z->finished = 1;
+    return 1;
+}
+
+const char* zstd_get_stream_bytes(void* handle) {
+    ZstdStream* z = (ZstdStream*)handle;
+    if (!z || !z->out) return "";
+    return (const char*)z->out;
+}
+
+int zstd_get_stream_length(void* handle) {
+    ZstdStream* z = (ZstdStream*)handle;
+    return z ? z->out_len : 0;
+}
+
+void zstd_release_stream(void* handle) {
+    ZstdStream* z = (ZstdStream*)handle;
+    if (!z) return;
+    if (z->cctx) ZSTD_freeCCtx(z->cctx);
+    if (z->out) aether_caps_free(z->out, z->out_cap);
+    aether_caps_free(z, sizeof(ZstdStream));
+}
+
+int zstd_try_compress(const char* data, int length, int level) {
+    free_comp_tls();
+    if (length < 0) return 0;
+
+    size_t in_len;
+    const unsigned char* in = zstd_unwrap_bytes(data, length, &in_len);
+    if (in_len > 0 && !in) return 0;
+
+    size_t bound = ZSTD_compressBound(in_len);
+    if (ZSTD_isError(bound) || bound == 0) return 0;
+    unsigned char* out = (unsigned char*)aether_caps_malloc(bound);
+    if (!out) return 0;
+
+    size_t n = ZSTD_compress(out, bound, in, in_len, clamp_level(level));
+    if (ZSTD_isError(n)) { aether_caps_free(out, bound); return 0; }
+
+    tls_comp_buf = out;
+    tls_comp_cap = bound;
+    tls_comp_len = (int)n;
+    return 1;
+}
+
+#else /* !AETHER_HAS_ZSTD */
+
+/* stream_new returning NULL is the signal a caller cannot ignore: every other
+ * stream entry point needs a handle, so a program built without zstd fails
+ * where it ASKS for a stream rather than silently emitting nothing. (base64 in
+ * #1884 returned empty from its no-backend branch and callers shipped broken
+ * output for it.) */
+void* zstd_try_stream_new(int level) { (void)level; return NULL; }
+int zstd_try_stream_write(void* handle, const char* data, int length) {
+    (void)handle; (void)data; (void)length; return 0;
+}
+int zstd_try_stream_flush(void* handle)  { (void)handle; return 0; }
+int zstd_try_stream_finish(void* handle) { (void)handle; return 0; }
+const char* zstd_get_stream_bytes(void* handle) { (void)handle; return ""; }
+int zstd_get_stream_length(void* handle) { (void)handle; return 0; }
+void zstd_release_stream(void* handle) { (void)handle; }
+
+int zstd_try_compress(const char* data, int length, int level) {
+    (void)data; (void)length; (void)level; return 0;
+}
+
+#endif /* AETHER_HAS_ZSTD */
+
+const char* zstd_get_compress_bytes(void) {
+    return (const char*)(tls_comp_buf ? tls_comp_buf : (unsigned char*)"");
+}
+int  zstd_get_compress_length(void) { return tls_comp_len; }
+void zstd_release_compress(void)    { free_comp_tls(); }

--- a/std/zstd/aether_zstd.c
+++ b/std/zstd/aether_zstd.c
@@ -60,9 +60,17 @@ typedef struct {
 } ZstdStream;
 
 static int clamp_level(int level) {
-    int lo = ZSTD_minCLevel();
+    /* ZSTD_maxCLevel() is present in every libzstd. ZSTD_minCLevel() needs
+     * v1.4.0+, and this file already tripped over a version-gated symbol
+     * (ZSTD_defaultCLevel, v1.5.0+) breaking every older-libzstd CI box, so
+     * take the documented floor of 1 rather than call it. Negative levels are
+     * a zstd extension we deliberately do not expose. */
+    int lo = 1;
     int hi = ZSTD_maxCLevel();
-    if (level < lo || level > hi) return ZSTD_defaultCLevel();
+    /* ZSTD_CLEVEL_DEFAULT is a plain macro (guarded, 3) present in every
+     * libzstd; ZSTD_defaultCLevel() is a function requiring v1.5.0+, and
+     * calling it broke the build on every CI box with an older library. */
+    if (level < lo || level > hi) return ZSTD_CLEVEL_DEFAULT;
     return level;
 }
 

--- a/std/zstd/aether_zstd.h
+++ b/std/zstd/aether_zstd.h
@@ -1,0 +1,52 @@
+/* std.zstd — Zstandard compression (RFC 8878), streaming and one-shot.
+ *
+ * Zstandard is a different FORMAT from DEFLATE, not a faster implementation of
+ * it: this module wraps libzstd and has nothing to do with std.zlib beyond the
+ * similar library name. Its case is strongest away from the browser --
+ * archives, logs, snapshots, internal RPC -- because `Content-Encoding: zstd`
+ * support is still thin compared with `br` and `gzip`. It compresses harder
+ * than gzip at comparable speed, and decompresses faster than both.
+ *
+ * The surface mirrors std.zlib's and std.brotli's streaming shape, so a caller
+ * choosing an encoding writes the same code whichever it picks:
+ *
+ *   s = stream_new(level)
+ *   stream_write(s, data, len)   -- buffer input, may emit nothing
+ *   stream_flush(s)              -- emit a decodable boundary, KEEP the window
+ *   stream_finish(s)             -- close the frame
+ *   stream_free(s)
+ *
+ * As there, the handle owns its output buffer rather than sharing a
+ * thread-local slot, so two streams may be open on one thread.
+ *
+ * Without libzstd (AETHER_HAS_ZSTD undefined) zstd_try_stream_new returns NULL
+ * and the one-shot try_ entry points return 0, so a caller sees "zstd
+ * unavailable" rather than silently shipping empty output.
+ */
+
+#ifndef AETHER_ZSTD_H
+#define AETHER_ZSTD_H
+
+int zstd_backend_available(void);
+
+/* `level` is 1..22 (libzstd's own range; 3 is its default). Values outside it
+ * are clamped rather than rejected, matching std.zlib's treatment of `level`
+ * and std.brotli's of `quality`. */
+void* zstd_try_stream_new(int level);
+int   zstd_try_stream_write(void* handle, const char* data, int length);
+int   zstd_try_stream_flush(void* handle);
+int   zstd_try_stream_finish(void* handle);
+
+/* Bytes produced by the most recent write/flush/finish on this handle.
+ * Borrowed; valid until the next call on the same handle. */
+const char* zstd_get_stream_bytes(void* handle);
+int         zstd_get_stream_length(void* handle);
+void        zstd_release_stream(void* handle);
+
+/* One-shot, for a body already in memory. Split-accessor shape, as std.zlib. */
+int         zstd_try_compress(const char* data, int length, int level);
+const char* zstd_get_compress_bytes(void);
+int         zstd_get_compress_length(void);
+void        zstd_release_compress(void);
+
+#endif /* AETHER_ZSTD_H */

--- a/std/zstd/module.ae
+++ b/std/zstd/module.ae
@@ -1,0 +1,134 @@
+// std.zstd — Zstandard compression (RFC 8878), streaming and one-shot.
+//
+// Zstandard is a different FORMAT from DEFLATE, not a faster implementation of
+// it: this wraps libzstd and has nothing to do with std.zlib beyond the
+// similar library name. Its case is strongest away from the browser —
+// archives, logs, snapshots, internal RPC — because `Content-Encoding: zstd`
+// support is thinner than `br` and `gzip`. It compresses harder than gzip at
+// comparable speed and decompresses faster than both.
+//
+// The streaming surface mirrors std.zlib's and std.brotli's, so a caller
+// choosing an encoding writes the same shape whichever it picks:
+//
+//   s, err = zstd.stream_new(zstd.DEFAULT_LEVEL)
+//   chunk, n, err = zstd.stream_write(s, ev, string.length(ev))
+//   chunk, n, err = zstd.stream_flush(s)     // send these bytes now
+//   tail,  n, err = zstd.stream_finish(s)    // close the frame
+//   zstd.stream_free(s)
+//
+// Compression only, as with std.brotli: nothing in-tree needs to decode zstd.
+
+exports(
+    zstd_backend_available,
+    zstd_try_stream_new, zstd_try_stream_write, zstd_try_stream_flush,
+    zstd_try_stream_finish, zstd_get_stream_bytes, zstd_get_stream_length,
+    zstd_release_stream,
+    zstd_try_compress, zstd_get_compress_bytes, zstd_get_compress_length,
+    zstd_release_compress,
+    available, compress,
+    stream_new, stream_write, stream_flush, stream_finish, stream_free
+)
+
+extern zstd_backend_available() -> int
+
+extern zstd_try_stream_new(level: int) -> ptr
+extern zstd_try_stream_write(handle: ptr, data: string, length: int) -> int
+extern zstd_try_stream_flush(handle: ptr) -> int
+extern zstd_try_stream_finish(handle: ptr) -> int
+extern zstd_get_stream_bytes(handle: ptr) -> string
+extern zstd_get_stream_length(handle: ptr) -> int
+extern zstd_release_stream(handle: ptr)
+
+extern zstd_try_compress(data: string, length: int, level: int) -> int
+extern zstd_get_compress_bytes() -> string
+extern zstd_get_compress_length() -> int
+extern zstd_release_compress()
+
+// Length-preserving string constructor from std.string — takes an explicit
+// byte count so binary payloads with embedded NULs survive the copy out of
+// the borrowed C buffer into an owned AetherString.
+extern string_new_with_length(data: string, length: int) -> ptr
+
+// libzstd's own range. 3 is its default and a good general choice; higher
+// levels cost markedly more time for modest gains.
+const MIN_LEVEL = 1
+const MAX_LEVEL = 22
+const DEFAULT_LEVEL = 3
+
+// 1 when the toolchain was built with libzstd detected. Use it to skip a test
+// or pick a fallback encoding rather than threading an error everywhere.
+available() -> int { return zstd_backend_available() }
+
+// One-shot: compress a body already in memory. Returns (bytes, count, "") on
+// success, ("", 0, error) otherwise. Level out of range is clamped.
+compress(data: string, length: int, level: int) -> {
+    if zstd_backend_available() == 0 {
+        return "", 0, "zstd unavailable"
+    }
+    ok = zstd_try_compress(data, length, level)
+    if ok == 0 {
+        return "", 0, "zstd compress failed"
+    }
+    raw = zstd_get_compress_bytes()
+    n = zstd_get_compress_length()
+    owned = string_new_with_length(raw, n)
+    zstd_release_compress()
+    return owned, n, ""
+}
+
+// Open a stream. Returns (handle, "") or (null, error) — an unavailable
+// backend fails HERE, not silently later, because every other stream call
+// needs the handle.
+stream_new(level: int) -> {
+    if zstd_backend_available() == 0 {
+        return null, "zstd unavailable"
+    }
+    h = zstd_try_stream_new(level)
+    if h == null {
+        return null, "zstd stream_new failed"
+    }
+    return h, ""
+}
+
+// Feed bytes. Returns (bytes, count, "") — the count is usually 0, because
+// the encoder buffers internally for compression ratio. Emit whatever comes
+// back, then stream_flush when the event is complete.
+stream_write(handle: ptr, data: string, length: int) -> {
+    if handle == null { return "", 0, "zstd stream: null handle" }
+    ok = zstd_try_stream_write(handle, data, length)
+    if ok == 0 { return "", 0, "zstd stream_write failed" }
+    return stream_take(handle)
+}
+
+// Emit everything buffered so far at a boundary the decoder can consume,
+// WITHOUT ending the frame. This is what makes per-event streaming work.
+stream_flush(handle: ptr) -> {
+    if handle == null { return "", 0, "zstd stream: null handle" }
+    ok = zstd_try_stream_flush(handle)
+    if ok == 0 { return "", 0, "zstd stream_flush failed" }
+    return stream_take(handle)
+}
+
+// Close the frame. The handle takes no further writes; calling it twice is
+// harmless and yields no bytes the second time. Still needs stream_free.
+stream_finish(handle: ptr) -> {
+    if handle == null { return "", 0, "zstd stream: null handle" }
+    ok = zstd_try_stream_finish(handle)
+    if ok == 0 { return "", 0, "zstd stream_finish failed" }
+    return stream_take(handle)
+}
+
+// Copy the borrowed C buffer into an owned, length-aware AetherString.
+// Shared by write/flush/finish so the ownership rule lives in one place.
+stream_take(handle: ptr) -> {
+    raw = zstd_get_stream_bytes(handle)
+    n = zstd_get_stream_length(handle)
+    if n == 0 { return "", 0, "" }
+    owned = string_new_with_length(raw, n)
+    return owned, n, ""
+}
+
+// Release the handle. Safe on null.
+stream_free(handle: ptr) {
+    if handle != null { zstd_release_stream(handle) }
+}

--- a/tests/integration/brotli_streaming/prog.ae
+++ b/tests/integration/brotli_streaming/prog.ae
@@ -1,0 +1,66 @@
+// #1891: brotli streaming — one stream held open across many flushes.
+//
+// Same shape and same assertion as the zlib streaming test: the point is not
+// that one chunk round-trips (independent per-event compression does that too
+// and is still broken), but that every flushed chunk CONCATENATED is one
+// continuous stream, and that later events cost far less than the first
+// because the window is shared.
+import std.brotli
+import std.string
+
+main() {
+    if brotli.available() == 0 {
+        println("brotli streaming ok (skipped: no backend)")
+        return 0
+    }
+
+    s, err = brotli.stream_new(brotli.FAST_QUALITY, 0)
+    if err != "" { println("FAIL stream_new: ${err}") return 1 }
+
+    all = ""
+    first = 0
+    later = 0
+
+    i = 0
+    while i < 4 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        c1, n1, e1 = brotli.stream_write(s, ev, string.length(ev))
+        if e1 != "" { println("FAIL stream_write: ${e1}") return 1 }
+        if n1 > 0 { all = string.concat(all, c1) }
+
+        c2, n2, e2 = brotli.stream_flush(s)
+        if e2 != "" { println("FAIL stream_flush: ${e2}") return 1 }
+        if n2 > 0 { all = string.concat(all, c2) }
+
+        // A flush must emit something, or the peer sees nothing until close.
+        if n1 + n2 == 0 { println("FAIL: flush ${i} emitted nothing") return 1 }
+        if i == 0 { first = n1 + n2 } else { later = later + n1 + n2 }
+        i = i + 1
+    }
+
+    t, tn, e3 = brotli.stream_finish(s)
+    if e3 != "" { println("FAIL stream_finish: ${e3}") return 1 }
+    if tn > 0 { all = string.concat(all, t) }
+    brotli.stream_free(s)
+
+    total = string.length(all)
+    if total == 0 { println("FAIL: produced no output") return 1 }
+
+    // The window must be SHARED: three repeats of near-identical text must
+    // cost far less than the first event. N independent streams would each
+    // cost about the same, which is the bug this guards.
+    if later >= first * 3 {
+        println("FAIL: later flushes cost ${later} vs first ${first} —")
+        println("      the window does not look shared across flushes")
+        return 1
+    }
+
+    // One-shot must work too, and beat the input on repetitive text.
+    body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    c, cn, e4 = brotli.compress(body, string.length(body), brotli.FAST_QUALITY)
+    if e4 != "" { println("FAIL compress: ${e4}") return 1 }
+    if cn >= string.length(body) { println("FAIL: one-shot did not compress") return 1 }
+
+    println("brotli streaming ok")
+    return 0
+}

--- a/tests/integration/brotli_streaming/test_brotli_streaming.sh
+++ b/tests/integration/brotli_streaming/test_brotli_streaming.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# #1891: brotli streaming holds ONE stream open across many flushes.
+#
+# `br` is what browsers actually prefer over gzip, so this is the higher-value
+# codec for HTTP. The surface deliberately mirrors std.zlib's streaming
+# deflate, so a server negotiating br vs gzip writes the same shape either way.
+#
+# Two assertions, as with the zlib test:
+#   1. every flushed chunk concatenated is ONE stream, and later events cost
+#      far less than the first -- proving a shared window rather than N
+#      independent streams (prog.ae);
+#   2. an INDEPENDENT decoder accepts the bytes. We only have an encoder, so
+#      this uses the system libbrotlidec directly: our encoder agreeing with
+#      itself would prove nothing about RFC 7932 framing.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] brotli_streaming: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+OUT=$("$AE" run "$SCRIPT_DIR/prog.ae" 2>&1) || {
+    echo "  [FAIL] brotli_streaming: did not build/run"
+    echo "$OUT" | sed 's/^/    /' | head -12
+    exit 1
+}
+case "$OUT" in
+    *"skipped: no backend"*)
+        echo "  [SKIP] brotli_streaming: no libbrotlienc"; exit 0 ;;
+    *"brotli streaming ok"*) ;;
+    *)
+        echo "  [FAIL] brotli_streaming: assertions did not pass"
+        echo "$OUT" | sed 's/^/    /' | head -12
+        exit 1 ;;
+esac
+
+# --- 2. an independent decoder must accept the framing ------------------
+if ! pkg-config --exists libbrotlidec 2>/dev/null; then
+    echo "  [PASS] brotli_streaming: one stream across flushes (no libbrotlidec, external check skipped)"
+    exit 0
+fi
+
+# Heredoc UNQUOTED so $TMP expands; Aether ${...} escaped as \${...}.
+# (Written rather than sed-patched: BSD `sed -i` needs a backup suffix and
+# GNU sed does not, so a substitution here breaks on one platform or the
+# other -- the same trap tests/integration/cache_symlinked_lib_edit notes.)
+cat > "$TMP/emit.ae" <<AEOF
+import std.brotli
+import std.string
+import std.fs
+
+main() {
+    if brotli.available() == 0 { return 0 }
+    s, err = brotli.stream_new(5, 0)
+    if err != "" { println("new: \${err}") return 1 }
+    all = ""
+    i = 0
+    while i < 3 {
+        ev = "event: patch\ndata: chunk-\${i}\n\n"
+        c1, n1, e1 = brotli.stream_write(s, ev, string.length(ev))
+        if n1 > 0 { all = string.concat(all, c1) }
+        c2, n2, e2 = brotli.stream_flush(s)
+        if n2 > 0 { all = string.concat(all, c2) }
+        i = i + 1
+    }
+    t, tn, e3 = brotli.stream_finish(s)
+    if tn > 0 { all = string.concat(all, t) }
+    brotli.stream_free(s)
+    werr = fs.write_binary("$TMP/out.br", all, string.length(all))
+    if werr != "" { println("write: \${werr}") return 1 }
+    return 0
+}
+AEOF
+
+"$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
+    echo "  [FAIL] brotli_streaming: fixture did not run"
+    sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }
+[ -f "$TMP/out.br" ] || { echo "  [FAIL] brotli_streaming: no .br written"; exit 1; }
+
+cat > "$TMP/dec.c" <<'CEOF'
+#include <stdio.h>
+#include <brotli/decode.h>
+int main(int argc, char** argv) {
+    if (argc < 2) return 2;
+    FILE* f = fopen(argv[1], "rb"); if (!f) return 2;
+    static unsigned char in[1<<20]; size_t n = fread(in, 1, sizeof(in), f); fclose(f);
+    static unsigned char out[1<<20]; size_t out_n = sizeof(out);
+    if (BrotliDecoderDecompress(n, in, &out_n, out) != BROTLI_DECODER_RESULT_SUCCESS) {
+        fprintf(stderr, "decode failed\n"); return 1;
+    }
+    fwrite(out, 1, out_n, stdout);
+    return 0;
+}
+CEOF
+CC_BIN="${CC:-cc}"
+if ! "$CC_BIN" -o "$TMP/dec" "$TMP/dec.c" $(pkg-config --cflags --libs libbrotlidec) >"$TMP/cc.log" 2>&1; then
+    echo "  [PASS] brotli_streaming: one stream across flushes (decoder probe would not build, external check skipped)"
+    exit 0
+fi
+
+GOT=$("$TMP/dec" "$TMP/out.br" 2>"$TMP/dec.err") || {
+    echo "  [FAIL] brotli_streaming: an independent brotli decoder REJECTED the stream"
+    sed 's/^/    /' "$TMP/dec.err" | head -5
+    exit 1; }
+
+for n in 0 1 2; do
+    case "$GOT" in
+        *"chunk-$n"*) ;;
+        *) echo "  [FAIL] brotli_streaming: decoder output missing chunk-$n"; exit 1 ;;
+    esac
+done
+
+echo "  [PASS] brotli_streaming: one stream across flushes, and libbrotlidec reads it"

--- a/tests/integration/brotli_streaming/test_brotli_streaming.sh
+++ b/tests/integration/brotli_streaming/test_brotli_streaming.sh
@@ -45,6 +45,15 @@ fi
 # (Written rather than sed-patched: BSD `sed -i` needs a backup suffix and
 # GNU sed does not, so a substitution here breaks on one platform or the
 # other -- the same trap tests/integration/cache_symlinked_lib_edit notes.)
+# The fixture writes through the NATIVE `ae`, which on MSYS does not understand
+# an /tmp/... MSYS path -- fs.write_binary just reports "binary write failed".
+# Convert with cygpath where it exists, as http_middleware_d2 does.
+if command -v cygpath >/dev/null 2>&1; then
+    OUT_BR="$(cygpath -m "$TMP")/out.br"
+else
+    OUT_BR="$TMP/out.br"
+fi
+
 cat > "$TMP/emit.ae" <<AEOF
 import std.brotli
 import std.string
@@ -67,7 +76,7 @@ main() {
     t, tn, e3 = brotli.stream_finish(s)
     if tn > 0 { all = string.concat(all, t) }
     brotli.stream_free(s)
-    werr = fs.write_binary("$TMP/out.br", all, string.length(all))
+    werr = fs.write_binary("$OUT_BR", all, string.length(all))
     if werr != "" { println("write: \${werr}") return 1 }
     return 0
 }

--- a/tests/integration/zlib_streaming_deflate/prog.ae
+++ b/tests/integration/zlib_streaming_deflate/prog.ae
@@ -1,0 +1,76 @@
+// #1890: streaming deflate — one stream held open across many flushes.
+//
+// The one-shot calls each emit a COMPLETE stream, which is wrong for a
+// long-lived response: an SSE connection carrying many small events needs ONE
+// deflate stream, flushed at each event boundary, so the client sees a single
+// continuous stream. N independently-compressed events concatenated is not
+// something any `Content-Encoding: gzip` client will decode.
+//
+// The assertion that matters is therefore NOT a round-trip of one chunk --
+// per-event compression passes that and is still broken. It is that every
+// flushed chunk CONCATENATED decodes as one stream.
+import std.zlib
+import std.string
+
+main() {
+    if zlib.available() == 0 {
+        println("zlib streaming ok (skipped: no backend)")
+        return 0
+    }
+
+    s, err = zlib.stream_new(zlib.GZIP, 6)
+    if err != "" { println("FAIL stream_new: ${err}") return 1 }
+
+    expected = ""
+    all = ""
+    first_flush = 0
+    later_flush = 0
+
+    i = 0
+    while i < 4 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        expected = string.concat(expected, ev)
+
+        c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
+        if e1 != "" { println("FAIL stream_write: ${e1}") return 1 }
+        if n1 > 0 { all = string.concat(all, c1) }
+
+        c2, n2, e2 = zlib.stream_flush(s)
+        if e2 != "" { println("FAIL stream_flush: ${e2}") return 1 }
+        if n2 > 0 { all = string.concat(all, c2) }
+
+        // A flush must actually emit something, or the peer never sees
+        // the event until the connection closes -- which is the whole bug.
+        if n1 + n2 == 0 { println("FAIL: flush ${i} emitted nothing") return 1 }
+        if i == 0 { first_flush = n1 + n2 } else { later_flush = later_flush + n1 + n2 }
+        i = i + 1
+    }
+
+    t, tn, e3 = zlib.stream_finish(s)
+    if e3 != "" { println("FAIL stream_finish: ${e3}") return 1 }
+    if tn > 0 { all = string.concat(all, t) }
+    zlib.stream_free(s)
+
+    total = string.length(all)
+
+    // THE test: the whole concatenation decodes as ONE gzip stream.
+    out, on, e4 = zlib.gzip_inflate(all, total)
+    if e4 != "" { println("FAIL: concatenated chunks did not decode: ${e4}") return 1 }
+    if out != expected {
+        println("FAIL: decoded ${on} bytes, content mismatch")
+        return 1
+    }
+
+    // The window must be SHARED across flushes: later events repeat the
+    // earlier ones almost exactly, so they must cost far less than the
+    // first. Independent per-event compression would cost about the same
+    // each time -- this is what distinguishes streaming from N streams.
+    if later_flush >= first_flush * 3 {
+        println("FAIL: later flushes cost ${later_flush} vs first ${first_flush} —")
+        println("      the window does not look shared across flushes")
+        return 1
+    }
+
+    println("zlib streaming ok")
+    return 0
+}

--- a/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
+++ b/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
@@ -41,7 +41,17 @@ if ! command -v gunzip >/dev/null 2>&1; then
     exit 0
 fi
 
-# Heredoc is UNQUOTED so $TMP expands here; ${...} in the Aether source is
+# The fixture writes through the NATIVE `ae`, which on MSYS does not understand
+# an /tmp/... MSYS path -- fs.write_binary just reports "binary write failed".
+# Convert with cygpath where it exists, as tests/integration/http_middleware_d2
+# does for the same reason.
+if command -v cygpath >/dev/null 2>&1; then
+    OUT_GZ="$(cygpath -m "$TMP")/out.gz"
+else
+    OUT_GZ="$TMP/out.gz"
+fi
+
+# Heredoc is UNQUOTED so $OUT_GZ expands here; ${...} in the Aether source is
 # escaped as \${...} so the shell leaves interpolation alone.
 cat > "$TMP/emit.ae" <<AEOF
 import std.zlib
@@ -65,7 +75,7 @@ main() {
     t, tn, e3 = zlib.stream_finish(s)
     if tn > 0 { all = string.concat(all, t) }
     zlib.stream_free(s)
-    werr = fs.write_binary("$TMP/out.gz", all, string.length(all))
+    werr = fs.write_binary("$OUT_GZ", all, string.length(all))
     if werr != "" { println("write: \${werr}") return 1 }
     return 0
 }

--- a/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
+++ b/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# #1890: streaming deflate holds ONE stream open across many flushes.
+#
+# The one-shot calls each emit a complete stream. A long-lived response (SSE,
+# a chunked body) needs one stream flushed at each event boundary, or the
+# client gets N concatenated streams and refuses them.
+#
+# Two assertions, because the in-process one alone is not enough:
+#   1. every flushed chunk, concatenated, decodes as ONE stream (prog.ae),
+#      and later flushes cost far less than the first -- proving the window
+#      is shared rather than N independent streams;
+#   2. real `gunzip` accepts the bytes. Our own inflate agreeing with our own
+#      deflate would prove very little; the point of RFC 1952 framing is that
+#      a foreign decoder reads it.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] zlib_streaming_deflate: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+OUT=$("$AE" run "$SCRIPT_DIR/prog.ae" 2>&1) || {
+    echo "  [FAIL] zlib_streaming_deflate: did not build/run"
+    echo "$OUT" | sed 's/^/    /' | head -12
+    exit 1
+}
+case "$OUT" in
+    *"skipped: no backend"*)
+        echo "  [SKIP] zlib_streaming_deflate: no zlib backend"; exit 0 ;;
+    *"zlib streaming ok"*) ;;
+    *)
+        echo "  [FAIL] zlib_streaming_deflate: assertions did not pass"
+        echo "$OUT" | sed 's/^/    /' | head -12
+        exit 1 ;;
+esac
+
+# --- 2. a FOREIGN decoder must accept the framing -----------------------
+if ! command -v gunzip >/dev/null 2>&1; then
+    echo "  [PASS] zlib_streaming_deflate: one stream across flushes (gunzip absent, external check skipped)"
+    exit 0
+fi
+
+cat > "$TMP/emit.ae" <<'AEOF'
+import std.zlib
+import std.string
+import std.fs
+
+main() {
+    if zlib.available() == 0 { return 0 }
+    s, err = zlib.stream_new(zlib.GZIP, 6)
+    if err != "" { println("new: ${err}") return 1 }
+    all = ""
+    i = 0
+    while i < 3 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
+        if n1 > 0 { all = string.concat(all, c1) }
+        c2, n2, e2 = zlib.stream_flush(s)
+        if n2 > 0 { all = string.concat(all, c2) }
+        i = i + 1
+    }
+    t, tn, e3 = zlib.stream_finish(s)
+    if tn > 0 { all = string.concat(all, t) }
+    zlib.stream_free(s)
+    werr = fs.write_binary(OUT_PATH, all, string.length(all))
+    if werr != "" { println("write: ${werr}") return 1 }
+    return 0
+}
+AEOF
+# Substitute the output path (no argv plumbing needed for a fixture).
+sed -i "s|OUT_PATH|\"$TMP/out.gz\"|" "$TMP/emit.ae"
+
+"$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
+    echo "  [FAIL] zlib_streaming_deflate: fixture did not run"
+    sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }
+[ -f "$TMP/out.gz" ] || { echo "  [FAIL] zlib_streaming_deflate: no .gz written"; exit 1; }
+
+GOT=$(gunzip -c "$TMP/out.gz" 2>"$TMP/gz.err") || {
+    echo "  [FAIL] zlib_streaming_deflate: real gunzip REJECTED the stream"
+    sed 's/^/    /' "$TMP/gz.err" | head -5
+    exit 1; }
+
+# All three events must be there, in order.
+for n in 0 1 2; do
+    case "$GOT" in
+        *"chunk-$n"*) ;;
+        *) echo "  [FAIL] zlib_streaming_deflate: gunzip output missing chunk-$n"; exit 1 ;;
+    esac
+done
+
+echo "  [PASS] zlib_streaming_deflate: one stream across flushes, and real gunzip reads it"

--- a/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
+++ b/tests/integration/zlib_streaming_deflate/test_zlib_streaming_deflate.sh
@@ -41,7 +41,9 @@ if ! command -v gunzip >/dev/null 2>&1; then
     exit 0
 fi
 
-cat > "$TMP/emit.ae" <<'AEOF'
+# Heredoc is UNQUOTED so $TMP expands here; ${...} in the Aether source is
+# escaped as \${...} so the shell leaves interpolation alone.
+cat > "$TMP/emit.ae" <<AEOF
 import std.zlib
 import std.string
 import std.fs
@@ -49,11 +51,11 @@ import std.fs
 main() {
     if zlib.available() == 0 { return 0 }
     s, err = zlib.stream_new(zlib.GZIP, 6)
-    if err != "" { println("new: ${err}") return 1 }
+    if err != "" { println("new: \${err}") return 1 }
     all = ""
     i = 0
     while i < 3 {
-        ev = "event: patch\ndata: chunk-${i}\n\n"
+        ev = "event: patch\ndata: chunk-\${i}\n\n"
         c1, n1, e1 = zlib.stream_write(s, ev, string.length(ev))
         if n1 > 0 { all = string.concat(all, c1) }
         c2, n2, e2 = zlib.stream_flush(s)
@@ -63,14 +65,11 @@ main() {
     t, tn, e3 = zlib.stream_finish(s)
     if tn > 0 { all = string.concat(all, t) }
     zlib.stream_free(s)
-    werr = fs.write_binary(OUT_PATH, all, string.length(all))
-    if werr != "" { println("write: ${werr}") return 1 }
+    werr = fs.write_binary("$TMP/out.gz", all, string.length(all))
+    if werr != "" { println("write: \${werr}") return 1 }
     return 0
 }
 AEOF
-# Substitute the output path (no argv plumbing needed for a fixture).
-sed -i "s|OUT_PATH|\"$TMP/out.gz\"|" "$TMP/emit.ae"
-
 "$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
     echo "  [FAIL] zlib_streaming_deflate: fixture did not run"
     sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }

--- a/tests/integration/zstd_streaming/prog.ae
+++ b/tests/integration/zstd_streaming/prog.ae
@@ -1,0 +1,67 @@
+// #1891: zstd streaming — one frame held open across many flushes.
+//
+// Zstandard is a different FORMAT from DEFLATE, not a faster zlib. Same shape
+// and same assertion as the zlib and brotli streaming tests: the point is not
+// that one chunk round-trips (independent per-event compression does that too
+// and is still broken), but that every flushed chunk CONCATENATED is one
+// continuous stream, and that later events cost far less than the first
+// because the window is shared.
+import std.zstd
+import std.string
+
+main() {
+    if zstd.available() == 0 {
+        println("zstd streaming ok (skipped: no backend)")
+        return 0
+    }
+
+    s, err = zstd.stream_new(zstd.DEFAULT_LEVEL)
+    if err != "" { println("FAIL stream_new: ${err}") return 1 }
+
+    all = ""
+    first = 0
+    later = 0
+
+    i = 0
+    while i < 4 {
+        ev = "event: patch\ndata: chunk-${i}\n\n"
+        c1, n1, e1 = zstd.stream_write(s, ev, string.length(ev))
+        if e1 != "" { println("FAIL stream_write: ${e1}") return 1 }
+        if n1 > 0 { all = string.concat(all, c1) }
+
+        c2, n2, e2 = zstd.stream_flush(s)
+        if e2 != "" { println("FAIL stream_flush: ${e2}") return 1 }
+        if n2 > 0 { all = string.concat(all, c2) }
+
+        // A flush must emit something, or the peer sees nothing until close.
+        if n1 + n2 == 0 { println("FAIL: flush ${i} emitted nothing") return 1 }
+        if i == 0 { first = n1 + n2 } else { later = later + n1 + n2 }
+        i = i + 1
+    }
+
+    t, tn, e3 = zstd.stream_finish(s)
+    if e3 != "" { println("FAIL stream_finish: ${e3}") return 1 }
+    if tn > 0 { all = string.concat(all, t) }
+    zstd.stream_free(s)
+
+    total = string.length(all)
+    if total == 0 { println("FAIL: produced no output") return 1 }
+
+    // The window must be SHARED: three repeats of near-identical text must
+    // cost far less than the first event. N independent streams would each
+    // cost about the same, which is the bug this guards.
+    if later >= first * 3 {
+        println("FAIL: later flushes cost ${later} vs first ${first} —")
+        println("      the window does not look shared across flushes")
+        return 1
+    }
+
+    // One-shot must work too, and beat the input on repetitive text.
+    body = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    c, cn, e4 = zstd.compress(body, string.length(body), zstd.DEFAULT_LEVEL)
+    if e4 != "" { println("FAIL compress: ${e4}") return 1 }
+    if cn >= string.length(body) { println("FAIL: one-shot did not compress") return 1 }
+
+    println("zstd streaming ok")
+    return 0
+}

--- a/tests/integration/zstd_streaming/test_zstd_streaming.sh
+++ b/tests/integration/zstd_streaming/test_zstd_streaming.sh
@@ -46,6 +46,15 @@ fi
 # (Written rather than sed-patched: BSD `sed -i` needs a backup suffix and
 # GNU sed does not, so a substitution here breaks on one platform or the
 # other -- the same trap tests/integration/cache_symlinked_lib_edit notes.)
+# The fixture writes through the NATIVE `ae`, which on MSYS does not understand
+# an /tmp/... MSYS path -- fs.write_binary just reports "binary write failed".
+# Convert with cygpath where it exists, as http_middleware_d2 does.
+if command -v cygpath >/dev/null 2>&1; then
+    OUT_ZST="$(cygpath -m "$TMP")/out.zst"
+else
+    OUT_ZST="$TMP/out.zst"
+fi
+
 cat > "$TMP/emit.ae" <<AEOF
 import std.zstd
 import std.string
@@ -68,7 +77,7 @@ main() {
     t, tn, e3 = zstd.stream_finish(s)
     if tn > 0 { all = string.concat(all, t) }
     zstd.stream_free(s)
-    werr = fs.write_binary("$TMP/out.zst", all, string.length(all))
+    werr = fs.write_binary("$OUT_ZST", all, string.length(all))
     if werr != "" { println("write: \${werr}") return 1 }
     return 0
 }

--- a/tests/integration/zstd_streaming/test_zstd_streaming.sh
+++ b/tests/integration/zstd_streaming/test_zstd_streaming.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# #1891: zstd streaming holds ONE stream open across many flushes.
+#
+# Zstandard is a different FORMAT from DEFLATE, not a faster zlib. Its case is
+# strongest away from the browser (archives, logs, snapshots), since
+# Content-Encoding: zstd support is thinner than br/gzip. The surface mirrors
+# std.zlib's and std.brotli's so a caller picking an encoding writes one shape.
+#
+# Two assertions, as with the zlib test:
+#   1. every flushed chunk concatenated is ONE stream, and later events cost
+#      far less than the first -- proving a shared window rather than N
+#      independent streams (prog.ae);
+#   2. an INDEPENDENT decoder accepts the bytes. We only have an encoder, so
+#      this uses the system libzstd directly: our encoder agreeing with
+#      itself would prove nothing about RFC 7932 framing.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] zstd_streaming: ae not built"; exit 0; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+OUT=$("$AE" run "$SCRIPT_DIR/prog.ae" 2>&1) || {
+    echo "  [FAIL] zstd_streaming: did not build/run"
+    echo "$OUT" | sed 's/^/    /' | head -12
+    exit 1
+}
+case "$OUT" in
+    *"skipped: no backend"*)
+        echo "  [SKIP] zstd_streaming: no libzstd"; exit 0 ;;
+    *"zstd streaming ok"*) ;;
+    *)
+        echo "  [FAIL] zstd_streaming: assertions did not pass"
+        echo "$OUT" | sed 's/^/    /' | head -12
+        exit 1 ;;
+esac
+
+# --- 2. an independent decoder must accept the framing ------------------
+if ! pkg-config --exists libzstd 2>/dev/null; then
+    echo "  [PASS] zstd_streaming: one stream across flushes (no libzstd, external check skipped)"
+    exit 0
+fi
+
+# Heredoc UNQUOTED so $TMP expands; Aether ${...} escaped as \${...}.
+# (Written rather than sed-patched: BSD `sed -i` needs a backup suffix and
+# GNU sed does not, so a substitution here breaks on one platform or the
+# other -- the same trap tests/integration/cache_symlinked_lib_edit notes.)
+cat > "$TMP/emit.ae" <<AEOF
+import std.zstd
+import std.string
+import std.fs
+
+main() {
+    if zstd.available() == 0 { return 0 }
+    s, err = zstd.stream_new(3)
+    if err != "" { println("new: \${err}") return 1 }
+    all = ""
+    i = 0
+    while i < 3 {
+        ev = "event: patch\ndata: chunk-\${i}\n\n"
+        c1, n1, e1 = zstd.stream_write(s, ev, string.length(ev))
+        if n1 > 0 { all = string.concat(all, c1) }
+        c2, n2, e2 = zstd.stream_flush(s)
+        if n2 > 0 { all = string.concat(all, c2) }
+        i = i + 1
+    }
+    t, tn, e3 = zstd.stream_finish(s)
+    if tn > 0 { all = string.concat(all, t) }
+    zstd.stream_free(s)
+    werr = fs.write_binary("$TMP/out.zst", all, string.length(all))
+    if werr != "" { println("write: \${werr}") return 1 }
+    return 0
+}
+AEOF
+
+"$AE" run "$TMP/emit.ae" >"$TMP/emit.log" 2>&1 || {
+    echo "  [FAIL] zstd_streaming: fixture did not run"
+    sed 's/^/    /' "$TMP/emit.log" | head -8; exit 1; }
+[ -f "$TMP/out.zst" ] || { echo "  [FAIL] zstd_streaming: no .br written"; exit 1; }
+
+cat > "$TMP/dec.c" <<'CEOF'
+#include <stdio.h>
+#include <zstd.h>
+int main(int argc, char** argv) {
+    if (argc < 2) return 2;
+    FILE* f = fopen(argv[1], "rb"); if (!f) return 2;
+    static unsigned char in[1<<20]; size_t n = fread(in, 1, sizeof(in), f); fclose(f);
+    static unsigned char out[1<<20];
+    ZSTD_DCtx* d = ZSTD_createDCtx(); if (!d) return 2;
+    ZSTD_inBuffer  ib = { in, n, 0 };
+    ZSTD_outBuffer ob = { out, sizeof(out), 0 };
+    while (ib.pos < ib.size) {
+        size_t r = ZSTD_decompressStream(d, &ob, &ib);
+        if (ZSTD_isError(r)) { fprintf(stderr, "decode failed: %s\n", ZSTD_getErrorName(r)); return 1; }
+        if (r == 0 && ib.pos == ib.size) break;
+    }
+    fwrite(out, 1, ob.pos, stdout);
+    ZSTD_freeDCtx(d);
+    return 0;
+}
+CEOF
+CC_BIN="${CC:-cc}"
+if ! "$CC_BIN" -o "$TMP/dec" "$TMP/dec.c" $(pkg-config --cflags --libs libzstd) >"$TMP/cc.log" 2>&1; then
+    echo "  [PASS] zstd_streaming: one stream across flushes (decoder probe would not build, external check skipped)"
+    exit 0
+fi
+
+GOT=$("$TMP/dec" "$TMP/out.zst" 2>"$TMP/dec.err") || {
+    echo "  [FAIL] zstd_streaming: an independent zstd decoder REJECTED the stream"
+    sed 's/^/    /' "$TMP/dec.err" | head -5
+    exit 1; }
+
+for n in 0 1 2; do
+    case "$GOT" in
+        *"chunk-$n"*) ;;
+        *) echo "  [FAIL] zstd_streaming: decoder output missing chunk-$n"; exit 1 ;;
+    esac
+done
+
+echo "  [PASS] zstd_streaming: one stream across flushes, and libzstd reads it"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2573,8 +2573,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         else
             contrib_L[0] = '\0';
         int w = snprintf(cmd, size,
-            "\"%s\" %s %s \"%s\" %s -L\"%s\" %s-laether -o \"%s\" %s %s %s %s %s %s %s %s %s",
-            s_gcc_bin, opt, tc.include_flags, c_file, extra, lib_dir, contrib_L, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
+            "\"%s\" %s %s \"%s\" %s -L\"%s\" %s-laether -o \"%s\" %s %s %s %s %s %s %s %s %s %s %s",
+            s_gcc_bin, opt, tc.include_flags, c_file, extra, lib_dir, contrib_L, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",
@@ -2582,8 +2582,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         }
     } else {
         int w = snprintf(cmd, size,
-            "\"%s\" %s %s \"%s\" %s %s%s -o \"%s\" %s %s %s %s %s %s %s %s %s",
-            s_gcc_bin, opt, tc.include_flags, c_file, extra, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
+            "\"%s\" %s %s \"%s\" %s %s%s -o \"%s\" %s %s %s %s %s %s %s %s %s %s %s",
+            s_gcc_bin, opt, tc.include_flags, c_file, extra, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2502,6 +2502,14 @@ void build_gcc_cmd(char* cmd, size_t size,
 #else
     const char* brotli_libs = "";
 #endif
+#ifdef AETHER_ZSTD_LIBS
+    /* libzstd powers std.zstd. Empty when not detected, and that emptiness is
+     * load-bearing: a box without the library must not be handed a -lzstd it
+     * cannot resolve. */
+    const char* zstd_libs = AETHER_ZSTD_LIBS;
+#else
+    const char* zstd_libs = "";
+#endif
     /* Source-fallback (no libaether.a): compile the VENDORED pcre2
      * engine (#1389) instead of trusting this box to have the library
      * the toolchain's build box had. The defines turn the MANIFEST's
@@ -2765,6 +2773,14 @@ void build_gcc_cmd(char* cmd, size_t size,
 #else
     const char* brotli_libs = "";
 #endif
+#ifdef AETHER_ZSTD_LIBS
+    /* libzstd powers std.zstd. Empty when not detected, and that emptiness is
+     * load-bearing: a box without the library must not be handed a -lzstd it
+     * cannot resolve. */
+    const char* zstd_libs = AETHER_ZSTD_LIBS;
+#else
+    const char* zstd_libs = "";
+#endif
     // Source-fallback (no libaether.a): compile the VENDORED pcre2 engine
     // (#1389) — see the Windows branch above for the full rationale. The
     // defines activate aether_pcre2_vendored.c from the MANIFEST list; the
@@ -2830,8 +2846,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         else
             contrib_L[0] = '\0';
         int w = snprintf(cmd, size,
-            "%s %s %s \"%s\"%s %s -rdynamic -L%s %s%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s",
-            cc, opt, tc.include_flags, c_file, config_c, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
+            "%s %s %s \"%s\"%s %s -rdynamic -L%s %s%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s %s",
+            cc, opt, tc.include_flags, c_file, config_c, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu), "
@@ -2844,8 +2860,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         // symbols defined in tc.runtime_srcs (aether_shared_map_*,
         // etc.), so they appear BEFORE the runtime source list.
         int w = snprintf(cmd, size,
-            "%s %s %s \"%s\"%s %s %s %s%s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s",
-            cc, opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
+            "%s %s %s \"%s\"%s %s %s %s%s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s %s",
+            cc, opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu), "

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2493,6 +2493,15 @@ void build_gcc_cmd(char* cmd, size_t size,
 #else
     const char* pcre2_libs = "";
 #endif
+#ifdef AETHER_BROTLI_LIBS
+    /* libbrotlienc powers std.brotli. Empty when not detected, and that
+     * emptiness is load-bearing: a box without the library must not get a
+     * -lbrotlienc it cannot resolve. The std.brotli surface stays valid and
+     * reports "brotli unavailable". */
+    const char* brotli_libs = AETHER_BROTLI_LIBS;
+#else
+    const char* brotli_libs = "";
+#endif
     /* Source-fallback (no libaether.a): compile the VENDORED pcre2
      * engine (#1389) instead of trusting this box to have the library
      * the toolchain's build box had. The defines turn the MANIFEST's
@@ -2748,6 +2757,14 @@ void build_gcc_cmd(char* cmd, size_t size,
 #else
     const char* pcre2_libs = "";
 #endif
+    // libbrotlienc powers std.brotli. Empty when not detected, and that
+    // emptiness is load-bearing: a box without the library must not be handed
+    // a -lbrotlienc it cannot resolve.
+#ifdef AETHER_BROTLI_LIBS
+    const char* brotli_libs = AETHER_BROTLI_LIBS;
+#else
+    const char* brotli_libs = "";
+#endif
     // Source-fallback (no libaether.a): compile the VENDORED pcre2 engine
     // (#1389) — see the Windows branch above for the full rationale. The
     // defines activate aether_pcre2_vendored.c from the MANIFEST list; the
@@ -2813,8 +2830,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         else
             contrib_L[0] = '\0';
         int w = snprintf(cmd, size,
-            "%s %s %s \"%s\"%s %s -rdynamic -L%s %s%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s",
-            cc, opt, tc.include_flags, c_file, config_c, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
+            "%s %s %s \"%s\"%s %s -rdynamic -L%s %s%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s",
+            cc, opt, tc.include_flags, c_file, config_c, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu), "
@@ -2827,8 +2844,8 @@ void build_gcc_cmd(char* cmd, size_t size,
         // symbols defined in tc.runtime_srcs (aether_shared_map_*,
         // etc.), so they appear BEFORE the runtime source list.
         int w = snprintf(cmd, size,
-            "%s %s %s \"%s\"%s %s %s %s%s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s",
-            cc, opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
+            "%s %s %s \"%s\"%s %s %s %s%s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s",
+            cc, opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
             fprintf(stderr,
                 "Warning: gcc link command truncated at %d bytes (buffer %zu), "


### PR DESCRIPTION
Closes #1890 and #1891. Supersedes #1893, which carried the deflate half alone — consolidated into one PR to save CI minutes.

Three codecs, one streaming surface. Requested by the Datastar Go SDK port, which could not offer SSE compression at all: the blocker was never the codecs, it was that `std.zlib` was **one-shot only**.

## The problem

Every existing entry point runs `deflateInit2` → `deflate(Z_FINISH)` → `deflateEnd` in a single call, so each emits a **complete** stream. An SSE connection carrying many small events needs one stream held open and flushed at each event boundary. N independently-compressed events concatenated is not something any client will decode — the failure is a rejected response, not a worse ratio.

## One surface, three codecs

```
s, err        = zlib.stream_new(zlib.GZIP, 6)     // or brotli / zstd
chunk, n, err = X.stream_write(s, ev, len)        // usually emits nothing
chunk, n, err = X.stream_flush(s)                 // send these bytes now
tail,  n, err = X.stream_finish(s)
                X.stream_free(s)
```

A server negotiating `br` / `gzip` / `zstd` writes the same shape whichever it picks. On the same three-event fixture: **gzip 77 bytes, zstd 65, brotli 58**.

## Each drain loop is written against its own library's contract

This is the part most at risk of a copy-paste bug, so it is deliberately *not* shared:

| | termination condition |
|---|---|
| zlib | `deflate()` left `avail_out` spare |
| brotli | `BrotliEncoderHasMoreOutput()` goes false |
| zstd | `ZSTD_compressStream2()` **returns 0** ("bytes remaining to flush") |

Reusing a sibling's condition truncates the frame. zstd additionally gates growth on the buffer being genuinely full, since a nonzero return usually just means "call again with the room you already have".

Also: each handle owns its output buffer rather than sharing a thread-local slot, because two streams may be open on one thread (two SSE connections, one event loop).

## brotli and zstd bind system libraries, not vendored ports

Considered vendoring and rejected it. Brotli's reference encoder carries a mandatory ~120k-line static dictionary that is part of the *format* — so vendoring means carrying that whichever route is taken — plus ~17k lines of bit-exact entropy coding containing **383 shift operations and 1100 width-typed sites**, in a language whose integer-width pitfalls this project has hit four separate times. Both libraries ship in every mainstream distro and expose exactly the streaming encoders needed.

Detection is the established capability-macro shape (`pkg-config` → `AETHER_HAS_*` → empty `*_LIBS` when absent), so `std.http` can reach them at the C layer exactly as it already reaches gzip, with **no `std`→`contrib` layering edge**.

## Testing

Each codec is validated against an **independent decoder** — `gunzip`, `libbrotlidec`, `libzstd` — because our encoder agreeing with our decoder proves nothing about the wire format. Every test asserts:

1. **concatenated chunks decode as ONE stream** (per-event compression round-trips fine and is still broken, so a single-chunk test would pass against the bug);
2. **later flushes cost far less than the first** — 34/12/11 for gzip, 31/13/13 for brotli, 37/12/13 for zstd — the shared-window signature that distinguishes streaming from N independent frames.

**Cross-platform, on real hardware** (not just CI):

| | zlib | brotli | zstd | unit | fmt | docs |
|---|---|---|---|---|---|---|
| Linux (all backends present) | PASS | PASS | PASS | 409/409 | PASS | PASS |
| macOS 15.7.7 | PASS | SKIP | SKIP | 409/409 | PASS | PASS |
| Windows MSYS2/MinGW | PASS | SKIP | SKIP | 397/397 | PASS | — |

The SKIPs are the point: those boxes have no `libbrotlienc`/`libzstd`, and the tests skip cleanly rather than failing. Also checked: valgrind clean over write/flush/finish/free for all three, and `ZLIB=0` / `BROTLI=0` / `ZSTD=0` builds compile and report `"X unavailable"` from `stream_new` rather than silently emitting nothing — the base64 lesson from #1884.

## Two portability bugs this found, both mine

- **`sed -i`** — BSD requires a backup-suffix argument, GNU takes none, so the macOS legs died on the test fixture. Rewritten to need no substitution at all.
- **MSYS paths** — the fixture writes through the *native* `ae.exe`, which cannot resolve `/tmp/...`, so `fs.write_binary` reported `binary write failed`. Now converted with `cygpath -m`, as `http_middleware_d2` already does.

Both were caught by CI and then reproduced and fixed on the real boxes.

## Scope

Compression only, deflate/brotli/zstd. Streaming *inflate* is separate and was not needed to unblock the reported case; the one-shot readers handle a complete stream including one assembled from flushed chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
