### PR TITLE
Accept single-file modules in [package] modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A single-file module could not be declared in `[package] modules`.** The
+  check accepted only a directory, while `--lib D` has always resolved both
+  `D/<name>/module.ae` and `D/<name>.ae`. So a package exporting
+  `aether/webdriver.ae` was told the module "does not exist" and could export
+  nothing. Found against the real installed `selaenium` package — the one the
+  dependency-resolution issue was reported from — which is exactly that shape,
+  so the first cut rejected the very package it was written for.
+
 ## [0.637.0]
 
 ### Added

--- a/docs/module-system-design.md
+++ b/docs/module-system-design.md
@@ -457,7 +457,7 @@ name = "selaenium"
 modules = "aether, selenium_core, selenium_core/drivermgr"
 ```
 
-Each entry names an **importable module**, and what joins the search path is that module's parent directory — because `--lib D` means "D contains modules" (`D/<name>.ae` or `D/<name>/module.ae`). So `selenium_core/drivermgr` puts `<package>/selenium_core` on the path and `import drivermgr` resolves.
+Each entry names an **importable module**, and what joins the search path is that module's parent directory — because `--lib D` means "D contains modules" (`D/<name>.ae` or `D/<name>/module.ae`). So `selenium_core/drivermgr` puts `<package>/selenium_core` on the path and `import drivermgr` resolves. Either module form counts: `aether/webdriver` names a single-file `aether/webdriver.ae` just as readily as a directory holding `module.ae`.
 
 This is why the declaration lives with the publisher rather than the consumer: a package can move its directories in a patch release without any consumer changing a path. A consumer names the dependency and nothing else. A package with no `aether.toml`, or none with a `modules` key, exports nothing and says so — the package root is never joined speculatively, since a real package is a whole repository whose root holds docs, scripts and tests as well as modules.
 

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -120,6 +120,31 @@ echo "$SUBOUT" | grep -qE "widgets$" || {
     echo "    --- from project root ---"; echo "$OUT" | sed 's/^/    /' | head -6
     exit 1; }
 
+# --- 1d. a SINGLE-FILE module can be declared --------------------------
+# `--lib D` resolves both `D/<name>/module.ae` and `D/<name>.ae`, so a
+# declaration has to accept both -- checking only for a directory makes
+# single-file modules undeclarable. The selaenium package this issue came
+# from is exactly that shape (`aether/webdriver.ae`, no directory), so the
+# first cut rejected the very package it was written for.
+printf 'exports(solo)\nsolo() -> int { return 42 }\n' > "$PKGS/engine/solo.ae"
+cat > "$PKGS/aether.toml" <<'TOMLEOF'
+[package]
+name = "widgets"
+modules = "frontend, engine, engine/util, engine/solo"
+TOMLEOF
+SOLO=$("$AE" lib-path 2>&1 || true)
+case "$SOLO" in
+    *"neither"*|*"does not"*)
+        echo "  [FAIL] dep_resolution: a single-file module was rejected"
+        echo "$SOLO" | sed 's/^/    /' | head -6; exit 1 ;;
+esac
+# Restore the manifest the rest of the test expects.
+cat > "$PKGS/aether.toml" <<'TOMLEOF'
+[package]
+name = "widgets"
+modules = "frontend, engine, engine/util"
+TOMLEOF
+
 # --- 2. an import resolves with NO --lib -------------------------------
 RUN=$("$AE" run use.ae 2>&1 || true)
 case "$RUN" in

--- a/tests/integration/dep_resolution/test_dep_resolution.sh
+++ b/tests/integration/dep_resolution/test_dep_resolution.sh
@@ -138,6 +138,14 @@ case "$SOLO" in
         echo "  [FAIL] dep_resolution: a single-file module was rejected"
         echo "$SOLO" | sed 's/^/    /' | head -6; exit 1 ;;
 esac
+# Its PARENT joins the path, same as a directory module -- not the file, and
+# not the name with .ae stripped. `engine/solo.ae` means `<pkg>/engine`.
+echo "$SOLO" | grep -qE "widgets/engine$" || {
+    echo "  [FAIL] dep_resolution: single-file module gave the wrong search path"
+    echo "$SOLO" | sed 's/^/    /' | head -6; exit 1; }
+echo "$SOLO" | grep -q "solo" && {
+    echo "  [FAIL] dep_resolution: the single-file module itself reached the path"
+    echo "$SOLO" | sed 's/^/    /' | head -6; exit 1; }
 # Restore the manifest the rest of the test expects.
 cat > "$PKGS/aether.toml" <<'TOMLEOF'
 [package]

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -1818,10 +1818,19 @@ static int dep_append_module_roots(const char* root, const char* name) {
     for (char* tok = strtok(buf, " \t,"); tok; tok = strtok(NULL, " \t,")) {
         char full[3072];
         snprintf(full, sizeof(full), "%s/%s", root, tok);
-        if (!dir_exists(full)) {
+        /* A module is either a DIRECTORY holding module.ae or a single .ae
+         * FILE -- `--lib D` resolves both `D/<name>/module.ae` and
+         * `D/<name>.ae`, so a declaration must accept both or single-file
+         * modules become undeclarable. The selaenium package that prompted
+         * this issue is exactly that shape: `aether/webdriver.ae`, no
+         * directory. Checking only for a directory rejected it. */
+        char as_file[3072];
+        snprintf(as_file, sizeof(as_file), "%s.ae", full);
+        if (!dir_exists(full) && !path_exists(as_file)) {
             fprintf(stderr,
-                "Warning: dependency '%s' declares module '%s', which does not\n"
-                "         exist in the installed package.\n", name, tok);
+                "Warning: dependency '%s' declares module '%s', but neither\n"
+                "         %s/ nor %s.ae exists in the installed package.\n",
+                name, tok, tok, tok);
             continue;
         }
         /* `modules` names IMPORTABLE MODULES, not search paths. `--lib D`


### PR DESCRIPTION
Follow-up to #1904, found by testing the **shipped v0.637.0 against the real installed `selaenium` package** rather than the synthetic fixture the test builds.

## The bug

`[package] modules` entries were checked with `dir_exists` only. But `--lib D` has always resolved both forms:

- `D/<name>/module.ae` — a directory module
- `D/<name>.ae` — a single-file module

So a package exporting a single-file module was told its own module "does not exist", and could export nothing at all.

## Why it matters

`selaenium` — the package the dependency-resolution issue was reported from — is exactly that shape:

```
selaenium/aether/webdriver.ae     # a file, not a directory
```

So #1901's first cut **rejected the very package it was written for**. With the fix and `modules = "aether/webdriver"` declared:

```
$ ae lib-path
/home/paul/.aether/packages/github.com/aether-lang-dev/selaenium/aether

$ ae build u.ae      # `import webdriver`
error: unresolved import 'selenium_core'  --> u.ae:22:1
error: unresolved import 'selenium_bidi'  --> u.ae:23:1
...
```

Those errors are `webdriver.ae`'s **own** transitive imports at lines 22-25 — the module resolved and is being compiled. Before the fix it was `unresolved import 'webdriver'`.

The warning text now names both spellings it looked for, rather than saying only that a directory is missing.

## One thing worth recording

`selaenium`'s repository root holds `clojure/`, `crystal/`, `ci/` and `AGENTS.md` beside its Aether code. That is the concrete argument for #1904's no-fallback-to-package-root decision — joining the root would have put all of it on the module search path.

## Testing

`make test` 409/409, `make check-docs` green, and the `dep_resolution` integration test gains an assertion that a declared single-file module is accepted. Verified against the real installed package, with the package's own tree left unmodified afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)