### PR TITLE
Own a string field assigned through a nested path (#1879)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`heap.free` leaked a string field assigned through a nested path (#1879).**
+  Follow-up to #1866. `o.inner.name = ...` emitted a bare store with no
+  `_heap_<field>` tracker, so the inner struct's destructor believed it owned
+  nothing and the string leaked — while the identical write spelled on the
+  inner pointer, `i.name = ...`, released correctly. Ownership followed how the
+  assignment was *spelled* rather than the type, and nothing warned. The
+  ownership wrapper only recognised an object that was a bare identifier; a
+  nested path presents a member access instead, so it fell through to the plain
+  assignment.
+
+  Reaching a field through an owned sub-object is ordinary — a model holds a
+  material, the material holds a texture path — so `model_set_texture(m, path)`
+  writing `m.material.texture_path` silently leaked.
+
+  A **local alias** leaked for the same reason: `p = o.inner; p.name = ...` is
+  a bare identifier but neither a `heap.new` box nor a pointer parameter, so it
+  missed the wrapper too. The wrapper now accepts any struct pointer — safe
+  because whether the *previous* value may be freed is decided separately, and
+  that check is unchanged.
+
+  One limit remains, deliberately: the previous value is not freed when a
+  nested field is *re-assigned*, so `o.inner.name = a` followed by
+  `o.inner.name = b` still drops `a`. Freeing it means reading the existing
+  `_heap_<field>`, which is only sound on a box the compiler can see was
+  zero-initialised by `heap.new`; an inner struct reached through a pointer
+  field is not visible that way and may have come from `malloc(n) as *T`, whose
+  tracker is garbage. Acting on that frees a garbage pointer, so this matches
+  what a pointer parameter already does (#1873): claim ownership, do not
+  release the old value.
+
 ## [0.638.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1470,10 +1470,82 @@ static int is_ptr_struct_param(CodeGenerator* gen, const char* name) {
     return 0;
 }
 
+/* #1879: emit a NESTED-path field assignment (`o.inner.name = ...`).
+ *
+ * The identifier-only path below cannot serve this: it splices `obj->value`
+ * into the generated C as a bare name, and here the object is itself a member
+ * access. The result was a plain store with no `_heap_<field>` tracker, so the
+ * inner struct's destructor believed it owned nothing and the string leaked --
+ * while the identical write spelled on the inner pointer released correctly.
+ * Ownership followed how the assignment was SPELLED rather than the type.
+ *
+ * The object expression is bound to a temporary first: it is emitted three
+ * times (store, tracker, and the field read) and re-evaluating it would run
+ * any side effects more than once.
+ *
+ * The previous value is NOT freed here, for the #1873 reason. Reading
+ * `_heap_<field>` is only safe on a box we can SEE was zero-initialised by
+ * heap.new, and an inner struct reached through a pointer field is not
+ * visible that way -- it may have come from `malloc(n) as *T`, whose tracker
+ * is garbage, and acting on that frees a garbage pointer. Setting the tracker
+ * is safe regardless and is what stops the leak; a repeated assignment
+ * through a nested path can still drop the earlier value, which is strictly
+ * better than a segfault and matches what a pointer parameter already does. */
+static int emit_nested_field_heap_assign(CodeGenerator* gen, ASTNode* lhs,
+                                         ASTNode* rhs, ASTNode* obj) {
+    Type* obj_type = obj->node_type;
+    if (!obj_type) return 0;
+    /* Only a struct POINTER: a nested value struct is reached by "." and is
+     * covered by the identifier path when written on a local. */
+    if (obj_type->kind != TYPE_PTR || !obj_type->element_type ||
+        obj_type->element_type->kind != TYPE_STRUCT ||
+        !obj_type->element_type->struct_name) return 0;
+    if (!gen->program) return 0;
+
+    ASTNode* sdef = find_struct_definition_by_name(gen->program,
+                                                   obj_type->element_type->struct_name);
+    if (!sdef) return 0;
+    ASTNode* matching_field = NULL;
+    for (int fi = 0; fi < sdef->child_count; fi++) {
+        ASTNode* f = sdef->children[fi];
+        if (f && f->type == AST_STRUCT_FIELD &&
+            f->value && strcmp(f->value, lhs->value) == 0) {
+            matching_field = f;
+            break;
+        }
+    }
+    if (!matching_field || !matching_field->node_type ||
+        matching_field->node_type->kind != TYPE_STRING) return 0;
+    if (!struct_has_heap_string_field(sdef)) return 0;
+
+    int rhs_is_heap = is_heap_string_expr(gen, rhs);
+    /* Unique per emission: these blocks nest (an argument to the RHS may
+     * itself be a nested-path assignment), and a fixed name would shadow. */
+    static int nested_tgt_seq = 0;
+    char tgt[32];
+    snprintf(tgt, sizeof(tgt), "_ae_ntgt%d", nested_tgt_seq++);
+
+    print_indent(gen);
+    fprintf(gen->output, "{ %s* %s = ",
+            obj_type->element_type->struct_name, tgt);
+    generate_expression(gen, obj);
+    fprintf(gen->output, "; %s->%s = ", tgt, lhs->value);
+    generate_expression(gen, rhs);
+    fprintf(gen->output, "; %s->_heap_%s = %d; }\n",
+            tgt, lhs->value, rhs_is_heap ? 1 : 0);
+    return 1;
+}
+
 static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNode* rhs) {
     if (!gen || !lhs || !rhs) return 0;
     if (lhs->type != AST_MEMBER_ACCESS || !lhs->value) return 0;
     if (lhs->child_count != 1 || !lhs->children[0]) return 0;
+    /* #1879: a nested path (`o.inner.name`) has a MEMBER_ACCESS object rather
+     * than a bare identifier. Handle it separately -- the code below splices
+     * the object in as a name. */
+    if (lhs->children[0]->type == AST_MEMBER_ACCESS) {
+        return emit_nested_field_heap_assign(gen, lhs, rhs, lhs->children[0]);
+    }
     if (lhs->children[0]->type != AST_IDENTIFIER || !lhs->children[0]->value) return 0;
     ASTNode* obj = lhs->children[0];
     Type* obj_type = obj->node_type;
@@ -1495,9 +1567,17 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
         struct_name = obj_type->struct_name;
     } else if (obj_type->kind == TYPE_PTR && obj_type->element_type &&
                obj_type->element_type->kind == TYPE_STRUCT &&
-               obj_type->element_type->struct_name &&
-               (is_heap_box_var(gen, obj->value) ||
-                is_ptr_struct_param(gen, obj->value))) {
+               obj_type->element_type->struct_name) {
+        /* #1879: ANY struct pointer, not only a heap.new local or a pointer
+         * parameter. A local ALIAS (`p = o.inner; p.name = ...`) is neither,
+         * so it used to fall through to a bare store and leak -- the same
+         * "ownership depends on how you spell it" defect as the nested path,
+         * reached by binding the inner pointer to a name first.
+         *
+         * Widening is safe because the trustworthiness check below, not this
+         * guard, is what decides whether the previous value may be FREED.
+         * Claiming ownership is sound for any struct pointer; reading a
+         * possibly-garbage tracker is not, and that stays gated. */
         /* #1873: a PARAMETER is not a promise that the box was zeroed — the
          * caller may have handed us `malloc(n) as *T`, whose `_heap_<field>`
          * tracker is garbage. Reading it to decide whether to free the

--- a/tests/integration/heap_nested_path_ownership/prog.ae
+++ b/tests/integration/heap_nested_path_ownership/prog.ae
@@ -1,0 +1,76 @@
+// #1879: a string field assigned through a NESTED path is owned the same way
+// as one assigned on the inner pointer directly.
+//
+// `o.inner.name = ...` emitted a bare store with no `_heap_name` tracker, so
+// Inner's destructor believed it owned nothing and the string leaked, while
+// the identical write spelled `i.name = ...` released correctly. Ownership
+// followed how the assignment was SPELLED rather than the type.
+import std.heap
+import std.string
+
+struct Inner { name: string }
+struct Outer { inner: *Inner }
+
+struct Leaf { tag: string }
+struct Mid { leaf: *Leaf }
+struct Top { mid: *Mid }
+
+own(previous: string, value: string) -> string {
+    if previous != null { string.free(previous) }
+    return string.copy(value)
+}
+
+set_through_outer(o: *Outer, v: string) {
+    o.inner.name = own(o.inner.name, v)
+}
+
+set_direct(i: *Inner, v: string) {
+    i.name = own(i.name, v)
+}
+
+main() {
+    // The reported case: assigned through a nested path inside a function.
+    a = heap.new(Outer)
+    a.inner = heap.new(Inner)
+    set_through_outer(a, "assigned-through-a-nested-path")
+    heap.free(a.inner)
+    heap.free(a)
+
+    // The case that already worked -- must keep working, and must not
+    // double-free now that the nested form also claims ownership.
+    b = heap.new(Outer)
+    b.inner = heap.new(Inner)
+    set_direct(b.inner, "assigned-on-the-inner-pointer")
+    heap.free(b.inner)
+    heap.free(b)
+
+    // The report notes that inlining the same write into main also leaked,
+    // so it is the path shape rather than the function boundary.
+    c = heap.new(Outer)
+    c.inner = heap.new(Inner)
+    c.inner.name = string.copy("assigned-inline-in-main")
+    heap.free(c.inner)
+    heap.free(c)
+
+    // Three levels: the object expression is itself a nested access.
+    t = heap.new(Top)
+    t.mid = heap.new(Mid)
+    t.mid.leaf = heap.new(Leaf)
+    t.mid.leaf.tag = string.copy("three-levels-deep")
+    heap.free(t.mid.leaf)
+    heap.free(t.mid)
+    heap.free(t)
+
+    // A local ALIAS to the inner pointer: a bare identifier, but neither a
+    // heap.new box nor a pointer parameter, so it used to miss the ownership
+    // wrapper too. Same defect as the nested path, reached by naming the
+    // inner pointer first.
+    d = heap.new(Outer)
+    d.inner = heap.new(Inner)
+    alias = d.inner
+    alias.name = string.copy("assigned-through-a-local-alias")
+    heap.free(d.inner)
+    heap.free(d)
+
+    println("all freed")
+}

--- a/tests/integration/heap_nested_path_ownership/test_heap_nested_path_ownership.sh
+++ b/tests/integration/heap_nested_path_ownership/test_heap_nested_path_ownership.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# A struct string field is owned the same way however the path is spelled (#1879).
+#
+# Follow-up to #1866. That fixed the setter-through-a-parameter case; a NESTED
+# path (`o.inner.name = ...`) still emitted a bare store with no
+# `_heap_<field>` tracker, so the inner struct's destructor believed it owned
+# nothing and the string leaked -- while the identical write on the inner
+# pointer released correctly. Ownership followed how the assignment was
+# SPELLED rather than the type, which the reporter reached through the
+# ordinary shape of a model holding a material holding a texture path.
+#
+# Running to completion is half the assertion (a double free aborts). The
+# emitted ownership claim is checked directly too, so this still means
+# something on the platforms with no leak checker in CI.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+AETHERC="$ROOT/build/aetherc"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+if ! "$AETHERC" "$SCRIPT_DIR/prog.ae" "$TMP/out.c" > "$TMP/gen.log" 2>&1; then
+    echo "  [FAIL] heap_nested_path_ownership: codegen failed"
+    sed 's/^/        /' "$TMP/gen.log" | head -8
+    exit 1
+fi
+
+# The direct write already claimed ownership before the fix; the nested one
+# did not. Both must now, and `name` is written both ways in prog.ae, so
+# count the claims rather than merely finding one.
+claims=$(grep -c "_heap_name = 1" "$TMP/out.c" || true)
+if [ "$claims" -lt 4 ]; then
+    echo "  [FAIL] heap_nested_path_ownership: expected >=4 '_heap_name = 1' claims, found $claims"
+    echo "         (set_through_outer, set_direct, the inline write, and the alias)"
+    grep -n "_heap_name" "$TMP/out.c" | sed 's/^/        /' | head -8
+    exit 1
+fi
+# Three levels deep: the object of the assignment is itself a member access.
+if ! grep -q "_heap_tag = 1" "$TMP/out.c"; then
+    echo "  [FAIL] heap_nested_path_ownership: a three-level path did not claim ownership"
+    exit 1
+fi
+
+if ! "$AE" build "$SCRIPT_DIR/prog.ae" -o "$TMP/prog" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] heap_nested_path_ownership: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -8
+    exit 1
+fi
+
+if ! "$TMP/prog" > "$TMP/out.txt" 2>&1; then
+    echo "  [FAIL] heap_nested_path_ownership: program aborted (double free?)"
+    sed 's/^/        /' "$TMP/out.txt" | head -6
+    exit 1
+fi
+grep -q "^all freed$" "$TMP/out.txt" || {
+    echo "  [FAIL] heap_nested_path_ownership: program did not run to completion"
+    sed 's/^/        /' "$TMP/out.txt" | head -6
+    exit 1
+}
+
+# Where a leak checker exists, assert the actual property rather than only the
+# generated text -- the tracker could be set and still not be read at free.
+if command -v valgrind >/dev/null 2>&1; then
+    if ! valgrind --error-exitcode=9 --leak-check=full --errors-for-leak-kinds=definite \
+            "$TMP/prog" > "$TMP/vg.txt" 2>&1; then
+        echo "  [FAIL] heap_nested_path_ownership: valgrind reported a definite leak"
+        grep -E "definitely lost|Invalid" "$TMP/vg.txt" | sed 's/^/        /' | head -6
+        exit 1
+    fi
+fi
+
+echo "  [PASS] heap_nested_path_ownership: a field assigned through a nested path is owned like a direct one"


### PR DESCRIPTION
Closes #1879. Follow-up to #1866.

## The bug

`o.inner.name = ...` emitted a bare store with no `_heap_<field>` tracker, so `Inner`'s destructor believed it owned nothing and the string leaked — while the identical write spelled on the inner pointer, `i.name = ...`, released correctly.

Ownership followed how the assignment was **spelled** rather than the type, and nothing warned.

As the reporter put it, reaching a field through an owned sub-object is ordinary: a model holds a material, the material holds a texture path, so `model_set_texture(m, path)` naturally writes `m.material.texture_path` — and that silently leaked.

## Two spellings missed the wrapper

**1. A nested path.** `emit_struct_field_heap_assign` required the assignment's object to be a bare `AST_IDENTIFIER`, because it splices that name straight into the generated C. A nested path presents an `AST_MEMBER_ACCESS` instead, so the function returned 0 and the caller fell through to the plain assignment:

```c
// before
(o->inner->name = own(o->inner->name, v));

// after
{ Inner* _ae_ntgt0 = o->inner; _ae_ntgt0->name = own(o->inner->name, v); _ae_ntgt0->_heap_name = 1; }
```

The temporary is uniquely named because these blocks nest — an argument to the RHS can contain another such assignment.

**2. A local alias**, found while testing the first. `p = o.inner; p.name = ...` leaks 32 bytes for a different reason: `p` *is* a bare identifier, so it passes the shape check, but it is neither a `heap.new` box nor a pointer parameter, so it failed both name-based guards. The guard now accepts **any** struct pointer.

That widening is safe because the name-based guard was never what made freeing sound — `tracker_is_trustworthy` decides that, and it is unchanged. Claiming ownership is sound for any struct pointer; *reading* a possibly-garbage `_heap_<field>` is not, and stays gated to a box the compiler can see was zeroed by `heap.new`. `heap_field_setter_malloc_box`, which guards exactly that garbage-tracker free, still passes.

## One limit kept, deliberately

The previous value is **not** freed on re-assignment, so `o.inner.name = a; o.inner.name = b` still drops `a`. The direct spelling releases it, so this asymmetry is real — and measured, not assumed:

| | repeated assignment |
|---|---|
| `i.name = ...` on a local box | 0 errors |
| `o.inner.name = ...` nested | 32 bytes definitely lost |

Freeing means reading the existing tracker, which on a hand-`malloc`'d box is garbage — acting on which frees a garbage pointer. This matches what a pointer parameter already does (#1873). It is stated in the CHANGELOG rather than left to be discovered; a segfault would be strictly worse than a leak.

## Testing

Four spellings verified clean under valgrind, where before only the direct one was:

| spelling | before | after |
|---|---|---|
| `o.inner.name` (reporter's repro) | 63 bytes lost | 0 errors |
| `p = o.inner; p.name` (alias) | 32 bytes lost | 0 errors |
| `q = get_inner(o); q.name` (returned ptr) | leaked | 0 errors |
| `t.mid.leaf.tag` (three levels) | leaked | 0 errors |

Plus **macOS `leaks --atExit`: 0 leaks for 0 bytes** — the exact tool and platform from the report, which showed "2 leaks for 96 total leaked bytes".

All six sibling heap tests pass; `make test` 409/409; `make test-ae` shows only the two failures already present on clean `main` (`http_server_h2` curl HTTP/2 framing flake, `windows_crt_symbols`).

The new test asserts the ownership claim in the emitted C (so it means something where no leak checker runs), that the program completes (a double free aborts), and — where valgrind exists — the actual leak property, since the tracker could be set and still not read at free time. **Confirmed to fail on the unfixed compiler**: 1 ownership claim instead of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
