### PR TITLE
feat(std.http): SSE upgrade-in-place, and the `retry:` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ version number before tagging the release.
 
 ### Added
 
+- **`http.response_upgrade_sse` — turn an in-flight response into an SSE
+  stream.** `server_sse` registers a whole *route* as SSE, so the decision is
+  made before the request is parsed. A handler that must be able to answer 400
+  on a malformed body and only *then* stream could not use it, and had to seize
+  the raw socket with `response_accept_tunnel` instead — which returns NULL on
+  a TLS connection, so every SSE endpoint built that way was silently
+  plaintext-only. The upgrade writes through the connection's own send path, so
+  it works over `https`.
+
+  Contract when the handler has already touched the response: headers set
+  earlier are **discarded** (the SSE head is fixed, and a stale
+  `Content-Length` would corrupt the stream), and if a body was already set the
+  upgrade is **refused** — that body is data the caller believes it sent.
+
+- **`http.sse_send_full` — SSE events carrying `retry:`.** That field is the
+  spec's own reconnection-backoff mechanism, and it was emitted nowhere: the
+  surface could write `id:`, `event:` and `data:` but gave a server no way to
+  tell a client how long to wait before reconnecting. `sse_send` and
+  `sse_send_id` are unchanged, passing 0 to omit the field. Field order on the
+  wire is id, event, retry, data — every field must precede the blank line that
+  dispatches the event.
+
+  Both were asked for by the Datastar SDK port, whose cross-SDK conformance
+  goldens require `retry:` in 5 of 20 cases.
+
+### Added
+
 - **The website's first demo is now a test.** A Windows user (MSYS2 / ucrt64)
   ran `ae init` and the front-page actor program and it failed to link, with
   `undefined reference to __emutls_v.current_core_id` and two siblings: the

--- a/docs/stdlib-reference.md
+++ b/docs/stdlib-reference.md
@@ -36,7 +36,7 @@ header comment is the authoritative description.
 | `std.fs` | Files, directories, metadata, recursive walk, and change watching. | 147 | [guide](../std/fs/README.md) · [source](../std/fs/module.ae) |
 | `std.hash` | Fast non-cryptographic hashes: FNV, MurmurHash3, SipHash. | 4 | [guide](../std/hash/README.md) · [source](../std/hash/module.ae) |
 | `std.host` | Primitives for Aether scripts embedded in a host application. | 17 | [guide](../std/host/README.md) · [source](../std/host/module.ae) |
-| `std.http` | HTTP client and server: the `std.net` surface plus Go-style wrappers. | 159 | [guide](../std/http/README.md) · [source](../std/http/module.ae) |
+| `std.http` | HTTP client and server: the `std.net` surface plus Go-style wrappers. | 163 | [guide](../std/http/README.md) · [source](../std/http/module.ae) |
 | `std.http1` | Pure-Aether HTTP/1.1 response reader (RFC 9112). | 15 | [guide](../std/http1/README.md) · [source](../std/http1/module.ae) |
 | `std.intarr` | Fixed-size packed-int buffer. | 13 | [guide](../std/intarr/README.md) · [source](../std/intarr/module.ae) |
 | `std.io` | Console output, whole-file reads and writes, file descriptors, environment variables. | 43 | [full section](#io-stdio) |

--- a/std/http/module.ae
+++ b/std/http/module.ae
@@ -52,7 +52,9 @@ exports(
     http_server_set_metrics_raw, server_set_metrics,
     http_server_sse, server_sse,
     http_sse_send_event, http_sse_send_event_id, http_sse_close,
-    sse_send, sse_send_id, sse_close,
+    http_sse_send_event_full, http_response_sse_upgrade_raw,
+    sse_send, sse_send_id, sse_send_full, sse_close,
+    response_upgrade_sse,
     http_server_websocket, server_websocket,
     http_ws_send_text, http_ws_send_binary, http_ws_recv,
     http_ws_recv_timeout, http_ws_poll, http_ws_fd,
@@ -503,6 +505,8 @@ server_set_metrics(server: ptr, metrics_endpoint: string) -> {
 extern http_server_sse(server: ptr, path: string, handler: ptr, user_data: ptr)
 extern http_sse_send_event(sse: ptr, event_name: string, data: string) -> int
 extern http_sse_send_event_id(sse: ptr, event_name: string, data: string, id: string) -> int
+extern http_sse_send_event_full(sse: ptr, event_name: string, data: string, id: string, retry_ms: int) -> int
+extern http_response_sse_upgrade_raw(res: ptr) -> ptr
 extern http_sse_close(sse: ptr)
 
 server_sse(server: ptr, path: string, handler: ptr, user_data: ptr) {
@@ -515,6 +519,45 @@ sse_send(sse: ptr, event_name: string, data: string) -> int {
 
 sse_send_id(sse: ptr, event_name: string, data: string, id: string) -> int {
     return http_sse_send_event_id(sse, event_name, data, id)
+}
+
+// Full SSE event, including `retry:` -- the spec's own reconnection-backoff
+// field (WHATWG HTML, server-sent events). Without it a client can only use
+// its default backoff and the server has no way to say otherwise, so an SSE
+// surface emitting id/event/data but not retry is incomplete rather than
+// merely minimal. 5 of the 20 Datastar cross-SDK conformance goldens require
+// it, which is how the gap surfaced.
+//
+// `retry_ms` <= 0 omits the field; sse_send and sse_send_id pass 0, so their
+// behaviour is unchanged. Field order on the wire is id, event, retry, data --
+// retry must precede the blank line that dispatches the event.
+sse_send_full(sse: ptr, event_name: string, data: string, id: string, retry_ms: int) -> int {
+    return http_sse_send_event_full(sse, event_name, data, id, retry_ms)
+}
+
+// Turn an in-flight ordinary response into an SSE stream.
+//
+// `server_sse` registers a whole ROUTE as SSE, which forces the decision
+// before the request is parsed -- so a handler that must be able to answer 400
+// on a malformed body and only THEN stream cannot use it. This is that seam.
+//
+// Unlike `response_accept_tunnel` this does NOT hand back a raw socket, so it
+// works over TLS: writes go through the connection's own send path.
+//
+// Contract when the handler has already touched `res`: headers set earlier are
+// DISCARDED (the SSE head is fixed, and a stale Content-Length would corrupt
+// the stream), and if a body was already set the upgrade is REFUSED -- that
+// body is data the caller believes it sent.
+//
+// Returns (sse, "") on success, (null, error) when the response is not on a
+// live connection, has already been taken over, or has a body.
+response_upgrade_sse(res: ptr) -> {
+    if res == null { return null, "no response" }
+    sse = http_response_sse_upgrade_raw(res)
+    if sse == null {
+        return null, "sse upgrade failed (no live connection, already taken over, or body already set)"
+    }
+    return sse, ""
 }
 
 sse_close(sse: ptr) {

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -80,6 +80,11 @@ int http_sse_send_event(HttpSseConn* c, const char* n, const char* d) {
 int http_sse_send_event_id(HttpSseConn* c, const char* n, const char* d, const char* i) {
     (void)c; (void)n; (void)d; (void)i; return -1;
 }
+int http_sse_send_event_full(HttpSseConn* c, const char* n, const char* d,
+                             const char* i, int r) {
+    (void)c; (void)n; (void)d; (void)i; (void)r; return -1;
+}
+HttpSseConn* http_response_sse_upgrade_raw(HttpServerResponse* r) { (void)r; return NULL; }
 void http_sse_close(HttpSseConn* c) { (void)c; }
 void http_server_websocket(HttpServer* s, const char* p, HttpWsHandler h, void* u) {
     (void)s; (void)p; (void)h; (void)u;
@@ -2355,6 +2360,7 @@ char* http_response_serialize(HttpServerResponse* res) {
 }
 
 void http_server_response_free(HttpServerResponse* res) {
+    if (res && res->sse_upgrade) { free(res->sse_upgrade); res->sse_upgrade = NULL; }
     if (!res) return;
 
     free(res->status_text);
@@ -2489,6 +2495,48 @@ struct HttpSseConn {
     int       closed;
 };
 
+HttpSseConn* http_response_sse_upgrade_raw(HttpServerResponse* res) {
+    if (!res || res->takeover_taken || !res->takeover_conn) return NULL;
+
+    /* A handler that already committed a body has answered the request; we
+     * will not silently discard it. Headers ARE discarded (see the header
+     * comment) because the SSE head is fixed and a stale Content-Length
+     * would corrupt the stream, but a body is data the caller believes it
+     * sent. */
+    if (res->body && res->body_length > 0) return NULL;
+
+    HttpConn* conn = (HttpConn*)res->takeover_conn;
+    if (!conn || conn->fd < 0) return NULL;
+
+    /* Deliberately NO TLS guard, unlike http_response_accept_tunnel: that
+     * function hands back a raw std.tcp socket, which cannot carry TLS
+     * framing. Here every write goes through conn_send, which unwraps TLS
+     * when the connection has it -- so an upgraded SSE stream works over
+     * https where a tunnel cannot. */
+
+    /* Same fixed head the route-level SSE path sends (see the sse_routes
+     * dispatch): no Content-Length, because the body is open-ended. */
+    static const char* head =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/event-stream\r\n"
+        "Cache-Control: no-cache\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+    int hlen = (int)strlen(head);
+    if (conn_send(conn, head, hlen) != hlen) return NULL;
+
+    HttpSseConn* sse = (HttpSseConn*)calloc(1, sizeof(HttpSseConn));
+    if (!sse) return NULL;
+    sse->conn = conn;
+    sse->closed = 0;
+
+    /* Mark the response as taken over so the dispatcher does not serialize
+     * a second response over the stream we just opened. */
+    res->takeover_taken = 1;
+    res->sse_upgrade = sse;
+    return sse;
+}
+
 /* WebSocket route node (#260 Tier 2 / E2). */
 struct HttpWsRoute {
     char* path;
@@ -2555,6 +2603,14 @@ int http_sse_send_event_id(HttpSseConn* sse,
                            const char* event_name,
                            const char* data,
                            const char* id) {
+    return http_sse_send_event_full(sse, event_name, data, id, 0);
+}
+
+int http_sse_send_event_full(HttpSseConn* sse,
+                             const char* event_name,
+                             const char* data,
+                             const char* id,
+                             int retry_ms) {
     if (!sse || !sse->conn || sse->closed) return -1;
 
     /* Build an SSE chunk:
@@ -2574,7 +2630,8 @@ int http_sse_send_event_id(HttpSseConn* sse,
      * below — so it threads cleanly through the caps allocator. */
     size_t cap = data_len * 4 + 256
                + (event_name ? strlen(event_name) + 16 : 0)
-               + (id ? strlen(id) + 16 : 0);
+               + (id ? strlen(id) + 16 : 0)
+               + (retry_ms > 0 ? 32 : 0);   /* "retry: " + int + \n */
     char* buf = (char*)aether_caps_malloc(cap);
     if (!buf) return -1;
     size_t off = 0;
@@ -2584,6 +2641,12 @@ int http_sse_send_event_id(HttpSseConn* sse,
     }
     if (event_name && *event_name) {
         off += (size_t)snprintf(buf + off, cap - off, "event: %s\n", event_name);
+    }
+    /* retry: must precede the blank line that dispatches the event, so it
+     * goes here rather than after the data lines. <= 0 omits it, which is
+     * what send_event / send_event_id pass. */
+    if (retry_ms > 0) {
+        off += (size_t)snprintf(buf + off, cap - off, "retry: %d\n", retry_ms);
     }
     if (data && *data) {
         const char* line_start = data;

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -114,6 +114,11 @@ typedef struct {
      * close a socket now owned by the handler. */
     void* takeover_conn;
     int   takeover_taken;
+    /* SSE upgrade (#sse-upgrade). http_response_sse_upgrade_raw allocates one
+     * HttpSseConn here and returns it; freed with the response. Kept on the
+     * response rather than returned by value because the handler holds it
+     * across many sse_send calls. */
+    void* sse_upgrade;
 } HttpServerResponse;
 
 // Route handler callback
@@ -642,6 +647,46 @@ int http_sse_send_event_id(HttpSseConn* sse,
                            const char* event_name,
                            const char* data,
                            const char* id);
+
+// Full SSE event: adds `retry:`, the spec's own reconnection-backoff field
+// (WHATWG HTML "server-sent events", the `retry` field). Without it a client
+// falls back to its default backoff, and a server cannot tell it otherwise —
+// so an SSE surface that emits id/event/data but not retry is incomplete
+// rather than merely minimal.
+//
+// `retry_ms` <= 0 omits the field, which is what every existing caller wants;
+// http_sse_send_event and _id are thin wrappers that pass 0, so their
+// behaviour is unchanged. Field order is id, event, retry, data — retry
+// before data because the spec dispatches the event at the blank line, so
+// every field must precede it, and grouping the metadata reads better on the
+// wire.
+int http_sse_send_event_full(HttpSseConn* sse,
+                             const char* event_name,
+                             const char* data,
+                             const char* id,
+                             int retry_ms);
+
+// Turn an in-flight ordinary response into an SSE stream (#sse-upgrade).
+//
+// http_server_sse registers a whole ROUTE as an SSE endpoint, which forces the
+// decision before the request is parsed. A handler that must be able to answer
+// 400 on a malformed body and only THEN stream cannot use it. This is that
+// seam: call it from an ordinary handler once the request has been validated.
+//
+// Unlike http_response_accept_tunnel, this does NOT hand back a raw socket, so
+// it works over TLS -- writes go through the connection's own send path.
+//
+// Contract when the handler has already touched `res`:
+//   - headers set earlier are DISCARDED. The SSE head is fixed
+//     (200, text/event-stream, no-cache, close) and a stale Content-Type or
+//     Content-Length would corrupt the stream.
+//   - if a body was already set, the upgrade is REFUSED (returns NULL): the
+//     handler has committed to a non-streaming response, and silently
+//     dropping it would lose data the caller believed it had sent.
+// Returns NULL if the response is not attached to a live connection, has
+// already been taken over, or has a body. The returned handle is owned by the
+// server and is valid until http_sse_close or the handler returns.
+HttpSseConn* http_response_sse_upgrade_raw(HttpServerResponse* res);
 
 // Best-effort close. Idempotent. After this call, send_event
 // returns -1.

--- a/tests/integration/http_sse_upgrade/server.ae
+++ b/tests/integration/http_sse_upgrade/server.ae
@@ -1,0 +1,71 @@
+// Upgrade-in-place SSE, in the shape the Datastar SDK needs.
+//
+// `server_sse` registers a whole ROUTE as SSE, so the decision is made before
+// the request is parsed. A handler that must answer 400 on a malformed body
+// and only THEN stream cannot use it. `response_upgrade_sse` is that seam.
+//
+// Three paths, one per query string:
+//   ?bad     -> 400, no upgrade (the reason the seam is needed at all)
+//   ?hasbody -> upgrade must be REFUSED, because a committed body is data
+//               the caller believes it sent
+//   (else)   -> upgrade, then a plain event and a full one carrying retry:
+import std.http
+
+extern exit(code: int)
+extern http_server_start_raw(server: ptr) -> int
+
+const PORT = 18131
+
+@c_callback stream_handler(req: ptr, res: ptr, ud: ptr) {
+    q = http.request_query(req)
+
+    if q == "bad" {
+        http.http_response_set_status(res, 400)
+        http.http_response_set_body(res, "malformed")
+        return
+    }
+
+    if q == "hasbody" {
+        http.http_response_set_body(res, "already answered")
+        sse2, err2 = http.response_upgrade_sse(res)
+        if sse2 != null {
+            http.http_response_set_body(res, "BUG-upgraded-over-body")
+        }
+        return
+    }
+
+    sse, err = http.response_upgrade_sse(res)
+    if err != "" { return }
+
+    _a = http.sse_send(sse, "greet", "hello")
+    // Every field, including retry: — 5 of the 20 Datastar conformance
+    // goldens require it, and it is SSE's own field, not a Datastar one.
+    _b = http.sse_send_full(sse, "datastar-patch-elements",
+        "selector div\nmode append", "event1", 2000)
+    http.sse_close(sse)
+}
+
+message StartSrv { raw: ptr }
+message Noop {}
+actor SrvActor {
+    state s = 0
+    receive { StartSrv(raw) -> { s = raw; http_server_start_raw(raw) } }
+}
+actor SchedHelper {
+    state x = 0
+    receive { Noop() -> { x = 1 } }
+}
+
+main() {
+    raw = http.server_create(PORT)
+    if raw == 0 { println("FAIL: server_create") exit(1) }
+    http.server_set_host(raw, "127.0.0.1")
+    http.http_server_get(raw, "/stream", stream_handler, null)
+
+    println("READY")
+    spawn(SchedHelper())
+    a = spawn(SrvActor())
+    a ! StartSrv { raw: raw }
+    sleep(60000)
+    exit(0)
+}

--- a/tests/integration/http_sse_upgrade/test_http_sse_upgrade.sh
+++ b/tests/integration/http_sse_upgrade/test_http_sse_upgrade.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Upgrade-in-place SSE: response_upgrade_sse + the `retry:` field.
+#
+# `server_sse` registers a whole ROUTE as SSE, so the decision is made before
+# the request is parsed. A handler that must answer 400 on a malformed body and
+# only THEN stream cannot use it -- which is why the Datastar SDK bypassed the
+# stdlib entirely and seized the raw socket with response_accept_tunnel. That
+# works, but accept_tunnel returns NULL on a TLS connection, so every SSE
+# endpoint built that way is plaintext-only.
+#
+# Asserts:
+#   - a handler can answer 400 WITHOUT upgrading (the reason for the seam)
+#   - an upgraded stream carries the fixed SSE head
+#   - `retry:` is emitted, in spec order (id, event, retry, data). 5 of the 20
+#     Datastar cross-SDK conformance goldens require it, and it is SSE's own
+#     reconnection field, not a Datastar invention
+#   - upgrading over an already-committed body is REFUSED, so that body is not
+#     silently lost
+#
+# Skips on Windows for the same reason http_server_sse does: this is
+# platform-independent userland C and each curl under MSYS2 costs 10-100x a
+# POSIX spawn.
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        echo "  [SKIP-WIN] http_sse_upgrade — HTTP server code is platform-independent; covered by POSIX matrix"
+        exit 0
+        ;;
+esac
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+command -v curl >/dev/null 2>&1 || { echo "  [SKIP] curl not on PATH"; exit 0; }
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+    if [ -n "${SRV_PID:-}" ]; then
+        kill "$SRV_PID" 2>/dev/null || true
+        wait "$SRV_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+SRV_PID=$!
+PORT=18131
+
+# Probe the port rather than trusting READY: server.ae prints it before the
+# StartSrv message opens the listener, and a curl issued too early returns
+# nothing at all.
+deadline=$(($(date +%s) + 15))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$SRV_PID" 2>/dev/null; then
+        echo "  [FAIL] http_sse_upgrade: server died:"; head -20 "$TMPDIR/srv.log"; exit 1
+    fi
+    curl -s -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/stream?bad" 2>/dev/null && break
+    sleep 0.1
+done
+
+# --- 1. the 400-first path: answer WITHOUT upgrading --------------------
+CODE=$(curl -s -o "$TMPDIR/bad.out" -w "%{http_code}" --max-time 5 \
+       "http://127.0.0.1:$PORT/stream?bad" 2>/dev/null || echo 000)
+[ "$CODE" = "400" ] || {
+    echo "  [FAIL] http_sse_upgrade: bad request returned $CODE, want 400"; exit 1; }
+
+# --- 2. the stream: headers -------------------------------------------
+curl -sN -D "$TMPDIR/h" -o "$TMPDIR/sse.out" --max-time 5 \
+     "http://127.0.0.1:$PORT/stream" 2>/dev/null || true
+grep -qi "^Content-Type: *text/event-stream" "$TMPDIR/h" || {
+    echo "  [FAIL] http_sse_upgrade: no text/event-stream on the upgraded response"
+    sed 's/^/    /' "$TMPDIR/h" | head -8; exit 1; }
+
+# --- 3. retry:, and the field ORDER the spec requires ------------------
+grep -q "^retry: 2000$" "$TMPDIR/sse.out" || {
+    echo "  [FAIL] http_sse_upgrade: no 'retry: 2000' line"
+    sed 's/^/    /' "$TMPDIR/sse.out" | head -12; exit 1; }
+# retry must PRECEDE the data lines: the blank line dispatches the event, so a
+# field after the data would land in the next event (or be dropped).
+RETRY_AT=$(grep -n "^retry: 2000$" "$TMPDIR/sse.out" | head -1 | cut -d: -f1)
+DATA_AT=$(grep -n "^data: selector div$" "$TMPDIR/sse.out" | head -1 | cut -d: -f1)
+[ -n "$RETRY_AT" ] && [ -n "$DATA_AT" ] && [ "$RETRY_AT" -lt "$DATA_AT" ] || {
+    echo "  [FAIL] http_sse_upgrade: retry: must precede the data lines (retry@$RETRY_AT data@$DATA_AT)"
+    sed 's/^/    /' "$TMPDIR/sse.out" | head -12; exit 1; }
+# and the plain event still works, with no stray retry on it
+grep -q "^event: greet$" "$TMPDIR/sse.out" || {
+    echo "  [FAIL] http_sse_upgrade: the plain sse_send event is missing"; exit 1; }
+
+# --- 4. upgrading over a committed body must be REFUSED ----------------
+BODY=$(curl -s --max-time 5 "http://127.0.0.1:$PORT/stream?hasbody" 2>/dev/null || echo "")
+case "$BODY" in
+    *BUG-upgraded-over-body*)
+        echo "  [FAIL] http_sse_upgrade: upgraded over an already-committed body"; exit 1 ;;
+    *already\ answered*) ;;
+    *)
+        echo "  [FAIL] http_sse_upgrade: unexpected body for ?hasbody: '$BODY'"; exit 1 ;;
+esac
+
+echo "  [PASS] http_sse_upgrade: 400-then-upgrade, retry: in spec order, refuses over a body"


### PR DESCRIPTION
Two additions to `std.http`, both requested by the Datastar SDK port and both confirmed against their reply before building rather than inferred from reading their code.

## 1. `response_upgrade_sse(res)`

`server_sse` registers a whole **route** as SSE, so the decision is made before the request is parsed. A handler that must answer 400 on a malformed body and only *then* stream cannot use it:

```aether
stream, derr = events_frames(doc)
if derr != "" { respond_error(res, 400, derr); return }   // still an ordinary response
sse, err = http.response_upgrade_sse(res)                  // NOW become a stream
```

The Datastar port worked around this by seizing the raw socket with `response_accept_tunnel`.

### That workaround is silently plaintext-only

`http_response_accept_tunnel` returns NULL when `conn->ssl || conn->pure_tls` — a raw `std.tcp` socket cannot carry TLS framing. So **every SSE endpoint built that way fails the moment it is served over HTTPS**, with a runtime error string rather than anything a build or test would catch. They had not spotted it; their whole conformance matrix is plain HTTP.

This upgrade writes through `conn_send`, the connection's own send path, so it works over TLS. **Verified end-to-end against a real HTTPS server with a self-signed cert**, not asserted from reading the code.

### The contract question they asked

They asked what happens when the handler has already touched `res`, since the 400-first flow means it may have. Answered explicitly in the doc comment and enforced:

- **headers set earlier are discarded** — the SSE head is fixed, and a stale `Content-Type`/`Content-Length` would corrupt the stream;
- **a response that already has a body is refused** — that body is data the caller believes it sent, and silently dropping it would lose it.

## 2. `sse_send_full(sse, event, data, id, retry_ms)`

`retry:` was emitted **nowhere**. It is SSE's own reconnection-backoff field, so a surface writing `id:`/`event:`/`data:` but not `retry:` is *incomplete* rather than merely minimal — that is the reason to add it. That 5 of the Datastar port's 20 cross-SDK conformance goldens require it is corroboration, not the argument.

`sse_send` and `sse_send_id` are unchanged, passing 0 to omit the field. Order on the wire is **id, event, retry, data** — `retry:` must precede the data lines, because the blank line dispatches the event and a field after the data would land in the next one.

## What they asked me *not* to build

- **No compression coupling.** They argued the negotiation strategy is SDK-specific and that a compressing upgrade call "would make the simple case easy and the Datastar case unreachable". Agreed — `zlib.stream_*` composes over the returned handle instead.
- **No client-side SSE reader.** They said their conformance suite drives the real upstream Go runner and their one streaming test reads raw bytes off a socket, so nothing wants it.

## Testing

The suite asserts the four behaviours that matter: a handler answers **400 without upgrading**, the upgraded response carries the fixed SSE head, **`retry:` appears before the data lines**, and **upgrading over a committed body is refused**.

Verified on three platforms rather than CI alone:

| | build | `http_sse_upgrade` | `http_server_sse` (existing) | unit |
|---|---|---|---|---|
| Linux | ✅ | PASS | PASS | 409/409 |
| macOS 15.7.7 | ✅ | **PASS** | PASS | 409/409 |
| Windows MSYS2 | ✅ | SKIP-WIN (by design) | SKIP-WIN | 397/397 |

The existing `http_server_sse` passing everywhere is the guard that the route-based path is unregressed.

Two pre-existing failures seen on those boxes, both **confirmed on clean `main`** and unrelated: `http_server_h2` (HTTP/2 framing) and the Windows `-lfyaml` link error (#1896).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
