### PR TITLE
test(regression): the website's first demo, as a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **The website's first demo is now a test.** A Windows user (MSYS2 / ucrt64)
+  ran `ae init` and the front-page actor program and it failed to link, with
+  `undefined reference to __emutls_v.current_core_id` and two siblings: the
+  generated C named thread-local scheduler variables, `__thread` lowers to
+  emulated TLS on MinGW, and the shipped archive and the user's compiler did
+  not agree about the model. Codegen already reaches those through calls
+  instead, which has one ABI either way. What was missing was a test: the
+  first program every new user runs had none. It sits in `tests/regression`,
+  so the Windows/Wine sweep builds and runs it for Windows too, which is the
+  platform the report came from.
+
 ## [0.633.0]
 
 ### Added

--- a/tests/regression/test_website_first_demo.ae
+++ b/tests/regression/test_website_first_demo.ae
@@ -1,0 +1,39 @@
+// #1751 — the first demo on the website, as a test.
+//
+// A user on Windows (MSYS2 / ucrt64, gcc 15.2) ran `ae init` and then this
+// exact program from the front page, and it failed to LINK:
+//
+//   undefined reference to `__emutls_v.current_core_id'
+//   undefined reference to `__emutls_v.g_current_reply_slot'
+//   undefined reference to `__emutls_v.g_current_step_actor'
+//
+// Those are thread-local variables in the actor scheduler. The generated C
+// used to NAME them, and __thread lowers to emulated TLS on MinGW, so the
+// program depended on the shipped archive and the user's compiler agreeing
+// about the TLS model. They did not. Codegen now reaches those variables
+// through calls instead, which has one ABI either way.
+//
+// The program is unchanged from the website, deliberately: it is the first
+// thing a new user runs, and it had no test. It lives in tests/regression so
+// the Windows/Wine sweep (#1876) builds and runs it for Windows too, which
+// is the platform the report came from.
+
+extern exit(code: int)
+
+message Inc { n: int }
+
+actor Counter {
+    state count = 0
+    receive {
+        Inc(n) -> {
+            count = count + n
+            println("count = ${count}")
+        }
+    }
+}
+
+main() {
+    c = spawn(Counter())
+    c ! Inc { n: 41 }
+    c ! Inc { n: 1 }
+}


### PR DESCRIPTION
Closes #1751

## What the report was

A Windows user (MSYS2 / ucrt64, gcc 15.2) ran `ae init` and then the front-page actor program, and it failed to **link**:

```
undefined reference to `__emutls_v.current_core_id'
undefined reference to `__emutls_v.g_current_reply_slot'
undefined reference to `__emutls_v.g_current_step_actor'
```

Those are thread-local variables in the actor scheduler. The generated C used to **name** them, `__thread` lowers to emulated TLS on MinGW, and the program therefore depended on the shipped archive and the user's own compiler agreeing about the TLS model. They did not.

## State on main

Codegen already reaches those variables through calls rather than naming them. Verified on the user's exact program:

```
$ aetherc demo.ae demo.c
$ grep -cE '__emutls_v|extern __thread.*current_core_id' demo.c
0
$ ae build demo.ae -o demo && ./demo
count = 41
count = 42
```

The symbols are not referenced at all, which is what makes the reported failure structurally impossible rather than merely unlikely: a name that is not emitted cannot fail to resolve, whatever the toolchain's TLS model.

## What was actually missing

A test. The first program every new user runs had none, which is how a first-impression break reached somebody in the first place.

This adds it verbatim, in `tests/regression` so that the Windows/Wine sweep (#1876, merged) builds and runs it **for Windows** as well — the platform the report came from. Thirteen other actor tests already live there and passed 513/513 under Wine, so actor programs are covered on Windows now; this puts the specific reported program in that set.

I could not reproduce on MSYS2 directly, since I have no Windows machine here. The evidence is that the emitted C no longer contains the symbols that failed to resolve, plus the MSYS2 leg and the Wine sweep both running actor programs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
