### PR TITLE
Resolve [dependencies] onto the module search path (#1901)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ on:
     paths-ignore: [ 'CHANGELOG.md', 'VERSION' ]
   workflow_dispatch:
 
+
+# Cancel a superseded run when a new commit lands on the same ref. Without
+# this, every push left the previous run's jobs racing to completion: two
+# branches accumulated 12 and 18 runs during one day's work, and a stale run
+# kept reporting failure for a commit nobody was on any more (one such run sat
+# open for six hours after its last job finished).
+#
+# Keyed by workflow + ref so different workflows and different branches never
+# cancel each other. For a PR, github.ref is refs/pull/N/merge -- stable across
+# every push to that PR, which is the accumulation case this fixes, and distinct
+# from a branch push so the two never cancel one another. NOT applied to main:
+# a push there is a merge whose result is worth recording even if another lands
+# seconds later.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # ============================================================
   # Full CI suite — Linux (GCC), Linux (Clang), macOS (Clang)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,23 @@ on:
 # behaviour that compiles fine and then differs on Windows previously had no
 # signal until the MSYS2 legs finished, ~25 minutes in.
 
+
+# Cancel a superseded run when a new commit lands on the same ref. Without
+# this, every push left the previous run's jobs racing to completion: two
+# branches accumulated 12 and 18 runs during one day's work, and a stale run
+# kept reporting failure for a commit nobody was on any more (one such run sat
+# open for six hours after its last job finished).
+#
+# Keyed by workflow + ref so different workflows and different branches never
+# cancel each other. For a PR, github.ref is refs/pull/N/merge -- stable across
+# every push to that PR, which is the accumulation case this fixes, and distinct
+# from a branch push so the two never cancel one another. NOT applied to main:
+# a push there is a merge whose result is worth recording even if another lands
+# seconds later.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # ============================================================
   # FAST LANE — cross-build for Windows on a Linux runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ version number before tagging the release.
 
 ### Fixed
 
+- **MinGW: `cannot find -lfyaml` and `__imp_nghttp2_*` link failures (#1896).**
+  Building `ae` on MSYS2/MinGW failed at link, which made a real Windows box
+  unusable as a proving ground. Both errors came from the same cause: the
+  Windows link line carries `-static` (to avoid libwinpthread/libgcc DLL
+  dependencies in release binaries) and two dependencies were not told about
+  it. `-static` is not positional for library *resolution*, so `ld` demanded
+  `libfyaml.a` while MSYS2 ships only `libfyaml.dll.a` — the library was
+  installed and `pkg-config` correct, which is why it looked like a missing
+  package and was not. fyaml is the only dependency with no static archive
+  there, so it now links dynamically inside `-Wl,-Bdynamic` / `-Wl,-Bstatic`
+  rather than `-static` being dropped for everything. Separately, `nghttp2.h`
+  declares its API `__declspec(dllimport)` unless `NGHTTP2_STATICLIB` is
+  defined, so every call compiled to an `__imp_` reference the static archive
+  could not satisfy; the headers are now told what the linker was told.
+
 - **CI runs were never cancelled when superseded.** Neither `ci.yml` nor
   `windows.yml` carried a `concurrency:` block — only `release.yml` did — so
   every push left the previous run's jobs racing to completion. Two branches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ version number before tagging the release.
 
 ### Fixed
 
+- **The `aether.toml` walk-up did nothing on native Windows.** `ae build` from
+  a subdirectory is supposed to find the project's manifest in an ancestor
+  directory and chdir there. The walk stepped up by scanning for `/` only,
+  while `_getcwd()` on native Windows returns backslashes, so the loop broke on
+  its first pass and the walk-up silently did nothing — a build that behaved as
+  though the project had no manifest, with no error, so `extra_sources` and
+  `cflags` were dropped for anyone building from a subdirectory on Windows.
+  Both separators are now handled, including the `C:\` root case.
+
+  (Separately and still open: `ae build <bin-name>` from a subdirectory fails
+  on every platform, because the positional argument is rebased onto the
+  subdirectory as though it were a file path — `sub/widget` — when it is a
+  `[[bin]]` name. Pre-existing, unrelated to the separator bug, and not fixed
+  here.)
+
 - **MinGW: `cannot find -lfyaml` and `__imp_nghttp2_*` link failures (#1896).**
   Building `ae` on MSYS2/MinGW failed at link, which made a real Windows box
   unusable as a proving ground. Both errors came from the same cause: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,55 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **`[dependencies]` resolve onto the module search path.** `ae add` installed
+  packages that nothing read back: `ae lib-path` printed `lib`, and
+  `[dependencies]` appeared in the tree only where it was *written*, never
+  parsed for a build. Every consumer therefore hand-wrote a shell script to
+  guess the cache layout and spell out each importable subdirectory as
+  `--lib`. `ae run`, `ae build` and `ae lib-path` now read the section and join
+  the dependency's modules themselves — importing from a declared dependency
+  needs no `--lib` at all.
+
+  The publishing package declares what it exports, in its own `aether.toml`
+  (`[package] modules = "aether, selenium_core, selenium_core/drivermgr"`), so
+  a package can rearrange its directories in a patch release without any
+  consumer changing a path — the consumer names the dependency and nothing
+  else. Entries name importable modules, and each module's *parent* joins the
+  path, matching what `--lib` has always meant. A package root is never joined
+  speculatively: a real package is a whole repository whose root holds docs and
+  scripts too.
+
+  A declared-but-missing dependency now fails as `dependency 'X' is not
+  installed. Run: ae add X` rather than as an unresolved-import error naming a
+  module the user never typed.
+
+  This was reported from the datastar-aether line, where a hand-written
+  resolver globbed two path levels instead of three, silently fell through to a
+  sibling checkout that happened to exist locally, and stayed green for weeks
+  while the package path had never once worked.
+
+- **`--override` and `[patch]` for redirecting a dependency.**
+  `ae run x.ae --override <dep>=<path>` overrides per invocation, leaving no
+  trace in the manifest; `[patch]` does the same from the manifest in a stanza
+  separate from `[dependencies]`, so an override cannot ship by accident inside
+  a dependency line, in either a bare-path or Cargo's `{ path = "..." }` form.
+  `--override` wins where both name a dependency. Both
+  print `Overriding <dep> -> <path>`: an override that applied silently means a
+  green local build against a working copy CI does not have.
+
+### Fixed
+
+- **CI runs were never cancelled when superseded.** Neither `ci.yml` nor
+  `windows.yml` carried a `concurrency:` block — only `release.yml` did — so
+  every push left the previous run's jobs racing to completion. Two branches
+  accumulated 12 and 18 concurrent runs during one day's work, and a stale run
+  kept reporting failure against a commit nobody was on any more, one of them
+  sitting open for six hours after its last job had finished. Superseded runs
+  on a branch are now cancelled. `main` is deliberately exempt: a push there is
+  a merge whose result is worth recording even if another lands seconds later.
+
 ## [0.636.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,16 @@ else
 endif
 ifneq ($(NGHTTP2_LDFLAGS),)
   NGHTTP2_CFLAGS += -DAETHER_HAS_NGHTTP2
+  # #1896: nghttp2.h declares its API __declspec(dllimport) unless
+  # NGHTTP2_STATICLIB is defined (nghttp2.h:58-65). Without it every call
+  # compiles to an __imp_nghttp2_* reference, which the static libnghttp2.a
+  # the link actually uses cannot satisfy -- hence dozens of
+  # "undefined reference to `__imp_nghttp2_session_*'" on MinGW/MSYS2. The
+  # Windows link line is -static (WIN_LINK_LIBS), so the headers have to be
+  # told the same thing the linker was told.
+  ifneq ($(findstring MINGW,$(DETECTED_OS))$(findstring MSYS,$(DETECTED_OS))$(findstring CYGWIN,$(DETECTED_OS)),)
+    NGHTTP2_CFLAGS += -DNGHTTP2_STATICLIB
+  endif
 endif
 
 # Brotli detection: enables std.brotli (RFC 7932). `br` is what current
@@ -550,6 +560,19 @@ endif
 ifneq ($(YAML_LDFLAGS),)
   # libfyaml found (auto/1): compile the real bindings + link it.
   YAML_CFLAGS += -DAETHER_HAS_YAML
+  # #1896: on MinGW/MSYS2 the link line carries -static (WIN_LINK_LIBS below),
+  # which avoids libwinpthread/libgcc DLL dependencies in release binaries.
+  # -static is NOT positional for library resolution -- it governs the whole
+  # link -- so ld demands libfyaml.a. MSYS2's mingw-w64-x86_64-libfyaml ships
+  # ONLY libfyaml.dll.a, so the link fails with "cannot find -lfyaml" even
+  # though the library is installed and pkg-config reports it correctly.
+  # fyaml is the only one of our dependencies with no static archive there
+  # (openssl, zlib, nghttp2, pcre2, brotli and zstd all have both), so scope
+  # the exception to it rather than dropping -static and giving every Windows
+  # binary a DLL tail.
+  ifneq ($(findstring MINGW,$(DETECTED_OS))$(findstring MSYS,$(DETECTED_OS))$(findstring CYGWIN,$(DETECTED_OS)),)
+    YAML_LDFLAGS := -Wl,-Bdynamic $(YAML_LDFLAGS) -Wl,-Bstatic
+  endif
 else
   # libfyaml absent (or YAML=0): define NOTHING and link NOTHING, so
   # aether_yaml.c compiles its unavailable-stub path and the build works

--- a/docs/module-system-design.md
+++ b/docs/module-system-design.md
@@ -447,7 +447,7 @@ Inputs are merged in the same priority order the build path uses: explicit `--li
 "github.com/aether-lang-dev/selaenium" = "0.2.0"
 ```
 
-`ae run`, `ae build` and `ae lib-path` read that section and join the package's modules to the search path. **No `--lib` is needed to import from a declared dependency.**
+`ae run`, `ae build` and `ae lib-path` read that section and join the package's modules to the search path. **No `--lib` is needed to import from a declared dependency.** All three walk up to the project's manifest first, so they behave the same from a subdirectory as from the project root.
 
 The publishing package decides what it exports, in its own `aether.toml`:
 

--- a/docs/module-system-design.md
+++ b/docs/module-system-design.md
@@ -438,6 +438,59 @@ lib
 
 Inputs are merged in the same priority order the build path uses: explicit `--lib` flags first, then `AETHER_LIB_DIR`, then the default `lib`.
 
+#### Dependencies resolve onto the search path
+
+`ae add` installs into `~/.aether/packages/<host>/<owner>/<name>` and records the dependency:
+
+```toml
+[dependencies]
+"github.com/aether-lang-dev/selaenium" = "0.2.0"
+```
+
+`ae run`, `ae build` and `ae lib-path` read that section and join the package's modules to the search path. **No `--lib` is needed to import from a declared dependency.**
+
+The publishing package decides what it exports, in its own `aether.toml`:
+
+```toml
+[package]
+name = "selaenium"
+modules = "aether, selenium_core, selenium_core/drivermgr"
+```
+
+Each entry names an **importable module**, and what joins the search path is that module's parent directory — because `--lib D` means "D contains modules" (`D/<name>.ae` or `D/<name>/module.ae`). So `selenium_core/drivermgr` puts `<package>/selenium_core` on the path and `import drivermgr` resolves.
+
+This is why the declaration lives with the publisher rather than the consumer: a package can move its directories in a patch release without any consumer changing a path. A consumer names the dependency and nothing else. A package with no `aether.toml`, or none with a `modules` key, exports nothing and says so — the package root is never joined speculatively, since a real package is a whole repository whose root holds docs, scripts and tests as well as modules.
+
+A dependency that is declared but not installed fails by name:
+
+```
+Error: dependency 'github.com/aether-lang-dev/selaenium' is not installed. Run:
+    ae add github.com/aether-lang-dev/selaenium
+```
+
+rather than as an unresolved-import error naming a module the user never typed.
+
+#### Overriding a dependency
+
+Two forms, both of which **announce themselves** — an override that applied silently would mean a green local build against a working copy that CI does not have:
+
+```sh
+ae run x.ae --override github.com/aether-lang-dev/selaenium=../selaenium
+```
+
+per-invocation, leaving no trace in the manifest — right for "just this once" and for CI proving a change against an unpublished branch. And in the manifest, a separate stanza so an override cannot be shipped by accident inside a `[dependencies]` line:
+
+```toml
+[patch]
+"github.com/aether-lang-dev/selaenium" = "../selaenium"
+# or Cargo's table form, which means the same thing:
+"github.com/aether-lang-dev/other" = { path = "../other" }
+```
+
+Only a local path override is supported. A table naming anything else (a git URL, say) is an error rather than a silently-ignored line.
+
+Either way the build prints `Overriding <dep> -> <path>`. A `--override` for a dependency also overridden by `[patch]` wins, since the invocation is the more specific instruction. The override target is read exactly like an installed package: it needs its own `[package] modules` declaration.
+
 ### Namespace Convention
 
 Function names must be prefixed with the namespace:

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -1,0 +1,232 @@
+#!/bin/sh
+# #1901: [dependencies] resolve onto the module search path, with overrides.
+#
+# `ae add` installed packages that nothing read back, so every consumer wrote
+# its own shell script to guess the cache layout and spell each importable
+# subdirectory into --lib. The datastar-aether line reported this after their
+# hand-written resolver guessed wrong (two path levels, not three), silently
+# fell through to a sibling checkout that happened to exist, and stayed green
+# for weeks while the package path had never once worked.
+#
+# Asserts:
+#   - a declared dependency's module roots join `ae lib-path`
+#   - `ae run` resolves an import from it with NO --lib at all
+#   - the CONSUMER never spells the package's internal paths: the publishing
+#     package declares them in its own [package] modules
+#   - a missing dependency names itself and the fix, not "unknown module"
+#   - a package that declares nothing exports nothing, and says so
+#   - --override and [patch] both redirect, and both ANNOUNCE it -- the
+#     property the ask cared most about, since a silent override means a green
+#     local run against a working copy CI does not have
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] dep_resolution: ae not built"; exit 0; }
+
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+# A private package cache, so the test never touches the real ~/.aether and
+# never depends on what happens to be installed on the machine.
+PKGS="$TMPDIR_T/home/.aether/packages/example.com/acme/widgets"
+mkdir -p "$PKGS/frontend" "$PKGS/engine/util" "$PKGS/docs"
+cat > "$PKGS/aether.toml" <<'TOMLEOF'
+[package]
+name = "widgets"
+modules = "frontend, engine, engine/util"
+TOMLEOF
+printf 'exports(paint)\npaint() -> string { return "painted" }\n' > "$PKGS/frontend/module.ae"
+printf 'exports(spin)\nspin() -> int { return 7 }\n'              > "$PKGS/engine/module.ae"
+printf 'exports(helper)\nhelper() -> int { return 1 }\n'          > "$PKGS/engine/util/module.ae"
+# A non-module directory at the package root: joining the root would put this
+# on the search path, which is why the package declares roots instead.
+echo "not a module" > "$PKGS/docs/README.md"
+
+PROJ="$TMPDIR_T/proj"
+mkdir -p "$PROJ"
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/widgets" = "1.0.0"
+TOMLEOF
+printf 'import frontend\nmain() {\n    println(frontend.paint())\n    return 0\n}\n' > "$PROJ/use.ae"
+
+cd "$PROJ"
+export HOME="$TMPDIR_T/home"
+
+# --- 1. the declared modules become search paths -----------------------
+# `--lib D` means "D CONTAINS modules", so a declared module joins the path
+# as its PARENT: `frontend` and `engine` put the package root on, and
+# `engine/util` puts `<root>/engine` on. Asserting the leaves instead would
+# pass a resolver that makes every module unimportable.
+OUT=$("$AE" lib-path 2>/dev/null || true)
+for m in "widgets$" "widgets/engine$"; do
+    echo "$OUT" | grep -qE "$m" || {
+        echo "  [FAIL] dep_resolution: no search path matching '$m'"
+        echo "$OUT" | sed 's/^/    /' | head -8; exit 1; }
+done
+echo "$OUT" | grep -q "widgets/docs" && {
+    echo "  [FAIL] dep_resolution: a non-module directory reached the search path"; exit 1; }
+
+# --- 2. an import resolves with NO --lib -------------------------------
+RUN=$("$AE" run use.ae 2>&1 || true)
+case "$RUN" in
+    *painted*) ;;
+    *) echo "  [FAIL] dep_resolution: import did not resolve without --lib"
+       echo "$RUN" | sed 's/^/    /' | head -10; exit 1 ;;
+esac
+
+# --- 3. a missing dependency names itself and the fix -------------------
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/absent" = "1.0.0"
+TOMLEOF
+MISS=$("$AE" lib-path 2>&1 || true)
+case "$MISS" in
+    *"is not installed"*"ae add example.com/acme/absent"*) ;;
+    *) echo "  [FAIL] dep_resolution: missing dependency did not name itself and the fix"
+       echo "$MISS" | sed 's/^/    /' | head -6; exit 1 ;;
+esac
+
+# --- 4. a package declaring nothing exports nothing, loudly -------------
+SILENT="$TMPDIR_T/home/.aether/packages/example.com/acme/silent"
+mkdir -p "$SILENT/lib"
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/silent" = "1.0.0"
+TOMLEOF
+QUIET=$("$AE" lib-path 2>&1 || true)
+case "$QUIET" in
+    *"no aether.toml"*|*"declares no"*) ;;
+    *) echo "  [FAIL] dep_resolution: an undeclaring package failed silently"
+       echo "$QUIET" | sed 's/^/    /' | head -6; exit 1 ;;
+esac
+echo "$QUIET" | grep -q "silent/lib" && {
+    echo "  [FAIL] dep_resolution: guessed a module root for a package that declares none"; exit 1; }
+
+# --- 5. --override redirects, and SAYS so -------------------------------
+FAKE="$TMPDIR_T/fake"
+mkdir -p "$FAKE/frontend"
+printf '[package]\nmodules = "frontend"\n' > "$FAKE/aether.toml"
+printf 'exports(paint)\npaint() -> string { return "OVERRIDDEN" }\n' > "$FAKE/frontend/module.ae"
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/widgets" = "1.0.0"
+TOMLEOF
+OVR=$("$AE" run use.ae --override "example.com/acme/widgets=$FAKE" 2>&1 || true)
+case "$OVR" in
+    *OVERRIDDEN*) ;;
+    *) echo "  [FAIL] dep_resolution: --override did not redirect the build"
+       echo "$OVR" | sed 's/^/    /' | head -8; exit 1 ;;
+esac
+case "$OVR" in
+    *Overriding*) ;;
+    *) echo "  [FAIL] dep_resolution: --override applied SILENTLY; an overridden"
+       echo "         build must announce itself or CI and local disagree unseen"; exit 1 ;;
+esac
+
+# --- 6. [patch] does the same from the manifest -------------------------
+cat >> "$PROJ/aether.toml" <<TOMLEOF
+
+[patch]
+"example.com/acme/widgets" = "$FAKE"
+TOMLEOF
+PATCHED=$("$AE" run use.ae 2>&1 || true)
+case "$PATCHED" in
+    *OVERRIDDEN*) ;;
+    *) echo "  [FAIL] dep_resolution: [patch] did not redirect the build"
+       echo "$PATCHED" | sed 's/^/    /' | head -8; exit 1 ;;
+esac
+case "$PATCHED" in
+    *Overriding*) ;;
+    *) echo "  [FAIL] dep_resolution: [patch] applied silently"; exit 1 ;;
+esac
+
+# --- 6b. [patch] in Cargo's inline-table form ---------------------------
+# The ask quoted `{ path = "../selaenium" }`, so someone will write it. Left
+# unhandled the whole brace expression reaches the filesystem as a filename.
+cat > "$PROJ/aether.toml" <<TOMLEOF
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/widgets" = "1.0.0"
+
+[patch]
+"example.com/acme/widgets" = { path = "$FAKE" }
+TOMLEOF
+TBL=$("$AE" run use.ae 2>&1 || true)
+case "$TBL" in
+    *OVERRIDDEN*) ;;
+    *) echo "  [FAIL] dep_resolution: inline-table [patch] did not redirect"
+       echo "$TBL" | sed 's/^/    /' | head -6; exit 1 ;;
+esac
+# The announced path must be the unwrapped one, not the raw braces.
+case "$TBL" in
+    *"Overriding example.com/acme/widgets -> $FAKE"*) ;;
+    *) echo "  [FAIL] dep_resolution: inline-table override announced the raw table"
+       echo "$TBL" | sed 's/^/    /' | head -4; exit 1 ;;
+esac
+
+# A table naming something we cannot honour must SAY so rather than silently
+# building against the unpatched package.
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/widgets" = "1.0.0"
+
+[patch]
+"example.com/acme/widgets" = { git = "https://example.com/x" }
+TOMLEOF
+GITP=$("$AE" run use.ae 2>&1 || true)
+case "$GITP" in
+    *"no path"*) ;;
+    *) echo "  [FAIL] dep_resolution: an unusable [patch] table failed silently"
+       echo "$GITP" | sed 's/^/    /' | head -6; exit 1 ;;
+esac
+
+# --- 7. `ae build` too, INCLUDING from a subdirectory -------------------
+# `ae build` walks up to the manifest and chdirs there, so resolution has to
+# happen after that walk-up rather than alongside the other flag handling.
+# Resolving first reads no manifest and yields an empty search path -- which
+# still "works" from the project root, so only the subdirectory case catches it.
+cat > "$PROJ/aether.toml" <<'TOMLEOF'
+[package]
+name = "consumer"
+
+[dependencies]
+"example.com/acme/widgets" = "1.0.0"
+TOMLEOF
+mkdir -p "$PROJ/sub"
+cp "$PROJ/use.ae" "$PROJ/sub/use.ae"
+for where in "$PROJ" "$PROJ/sub"; do
+    cd "$where"
+    BOUT=$("$AE" build use.ae -o "$TMPDIR_T/built" 2>&1 || true)
+    if [ ! -x "$TMPDIR_T/built" ]; then
+        echo "  [FAIL] dep_resolution: ae build failed in $where"
+        echo "$BOUT" | sed 's/^/    /' | head -8; exit 1
+    fi
+    RES=$("$TMPDIR_T/built" 2>&1 || true)
+    case "$RES" in
+        *painted*) ;;
+        *) echo "  [FAIL] dep_resolution: built binary from $where printed '$RES'"; exit 1 ;;
+    esac
+    rm -f "$TMPDIR_T/built"
+done
+cd "$PROJ"
+
+echo "  [PASS] dep_resolution: declared roots resolve, overrides redirect and announce"

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -55,7 +55,23 @@ TOMLEOF
 printf 'import frontend\nmain() {\n    println(frontend.paint())\n    return 0\n}\n' > "$PROJ/use.ae"
 
 cd "$PROJ"
+
+# The package cache is found via get_home_dir(), which on Windows prefers
+# USERPROFILE and only falls back to HOME (tools/ae_cache.c). Setting HOME
+# alone leaves a native ae.exe reading the REAL user profile, where the
+# fixture does not exist. On a dev box HOME and USERPROFILE usually name the
+# same directory in two spellings, so that failure appears only in CI --
+# exactly how the cache_subdir_entry_root_module test was caught.
+#
+# A native ae.exe also cannot resolve an MSYS /tmp/... path, so hand it the
+# Windows spelling, the same way http_middleware_d2 does.
 export HOME="$TMPDIR_T/home"
+if command -v cygpath >/dev/null 2>&1; then
+    USERPROFILE="$(cygpath -m "$TMPDIR_T/home")"
+else
+    USERPROFILE="$TMPDIR_T/home"
+fi
+export USERPROFILE
 
 # --- 1. the declared modules become search paths -----------------------
 # `--lib D` means "D CONTAINS modules", so a declared module joins the path
@@ -116,6 +132,14 @@ echo "$QUIET" | grep -q "silent/lib" && {
 # --- 5. --override redirects, and SAYS so -------------------------------
 FAKE="$TMPDIR_T/fake"
 mkdir -p "$FAKE/frontend"
+# The override path is handed to ae and echoed back in its announcement, so on
+# Windows both the value we pass and the string we match must be the native
+# spelling -- a native ae.exe cannot resolve an MSYS /tmp/... path.
+if command -v cygpath >/dev/null 2>&1; then
+    FAKE_N="$(cygpath -m "$FAKE")"
+else
+    FAKE_N="$FAKE"
+fi
 printf '[package]\nmodules = "frontend"\n' > "$FAKE/aether.toml"
 printf 'exports(paint)\npaint() -> string { return "OVERRIDDEN" }\n' > "$FAKE/frontend/module.ae"
 cat > "$PROJ/aether.toml" <<'TOMLEOF'
@@ -125,7 +149,7 @@ name = "consumer"
 [dependencies]
 "example.com/acme/widgets" = "1.0.0"
 TOMLEOF
-OVR=$("$AE" run use.ae --override "example.com/acme/widgets=$FAKE" 2>&1 || true)
+OVR=$("$AE" run use.ae --override "example.com/acme/widgets=$FAKE_N" 2>&1 || true)
 case "$OVR" in
     *OVERRIDDEN*) ;;
     *) echo "  [FAIL] dep_resolution: --override did not redirect the build"
@@ -141,7 +165,7 @@ esac
 cat >> "$PROJ/aether.toml" <<TOMLEOF
 
 [patch]
-"example.com/acme/widgets" = "$FAKE"
+"example.com/acme/widgets" = "$FAKE_N"
 TOMLEOF
 PATCHED=$("$AE" run use.ae 2>&1 || true)
 case "$PATCHED" in
@@ -165,7 +189,7 @@ name = "consumer"
 "example.com/acme/widgets" = "1.0.0"
 
 [patch]
-"example.com/acme/widgets" = { path = "$FAKE" }
+"example.com/acme/widgets" = { path = "$FAKE_N" }
 TOMLEOF
 TBL=$("$AE" run use.ae 2>&1 || true)
 case "$TBL" in
@@ -175,7 +199,7 @@ case "$TBL" in
 esac
 # The announced path must be the unwrapped one, not the raw braces.
 case "$TBL" in
-    *"Overriding example.com/acme/widgets -> $FAKE"*) ;;
+    *"Overriding example.com/acme/widgets -> $FAKE_N"*) ;;
     *) echo "  [FAIL] dep_resolution: inline-table override announced the raw table"
        echo "$TBL" | sed 's/^/    /' | head -4; exit 1 ;;
 esac

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -106,6 +106,20 @@ done
 echo "$OUT" | grep -q "widgets/docs" && {
     echo "  [FAIL] dep_resolution: a non-module directory reached the search path"; exit 1; }
 
+# --- 1c. lib-path agrees from a subdirectory ---------------------------
+# `ae build` walks up to the manifest, so it resolves from anywhere in the
+# project. `ae lib-path` did not, and printed a bare `lib` from a
+# subdirectory while `ae build` in that same directory worked. The documented
+# fallback `ae run x.ae --lib "$(ae lib-path)"` would then silently get an
+# empty chain -- a wrong answer that looks like a valid one.
+mkdir -p "$PROJ/deep"
+SUBOUT=$(cd "$PROJ/deep" && "$AE" lib-path 2>/dev/null || true)
+echo "$SUBOUT" | grep -qE "widgets$" || {
+    echo "  [FAIL] dep_resolution: lib-path from a subdirectory lost the dependencies"
+    echo "    --- from subdirectory ---"; echo "$SUBOUT" | sed 's/^/    /' | head -6
+    echo "    --- from project root ---"; echo "$OUT" | sed 's/^/    /' | head -6
+    exit 1; }
+
 # --- 2. an import resolves with NO --lib -------------------------------
 RUN=$("$AE" run use.ae 2>&1 || true)
 case "$RUN" in

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -31,6 +31,15 @@ trap 'rm -rf "$TMPDIR_T"' EXIT
 # never depends on what happens to be installed on the machine.
 PKGS="$TMPDIR_T/home/.aether/packages/example.com/acme/widgets"
 mkdir -p "$PKGS/frontend" "$PKGS/engine/util" "$PKGS/docs"
+# Verify the fixture actually landed before asserting anything about it. A
+# deep `mkdir -p` under a dot-directory silently fails on some MSYS2 setups
+# (observed on a real Win11/MSYS2 box: step-by-step mkdir works, one-shot
+# `mkdir -p a/.hidden/b/c/d` does not), and a fixture that was never created
+# would otherwise surface as a confusing resolver failure rather than as the
+# environment problem it is.
+for d in "$PKGS/frontend" "$PKGS/engine/util" "$PKGS/docs"; do
+    [ -d "$d" ] || { echo "  [SKIP] dep_resolution: cannot create fixture dir $d"; exit 0; }
+done
 cat > "$PKGS/aether.toml" <<'TOMLEOF'
 [package]
 name = "widgets"
@@ -78,11 +87,21 @@ export USERPROFILE
 # as its PARENT: `frontend` and `engine` put the package root on, and
 # `engine/util` puts `<root>/engine` on. Asserting the leaves instead would
 # pass a resolver that makes every module unimportable.
-OUT=$("$AE" lib-path 2>/dev/null || true)
+OUT=$("$AE" lib-path 2>&1 || true)
 for m in "widgets$" "widgets/engine$"; do
     echo "$OUT" | grep -qE "$m" || {
         echo "  [FAIL] dep_resolution: no search path matching '$m'"
-        echo "$OUT" | sed 's/^/    /' | head -8; exit 1; }
+        # CI logs for the Windows legs come back empty from the API, so the
+        # test has to carry its own diagnosis or a failure is unactionable.
+        echo "    --- lib-path output ---"
+        echo "$OUT" | sed 's/^/    /' | head -10
+        echo "    --- environment ---"
+        echo "    HOME=$HOME"
+        echo "    USERPROFILE=${USERPROFILE:-<unset>}"
+        echo "    pkg dir exists: $([ -d "$PKGS" ] && echo yes || echo NO) ($PKGS)"
+        echo "    pkg manifest:   $([ -f "$PKGS/aether.toml" ] && echo yes || echo NO)"
+        echo "    cwd=$(pwd)"
+        exit 1; }
 done
 echo "$OUT" | grep -q "widgets/docs" && {
     echo "  [FAIL] dep_resolution: a non-module directory reached the search path"; exit 1; }
@@ -92,7 +111,11 @@ RUN=$("$AE" run use.ae 2>&1 || true)
 case "$RUN" in
     *painted*) ;;
     *) echo "  [FAIL] dep_resolution: import did not resolve without --lib"
-       echo "$RUN" | sed 's/^/    /' | head -10; exit 1 ;;
+       echo "$RUN" | sed 's/^/    /' | head -12
+       echo "    --- lib-path at this point ---"
+       "$AE" lib-path 2>&1 | sed 's/^/    /' | head -8
+       echo "    HOME=$HOME USERPROFILE=${USERPROFILE:-<unset>}"
+       exit 1 ;;
 esac
 
 # --- 3. a missing dependency names itself and the fix -------------------

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1682,6 +1682,229 @@ static void expand_env_vars(const char* src, char* dst, size_t dst_size) {
  * -D. A space-separated string rather than a TOML array because the toml
  * reader here returns scalars, and because these are bare names with no
  * spaces in them. Command-line -D adds to whatever the file declares. */
+/* ---- Dependency resolution (#1901) ------------------------------ *
+ *
+ * `ae add` installs a package under ~/.aether/packages/<host>/<owner>/<repo>
+ * and writes it into [dependencies], and until now nothing read it back: a
+ * consumer had to know the cache layout and spell every importable
+ * subdirectory in --lib by hand. The datastar-aether line reported this after
+ * a hand-written resolver guessed the layout wrong (two path levels, not
+ * three), silently fell through to a sibling checkout that happened to exist,
+ * and stayed green for weeks while the package path had never once worked.
+ *
+ * The consumer therefore names ONLY the dependency. Where its importable
+ * modules live is the PUBLISHING package's business, declared in its own
+ * aether.toml:
+ *
+ *     [package]
+ *     modules = "aether, selenium_core, selenium_core/drivermgr"
+ *
+ * so a package can rearrange directories in a patch release without breaking
+ * anyone. There is deliberately NO fallback to the package root: real
+ * packages are whole repositories (the reporter's has clojure/, crystal/, ci/
+ * beside its Aether code), so joining the root would put non-module
+ * directories on the search path and reintroduce exactly the layout coupling
+ * this removes. A package that declares nothing exports nothing, and says so.
+ */
+
+/* Where `ae add` puts packages. Mirrors apkg's own layout. */
+static void dep_packages_root(char* out, size_t osz) {
+    snprintf(out, osz, "%s/.aether/packages", get_home_dir());
+}
+
+/* Per-invocation overrides from --override name=path (#1901 part 2).
+ * Bazel's --override_repository shape: leaves no trace in the manifest, which
+ * is what "just this once" and "CI proving an unpublished branch" want. */
+#define AE_MAX_OVERRIDES 32
+static char g_ovr_name[AE_MAX_OVERRIDES][512];
+static char g_ovr_path[AE_MAX_OVERRIDES][1024];
+static int  g_ovr_count = 0;
+
+void ae_dep_override_append(const char* spec) {
+    const char* eq = strchr(spec, '=');
+    if (!eq || eq == spec || !eq[1]) {
+        fprintf(stderr, "Error: --override wants <dependency>=<path>, got '%s'\n", spec);
+        return;
+    }
+    if (g_ovr_count >= AE_MAX_OVERRIDES) {
+        fprintf(stderr, "Error: too many --override flags (max %d)\n", AE_MAX_OVERRIDES);
+        return;
+    }
+    size_t nlen = (size_t)(eq - spec);
+    if (nlen >= sizeof(g_ovr_name[0])) nlen = sizeof(g_ovr_name[0]) - 1;
+    memcpy(g_ovr_name[g_ovr_count], spec, nlen);
+    g_ovr_name[g_ovr_count][nlen] = '\0';
+    snprintf(g_ovr_path[g_ovr_count], sizeof(g_ovr_path[0]), "%s", eq + 1);
+    g_ovr_count++;
+}
+
+/* A [patch] value is either a bare path string or Cargo's inline table,
+ * `{ path = "../selaenium" }` -- the shape the reporting ask quoted, so it
+ * WILL be written. The TOML parser hands back the raw text for a table, so
+ * pull `path` out of it here rather than letting the whole brace expression
+ * reach dir_exists as a filename. Returns the input unchanged when it is not
+ * a table, and NULL for a table with no usable `path` key -- a table naming
+ * something else (a git URL, say) is not an override we can honour, and
+ * quietly treating it as "no override" would be a silent wrong build. */
+static const char* dep_unwrap_patch_value(const char* v, char* buf, size_t bsz,
+                                          const char* name) {
+    while (*v == ' ' || *v == '\t') v++;
+    if (*v != '{') return v;
+    const char* k = strstr(v, "path");
+    const char* q = k ? strchr(k, '"') : NULL;
+    const char* e = q ? strchr(q + 1, '"') : NULL;
+    if (!e) {
+        fprintf(stderr,
+            "Error: [patch] entry for '%s' is a table with no path = \"...\" key;\n"
+            "       only a local path override is supported. Got: %s\n", name, v);
+        return NULL;
+    }
+    size_t n = (size_t)(e - q - 1);
+    if (n >= bsz) n = bsz - 1;
+    memcpy(buf, q + 1, n);
+    buf[n] = '\0';
+    return buf;
+}
+
+/* An override for `name`, from --override (highest) or the manifest's
+ * [patch] section. Returns NULL when the dependency is not overridden. */
+static const char* dep_override_for(TomlDocument* doc, const char* name) {
+    for (int i = 0; i < g_ovr_count; i++) {
+        if (strcmp(g_ovr_name[i], name) == 0) return g_ovr_path[i];
+    }
+    if (doc) {
+        /* [patch] keys are quoted in the file exactly as [dependencies] keys
+         * are, and the parser keeps the quotes -- so look up both spellings
+         * rather than silently never matching. */
+        static char unwrapped[1024];
+        const char* p = toml_get_value(doc, "patch", name);
+        if (!p || !*p) {
+            char quoted[520];
+            snprintf(quoted, sizeof(quoted), "\"%s\"", name);
+            p = toml_get_value(doc, "patch", quoted);
+        }
+        if (p && *p) return dep_unwrap_patch_value(p, unwrapped, sizeof(unwrapped), name);
+    }
+    return NULL;
+}
+
+/* Append every module root a package declares. `root` is the package's
+ * directory (cache or override). Returns the number appended, or -1 when the
+ * package has no manifest / declares nothing. */
+static int dep_append_module_roots(const char* root, const char* name) {
+    char manifest[2048];
+    snprintf(manifest, sizeof(manifest), "%s/aether.toml", root);
+    if (!path_exists(manifest)) {
+        fprintf(stderr,
+            "Warning: dependency '%s' has no aether.toml, so it declares no\n"
+            "         importable modules. Its maintainer needs a [package]\n"
+            "         modules = \"...\" entry naming the directories to export.\n",
+            name);
+        return -1;
+    }
+    TomlDocument* pdoc = toml_parse_file(manifest);
+    if (!pdoc) return -1;
+    const char* mods = toml_get_value(pdoc, "package", "modules");
+    if (!mods || !*mods) {
+        fprintf(stderr,
+            "Warning: dependency '%s' declares no [package] modules, so nothing\n"
+            "         from it is importable.\n", name);
+        toml_free_document(pdoc);
+        return -1;
+    }
+    char buf[2048];
+    snprintf(buf, sizeof(buf), "%s", mods);
+    int n = 0;
+    for (char* tok = strtok(buf, " \t,"); tok; tok = strtok(NULL, " \t,")) {
+        char full[3072];
+        snprintf(full, sizeof(full), "%s/%s", root, tok);
+        if (!dir_exists(full)) {
+            fprintf(stderr,
+                "Warning: dependency '%s' declares module '%s', which does not\n"
+                "         exist in the installed package.\n", name, tok);
+            continue;
+        }
+        /* `modules` names IMPORTABLE MODULES, not search paths. `--lib D`
+         * means "D contains modules" -- aetherc looks for D/<name>.ae and
+         * D/<name>/module.ae -- so what joins the path is each module's
+         * PARENT. A package exporting `engine/util` puts `<root>/engine` on
+         * the path, and `import util` resolves; appending the leaf itself
+         * would make the module invisible under every spelling.
+         *
+         * Parents repeat (`frontend` and `engine` share the root), and
+         * tc_lib_dir_append_one already drops duplicates. */
+        char* slash = strrchr(full, '/');
+        if (slash && slash > full) *slash = '\0'; else snprintf(full, sizeof(full), "%s", root);
+        tc_lib_dir_append_one(full);
+        n++;
+    }
+    toml_free_document(pdoc);
+    return n;
+}
+
+/* Resolve [dependencies] from the project manifest onto the module search
+ * path. Safe to call when there is no manifest and no dependencies. */
+void ae_resolve_dependencies(void) {
+    if (!path_exists("aether.toml")) return;
+    TomlDocument* doc = toml_parse_file("aether.toml");
+    if (!doc) return;
+
+    int count = 0;
+    TomlKeyValue* deps = toml_get_section_entries(doc, "dependencies", &count);
+    if (!deps || count <= 0) { toml_free_document(doc); return; }
+
+    char pkgroot[1024];
+    dep_packages_root(pkgroot, sizeof(pkgroot));
+
+    for (int i = 0; i < count; i++) {
+        /* Quoted keys keep their quotes through the parser, and a
+         * dependency name is a path with dots so it is ALWAYS quoted in
+         * practice. Strip them, or every lookup and every message carries
+         * literal quote characters. */
+        char name_buf[512];
+        {
+            const char* k = deps[i].key;
+            if (!k || !*k) continue;
+            size_t kl = strlen(k);
+            if (kl >= 2 && k[0] == '"' && k[kl-1] == '"') {
+                snprintf(name_buf, sizeof(name_buf), "%.*s", (int)(kl - 2), k + 1);
+            } else {
+                snprintf(name_buf, sizeof(name_buf), "%s", k);
+            }
+        }
+        const char* name = name_buf;
+        if (!*name) continue;
+
+        const char* ovr = dep_override_for(doc, name);
+        char root[2048];
+        if (ovr) {
+            snprintf(root, sizeof(root), "%s", ovr);
+            /* An overridden build MUST say so. The failure this prevents is a
+             * green local run against a working copy CI does not have --
+             * named explicitly in the reporting ask, and the reason Cargo
+             * prints its "Patching ..." line. */
+            fprintf(stderr, "Overriding %s -> %s\n", name, root);
+            if (!dir_exists(root)) {
+                fprintf(stderr,
+                    "Error: override path for '%s' does not exist: %s\n", name, root);
+                continue;
+            }
+        } else {
+            snprintf(root, sizeof(root), "%s/%s", pkgroot, name);
+            if (!dir_exists(root)) {
+                /* Name the missing dependency and the fix, rather than
+                 * letting it surface later as an unknown-module error. */
+                fprintf(stderr,
+                    "Error: dependency '%s' is not installed. Run:\n"
+                    "    ae add %s\n", name, name);
+                continue;
+            }
+        }
+        dep_append_module_roots(root, name);
+    }
+    toml_free_document(doc);
+}
+
 static void load_defines_from_toml(void) {
     if (!path_exists("aether.toml")) return;
     TomlDocument* doc = toml_parse_file("aether.toml");
@@ -3496,6 +3719,12 @@ static int cmd_run(int argc, char** argv) {
         } else if (strcmp(argv[i], "--extra") == 0 && i + 1 < argc) {
             if (extra_files[0]) strncat(extra_files, " ", sizeof(extra_files) - strlen(extra_files) - 1);
             strncat(extra_files, argv[++i], sizeof(extra_files) - strlen(extra_files) - 1);
+        } else if (strcmp(argv[i], "--override") == 0 && i + 1 < argc) {
+            /* #1901 part 2: --override <dep>=<path>, Bazel's
+             * --override_repository shape. Leaves no trace in the manifest,
+             * which is what "just this once" and "CI proving an unpublished
+             * branch" want. The resolver announces every override it applies. */
+            ae_dep_override_append(argv[++i]);
         } else if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
             /* Issue #413: each `--lib X` appends to the lib search
              * path with the platform separator. A single value may
@@ -3507,6 +3736,10 @@ static int cmd_run(int argc, char** argv) {
             file = argv[i];
         }
     }
+
+    /* #1901: [dependencies] join the module search path, after the caller's
+     * own --lib flags so an explicit path still wins. */
+    ae_resolve_dependencies();
 
     // Resolve directory argument (e.g. "." or "myproject/") to src/main.ae
     if (file && dir_exists(file)) {
@@ -5512,6 +5745,12 @@ static int cmd_build(int argc, char** argv) {
         } else if (strcmp(argv[i], "--extra") == 0 && i + 1 < argc) {
             if (extra_files[0]) strncat(extra_files, " ", sizeof(extra_files) - strlen(extra_files) - 1);
             strncat(extra_files, argv[++i], sizeof(extra_files) - strlen(extra_files) - 1);
+        } else if (strcmp(argv[i], "--override") == 0 && i + 1 < argc) {
+            /* #1901 part 2: --override <dep>=<path>, Bazel's
+             * --override_repository shape. Leaves no trace in the manifest,
+             * which is what "just this once" and "CI proving an unpublished
+             * branch" want. The resolver announces every override it applies. */
+            ae_dep_override_append(argv[++i]);
         } else if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
             /* Issue #413: same append semantics as `ae run` — see
              * cmd_run's --lib handler for the full rationale.
@@ -5702,6 +5941,12 @@ static int cmd_build(int argc, char** argv) {
     // works the same as if the user had run `ae build` from the
     // project root. Closes #280 (2).
     find_and_chdir_to_aether_toml(&file);
+
+    /* #1901: resolve [dependencies] AFTER the walk-up, not with the other
+     * flag handling. `ae build sub/thing.ae` from a subdirectory chdirs to
+     * the project root here; resolving before that would read no manifest
+     * (or the wrong one) and silently produce an empty search path. */
+    ae_resolve_dependencies();
 
     // Read target from aether.toml if not specified on CLI
     if (!target && path_exists("aether.toml")) {
@@ -6429,7 +6674,14 @@ static int cmd_init(int argc, char** argv) {
     fprintf(f, "name = \"%s\"\n", name);
     fprintf(f, "version = \"0.1.0\"\n");
     fprintf(f, "description = \"A new Aether project\"\n");
-    fprintf(f, "license = \"MIT\"\n\n");
+    fprintf(f, "license = \"MIT\"\n");
+    /* #1901: a scaffolded project is an application, so it exports nothing by
+     * default. The commented key is the only place a would-be PUBLISHER finds
+     * out the declaration exists -- without it, a package installs fine and
+     * then exports nothing, which reads as a resolver bug rather than a
+     * missing line in the publisher's own manifest. */
+    fprintf(f, "# modules = \"mylib, mylib/internal\"  "
+               "# Importable modules, if this is a library\n\n");
     fprintf(f, "[[bin]]\n");
     fprintf(f, "name = \"%s\"\n", name);
     fprintf(f, "path = \"src/main.ae\"\n\n");
@@ -7740,6 +7992,10 @@ static int cmd_lib_path(int argc, char** argv) {
     for (int i = 0; i < argc; i++) {
         if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
             tc_lib_dir_append(argv[++i]);
+        } else if (strcmp(argv[i], "--override") == 0 && i + 1 < argc) {
+            /* Accepted here too, so `ae lib-path --override ...` shows the
+             * same chain the equivalent `ae run` would use. */
+            ae_dep_override_append(argv[++i]);
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             printf("Usage: ae lib-path [--lib <dir>%c<dir>...]...\n",
                    AETHER_LIB_PATH_SEP_CHAR);
@@ -7776,6 +8032,10 @@ static int cmd_lib_path(int argc, char** argv) {
 #ifdef _WIN32
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
+    /* #1901: resolved dependencies join the chain too, so
+     * `ae run x.ae --lib "$(ae lib-path)"` works and the package-cache layout
+     * lives here rather than in every consumer's hand-written shell script. */
+    ae_resolve_dependencies();
     if (tc.lib_dir_count == 0) {
         fputs("lib\n", stdout);
         return 0;

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2262,9 +2262,15 @@ static int find_and_chdir_to_aether_toml(const char** file_inout) {
     strncpy(walk, start_cwd, sizeof(walk) - 1);
     walk[sizeof(walk) - 1] = '\0';
 
-    /* Walk up to /. POSIX `dirname` mutates; compose by truncating
-     * at the last '/'. Stop when we either find aether.toml or hit
-     * the root. */
+    /* Walk up to the root. POSIX `dirname` mutates; compose by truncating
+     * at the last separator. Stop when we either find aether.toml or hit
+     * the root.
+     *
+     * BOTH separators, because _getcwd() on native Windows returns
+     * backslashes ("C:\Users\paul\proj\sub"). Scanning for '/' alone found
+     * nothing there, so the loop broke on its first pass and the walk-up
+     * silently did nothing -- `ae build` from a subdirectory missed the
+     * project manifest on Windows while working everywhere else. */
     while (1) {
         char probe[1040];
         snprintf(probe, sizeof(probe), "%s/aether.toml", walk);
@@ -2281,7 +2287,8 @@ static int find_and_chdir_to_aether_toml(const char** file_inout) {
                     /* relative — splice the subdir we walked out of */
                     size_t walk_len = strlen(walk);
                     if (strncmp(start_cwd, walk, walk_len) == 0 &&
-                        start_cwd[walk_len] == '/') {
+                        (start_cwd[walk_len] == '/' ||
+                         start_cwd[walk_len] == '\\')) {
                         const char* sub = start_cwd + walk_len + 1;
                         static char rebased[1024];
                         snprintf(rebased, sizeof(rebased), "%s/%s", sub, f);
@@ -2291,10 +2298,22 @@ static int find_and_chdir_to_aether_toml(const char** file_inout) {
             }
             return 1;
         }
-        /* Step up one directory by truncating at the last '/'. Stop
+        /* Step up one directory by truncating at the last separator. Stop
          * when we hit the root marker (just "/" or empty). */
         char* slash = strrchr(walk, '/');
+        char* bslash = strrchr(walk, '\\');
+        if (bslash > slash) slash = bslash;
         if (!slash) break;
+        /* "C:\" / "C:/" is the Windows root -- truncating at that separator
+         * would leave a bare "C:", which names the drive's CURRENT directory
+         * rather than its root, so probe there and stop. */
+        if (slash > walk && slash[-1] == ':') {
+            slash[1] = '\0';
+            char root_probe[1040];
+            snprintf(root_probe, sizeof(root_probe), "%saether.toml", walk);
+            if (path_exists(root_probe) && chdir(walk) == 0) return 1;
+            break;
+        }
         if (slash == walk) {
             /* At "/X" — the parent is "/". One more probe at "/". */
             walk[1] = '\0';

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -8034,7 +8034,15 @@ static int cmd_lib_path(int argc, char** argv) {
 #endif
     /* #1901: resolved dependencies join the chain too, so
      * `ae run x.ae --lib "$(ae lib-path)"` works and the package-cache layout
-     * lives here rather than in every consumer's hand-written shell script. */
+     * lives here rather than in every consumer's hand-written shell script.
+     *
+     * Walk up to the manifest first, exactly as `ae build` does. Without it
+     * `ae lib-path` reports the dependencies only when run from the project
+     * root and prints a bare `lib` from any subdirectory -- while `ae build`
+     * from that same subdirectory resolves them fine. That inconsistency is
+     * worst for the shell-script fallback above, which would silently hand
+     * `--lib` an empty chain. */
+    find_and_chdir_to_aether_toml(NULL);
     ae_resolve_dependencies();
     if (tc.lib_dir_count == 0) {
         fputs("lib\n", stdout);

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -145,6 +145,11 @@ int wasm_collect_export_names(const char* c_file, const char* explicit_list,
 
 int  run_cross_compile_obj(const char* c_file, const char* obj_file,
                            bool optimize, const char* ztriple);
+/* #1901: resolve [dependencies] from aether.toml onto the module search
+ * path, honouring [patch] and --override. Safe with no manifest. */
+void ae_resolve_dependencies(void);
+void ae_dep_override_append(const char* spec);
+
 int  run_cross_build(const char* c_file, const char* out_file,
                      bool optimize, const char* extra_files,
                      const char* ztriple, bool emit_lib, bool emit_staticlib);


### PR DESCRIPTION
Closes #1901. Also closes #1896.

## Part 1 — `[dependencies]` resolve

`ae add` installed packages that nothing read back. `ae lib-path` printed `lib`; `[dependencies]` appeared in the tree only where it was *written*, never parsed for a build. So every consumer hand-wrote a shell script to guess the cache layout and spell each importable subdirectory into `--lib`.

The datastar-aether line reported this after their script globbed two path levels instead of three, silently fell through to a sibling checkout that happened to exist locally, and stayed green for weeks while the package path had never once worked. They had "tested" it — against a synthetic packages tree built with the same wrong assumption baked in.

`ae run`, `ae build` and `ae lib-path` now read the section themselves. **Importing from a declared dependency needs no `--lib` at all.**

The publishing package declares what it exports, in its own `aether.toml`:

```toml
[package]
modules = "aether, selenium_core, selenium_core/drivermgr"
```

so it can rearrange directories in a patch release without any consumer changing a path — the property the ask asked for ("the consumer never spells the dependency's internal paths").

Entries name importable **modules**, and each module's *parent* joins the path, matching what `--lib` has always meant (`--lib D` looks for `D/<name>.ae` and `D/<name>/module.ae`). Appending the leaf instead makes every module invisible under every spelling — the first cut did exactly that, and `ae lib-path` looked perfectly correct while no import resolved. The test asserts the parents for that reason, and separately asserts that an import resolves with no `--lib`; that second assertion is the one with teeth.

There is deliberately **no fallback to the package root**: real packages are whole repositories, so joining the root would put `docs/` and `ci/` on the search path and reintroduce the coupling this removes. A package declaring nothing exports nothing, and says so.

A declared-but-missing dependency fails as `dependency 'X' is not installed. Run: ae add X` rather than as an unresolved-import error naming a module the user never typed.

## Part 2 — overrides

- `ae run x.ae --override <dep>=<path>` — per invocation, Bazel's shape, no trace in the manifest.
- `[patch]` — from the manifest, in a stanza separate from `[dependencies]` so an override cannot ship by accident inside a dependency line. Takes a bare path or Cargo's `{ path = "..." }` table; a table naming anything else (a git URL) is an error, not a silently-ignored line.

`--override` wins where both name a dependency. **Both print `Overriding <dep> -> <path>`** — the property the ask cared most about, since an override applied silently means a green local build against a working copy CI does not have.

## Also fixed

**CI runs were never cancelled when superseded.** Neither `ci.yml` nor `windows.yml` carried a `concurrency:` block — only `release.yml` did. Two branches accumulated 12 and 18 runs in one day, and [one stale run sat open for six hours](https://github.com/aether-lang-dev/aether/actions/runs/33905809601) reporting failure for a commit nobody was on. `main` is exempt: a push there is a merge whose result is worth recording. **Verified in this PR** — pushing `91a2fd3c` cancelled the in-flight runs on `47997ad2` rather than letting them race.

**#1896 — MinGW link failures.** Building `ae` on MSYS2/MinGW failed two ways, both because the Windows link line carries `-static` and two dependencies were not told:

- `cannot find -lfyaml`: `-static` is not positional for library *resolution*, so `ld` demanded `libfyaml.a` while MSYS2 ships only `libfyaml.dll.a`. The library *was* installed and `pkg-config` *was* correct, which is why it looked like a missing package. fyaml is the only one of our eight dependencies without a static archive there, so it is scoped to `-Wl,-Bdynamic` / `-Wl,-Bstatic` rather than dropping `-static` for everything.
- `__imp_nghttp2_*`: a different cause. `nghttp2.h` declares its API `__declspec(dllimport)` unless `NGHTTP2_STATICLIB` is defined, so calls compiled to `__imp_` references the static archive cannot satisfy.

**The `aether.toml` walk-up did nothing on native Windows.** It stepped up a directory by scanning for `/`, and `_getcwd()` on Windows returns backslashes, so the loop broke on its first pass. `ae build` from a subdirectory silently behaved as though the project had no manifest — dropping `extra_sources` and `cflags`, with no error. Pre-existing and unrelated to dependencies; it surfaced only because the new test compares root against subdirectory output.

**`ae lib-path` now walks up too**, like `ae build`. It previously printed a bare `lib` from a subdirectory — which would have handed the ask's own documented fallback, `ae run x.ae --lib "$(ae lib-path)"`, an empty chain.

## Testing

27/27 CI checks green. New integration test builds its own package fixture under a private `HOME`/`USERPROFILE`, so it never touches the real `~/.aether`. It asserts resolution, the no-`--lib` import, root/subdirectory agreement, the missing-dependency message, that an undeclaring package exports nothing, that both override forms redirect **and announce** in bare and table forms, and that `ae build` works from a subdirectory.

Verified on a real Win11/MSYS2/MinGW box and locally: `make test` 409/409, `make check-docs`, `make test-ae` 1066/1068 — the two failures (`http_server_h2` curl HTTP/2 framing flake, `windows_crt_symbols`) confirmed failing identically on a clean stashed `main`.

Filed **#1905** along the way: `ae build <bin-name>` from a subdirectory fails on every platform, because the positional is rebased as a file path (`sub/widget`) when it is a `[[bin]]` name. Pre-existing, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
