### PR TITLE
Pin the tag in ae add, and leave no clone behind on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`ae add <pkg>@<tag>` never pinned the tag, and left an unpinned clone
+  behind on failure.** The checkout ran through the argv-spawning `run_cmd`,
+  which uses no shell, so `cd "dir" && git checkout ... 2>/dev/null || ...` was
+  handed to a program literally named `cd` and failed every time — the version
+  pin has never worked. The clone (a lone `git clone`, no shell metacharacters)
+  succeeded, so `ae add @tag` exited 1 having left a clone of the *default
+  branch* in the package cache; a later `ae run` / `ae lib-path` then resolved
+  the dependency to that unpinned tree and went green against the wrong code —
+  the exact reproducibility hole the dependency-resolution work set out to
+  close. The checkout now uses `git -C` (no shell), both `@v1.2.3` and `@1.2.3`
+  resolve, a failed pin removes the partial clone so nothing half-installed is
+  resolvable, and the "Available versions:" list — empty before, since it ran in
+  the wrong place — now names the tags. `AE_RELEASE_BASE_URL` additionally
+  redirects the git origin, mirroring the release-artifact path, so the clone is
+  testable without the public internet. Reported from the datastar-aether line
+  while pinning selaenium 0.2.1.
+
 ## [0.639.0]
 
 ### Fixed

--- a/tests/integration/ae_add_tag_pin/test_ae_add_tag_pin.sh
+++ b/tests/integration/ae_add_tag_pin/test_ae_add_tag_pin.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# `ae add <pkg>@<tag>` must pin the tag exactly, and a failed pin must leave
+# nothing resolvable behind (report: ae-add-tag-pin-fails-but-leaves-main).
+#
+# The checkout ran through run_cmd, which posix_spawns argv with NO shell, so
+# `cd "dir" && git checkout ... 2>/dev/null || ...` was handed to a program
+# literally named `cd`. The whole line failed every time -- the tag pin never
+# worked -- yet the clone (a lone `git clone`, no shell metacharacters)
+# succeeded, so `ae add @tag` exited 1 having left a clone of the DEFAULT
+# BRANCH in the cache. A later resolve then bound the dependency to that
+# unpinned tree and went green against the wrong code.
+#
+# Hermetic: a local bare git repo with three tags, served over file:// via
+# AE_RELEASE_BASE_URL. Nothing here touches the network or the real cache.
+#
+# Pinned properties:
+#   1. @vX.Y.Z checks out exactly that tag (not tag+N-commits),
+#   2. the bare form @X.Y.Z resolves too,
+#   3. a nonexistent tag exits 1, LISTS the available tags (empty before),
+#      and leaves NO directory in the cache,
+#   4. a valid pin records the dependency in aether.toml.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -n "${EXE_EXT:-}" ] && AE="$AE$EXE_EXT"
+[ -x "$AE" ] || { echo "  [SKIP] ae_add_tag_pin: ae not built"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "  [SKIP] ae_add_tag_pin: git needed"; exit 0; }
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Build a fake forge: origin/<host>/<user>/<repo> is a bare repo with tags.
+PKG="example.com/acme/widget"
+WORK="$TMP/work"
+BARE="$TMP/origin/$PKG"
+mkdir -p "$WORK" "$BARE"
+git init -q "$WORK"
+( cd "$WORK"
+  git config user.email t@t.test; git config user.name t
+  echo "v1" > f.txt; git add f.txt; git commit -qm one; git tag v0.1.0
+  echo "v2" > f.txt; git commit -aqm two; git tag v0.2.0
+  echo "v3" > f.txt; git commit -aqm three; git tag v0.2.1
+  echo "past-the-tag" > f.txt; git commit -aqm four    # default branch is now PAST v0.2.1
+  git init -q --bare "$BARE"
+  git push -q "$BARE" HEAD:refs/heads/main --tags ) || {
+    echo "  [FAIL] ae_add_tag_pin: could not build fixture repo"; exit 1; }
+
+# A consumer project, with HOME redirected so the real cache is untouched.
+PROJ="$TMP/proj"
+mkdir -p "$PROJ"
+( cd "$PROJ" && "$AE" init consumer >/dev/null 2>&1 ) || {
+    echo "  [FAIL] ae_add_tag_pin: ae init failed"; exit 1; }
+CONS="$PROJ/consumer"
+export HOME="$TMP/home"
+mkdir -p "$HOME"
+export AE_RELEASE_BASE_URL="file://$TMP/origin"
+CACHE="$HOME/.aether/packages/$PKG"
+
+# --- 1. @vX.Y.Z pins EXACTLY that tag ----------------------------------
+( cd "$CONS" && "$AE" add "$PKG@v0.2.1" ) > "$TMP/add.log" 2>&1
+if [ ! -d "$CACHE" ]; then
+    echo "  [FAIL] ae_add_tag_pin: @v0.2.1 installed nothing"
+    sed 's/^/    /' "$TMP/add.log" | head -8; exit 1
+fi
+desc=$(git -C "$CACHE" describe --tags 2>/dev/null)
+if [ "$desc" != "v0.2.1" ]; then
+    echo "  [FAIL] ae_add_tag_pin: @v0.2.1 landed at '$desc', not the tag"
+    echo "         (a '-N-g<sha>' suffix means the default branch, not the pin)"
+    exit 1
+fi
+
+# --- 4. and it is recorded in the manifest -----------------------------
+grep -q "$PKG" "$CONS/aether.toml" || {
+    echo "  [FAIL] ae_add_tag_pin: pin not written to aether.toml"; exit 1; }
+
+# --- 2. the bare form resolves too -------------------------------------
+rm -rf "$CACHE"
+( cd "$CONS" && "$AE" add "$PKG@0.2.0" ) > "$TMP/add2.log" 2>&1
+desc=$(git -C "$CACHE" describe --tags 2>/dev/null)
+if [ "$desc" != "v0.2.0" ]; then
+    echo "  [FAIL] ae_add_tag_pin: bare @0.2.0 landed at '$desc', not v0.2.0"
+    sed 's/^/    /' "$TMP/add2.log" | head -8; exit 1
+fi
+
+# --- 3. a bad tag: exit 1, lists tags, leaves NOTHING ------------------
+rm -rf "$CACHE"
+( cd "$CONS" && "$AE" add "$PKG@v9.9.9" ) > "$TMP/bad.log" 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    echo "  [FAIL] ae_add_tag_pin: a nonexistent tag exited 0"; exit 1
+fi
+if [ -d "$CACHE" ]; then
+    echo "  [FAIL] ae_add_tag_pin: a failed pin LEFT a clone in the cache:"
+    echo "         $(git -C "$CACHE" describe --tags --always 2>/dev/null) -- the reproducibility hole"
+    exit 1
+fi
+# The available-versions list was empty before the fix; it must name the tags.
+if ! grep -q "v0.2.1" "$TMP/bad.log"; then
+    echo "  [FAIL] ae_add_tag_pin: 'Available versions:' did not list the real tags"
+    sed 's/^/    /' "$TMP/bad.log" | head -10; exit 1
+fi
+
+echo "  [PASS] ae_add_tag_pin: tags pin exactly; a failed pin lists versions and leaves no cache"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -7400,6 +7400,20 @@ static int ae_try_release_asset(const char* package, const char* version,
     return 0;                            /* nothing published for us */
 }
 
+/* Remove a half-installed package clone. A failed `ae add` must leave nothing
+ * resolvable at the final cache path (report: ae-add-tag-pin-fails). Mirrors
+ * the rm -rf idiom used in ae_cache.c / ae_version.c, with the Windows arm. */
+static void ae_add_rmrf(const char* dir) {
+    if (!dir || !*dir) return;
+    char cmd[1200];
+#ifdef _WIN32
+    snprintf(cmd, sizeof(cmd), "rmdir /s /q \"%s\"", dir);
+#else
+    snprintf(cmd, sizeof(cmd), "rm -rf \"%s\"", dir);
+#endif
+    if (system(cmd) != 0) { /* best-effort */ }
+}
+
 static int cmd_add(int argc, char** argv) {
     if (argc < 1 || argv[0][0] == '-') {
         fprintf(stderr, "Usage: ae add <host>/<user>/<repo>[@version] [--source]\n");
@@ -7482,36 +7496,78 @@ static int cmd_add(int argc, char** argv) {
         if (slash) { *slash = '\0'; mkdirs(parent); }
 
         char cmd[4096];
-        if (version) {
-            snprintf(cmd, sizeof(cmd), "git clone https://%s %s", package, pkg_dir);
+        /* AE_RELEASE_BASE_URL also redirects the git origin, mirroring the
+         * release-artifact path above: an internal mirror or a file:// tree
+         * can serve the clone, and it is what makes this path testable
+         * without the public internet. `<origin>/<package>` so a bare git repo
+         * at that layout is reachable. */
+        const char* git_origin = getenv("AE_RELEASE_BASE_URL");
+        char clone_url[1600];
+        if (git_origin && *git_origin) {
+            snprintf(clone_url, sizeof(clone_url), "%s/%s", git_origin, package);
         } else {
-            snprintf(cmd, sizeof(cmd), "git clone --depth 1 https://%s %s", package, pkg_dir);
+            snprintf(clone_url, sizeof(clone_url), "https://%s", package);
+        }
+        if (version) {
+            snprintf(cmd, sizeof(cmd), "git clone %s %s", clone_url, pkg_dir);
+        } else {
+            snprintf(cmd, sizeof(cmd), "git clone --depth 1 %s %s", clone_url, pkg_dir);
         }
         if (run_cmd(cmd) != 0) {
             fprintf(stderr, "Failed to download package.\n");
             fprintf(stderr, "Check that the repository exists: https://%s\n", package);
+            /* git clone may have created a partial directory before failing;
+             * do not leave it resolvable. */
+            ae_add_rmrf(pkg_dir);
             return 1;
         }
 
         // Checkout specific version tag if requested
         if (version) {
-            char tag[128];
-            if (version[0] == 'v') {
-                snprintf(tag, sizeof(tag), "%s", version);
-            } else {
-                snprintf(tag, sizeof(tag), "v%s", version);
+            /* #1879-adjacent (ae-add-tag-pin report): the checkout ran through
+             * run_cmd, whose tokenizer posix_spawns argv directly with NO
+             * shell -- so `cd "dir" && git checkout ... 2>/dev/null || ...`
+             * was handed to a program literally named `cd`, and `&&`, `||`,
+             * `2>/dev/null` were argv words. The whole line failed every time;
+             * the tag pin has never actually worked. The clone succeeded only
+             * because a lone `git clone` has no shell metacharacters.
+             *
+             * Use `git -C <dir>` (a real git flag, no shell needed) so the
+             * checkout runs, and normalise the tag so both `@v0.2.1` and
+             * `@0.2.1` resolve. */
+            const char* bare = (version[0] == 'v') ? version + 1 : version;
+            char vtag[128];
+            snprintf(vtag, sizeof(vtag), "v%s", bare);
+
+            /* Try the v-prefixed tag, then the bare form for repos that tag
+             * without the `v`. run_cmd_quiet only to avoid the noise of the
+             * first miss; the real error is surfaced below if both fail. */
+            snprintf(cmd, sizeof(cmd), "git -C \"%s\" checkout %s", pkg_dir, vtag);
+            int co = run_cmd_quiet(cmd);
+            if (co != 0) {
+                snprintf(cmd, sizeof(cmd), "git -C \"%s\" checkout %s", pkg_dir, bare);
+                co = run_cmd_quiet(cmd);
             }
-            snprintf(cmd, sizeof(cmd), "cd \"%s\" && git checkout %s 2>/dev/null || git checkout v%s 2>/dev/null",
-                     pkg_dir, tag, version);
-            if (run_cmd_quiet(cmd) != 0) {
+            if (co != 0) {
                 fprintf(stderr, "Error: Version '%s' not found.\n", version);
-                // List available tags
-                snprintf(cmd, sizeof(cmd), "cd \"%s\" && git tag -l 'v*' | sort -V | tail -10", pkg_dir);
+                /* A failed pin MUST NOT leave an unpinned clone behind: a
+                 * later `ae run` / `ae lib-path` would resolve the dependency
+                 * to this main checkout and go green against the wrong tree --
+                 * the exact reproducibility hole this feature set closes. So
+                 * list the tags first (with -C, against the clone that has
+                 * them -- the old `cd` form left this empty too), THEN remove
+                 * the partial clone. */
+                /* No pipe: run_cmd has no shell, so `| sort | tail` would
+                 * be argv to `git tag`. git sorts natively; the newest tags
+                 * sort first, so the first handful is the useful part. */
+                snprintf(cmd, sizeof(cmd),
+                         "git -C \"%s\" tag -l --sort=-v:refname v*", pkg_dir);
                 fprintf(stderr, "Available versions:\n");
                 (void)run_cmd(cmd);
+                ae_add_rmrf(pkg_dir);
                 return 1;
             }
-            printf("Checked out %s\n", tag);
+            printf("Checked out %s\n", vtag);
         }
     }
 


### PR DESCRIPTION
Reported from the datastar-aether line while pinning selaenium 0.2.1: `ae add <pkg>@<tag>` exits 1 saying the version is missing, then **leaves a clone of the default branch in the cache** — which a later `ae run` / `ae lib-path` binds the dependency to, going green against the wrong tree. The exact reproducibility hole the dependency-resolution work set out to close.

## Root cause — one layer below the reported symptom

The reporter suspected the `2>/dev/null` was hiding a git error. It was, but the cause is deeper and explains all three symptoms at once.

The checkout ran through `run_cmd`, which `posix_spawn`s argv with **no shell** (its own comment: *"faster than system() — no /bin/sh overhead"*). So:

```c
"cd \"%s\" && git checkout %s 2>/dev/null || git checkout v%s 2>/dev/null"
```

was handed to a program literally named `cd`, with `&&`, `||`, `2>/dev/null` as argv words. **It failed every time — the tag pin has never worked.** The clone survived only because a lone `git clone` has no shell metacharacters.

That lines up every symptom the report listed:
- "works by hand" — the reporter's hand ran a real shell
- checkout fails inside `ae` — `cd` is not an executable
- "Available versions:" empty — same shell-less mistake, stacked with a `| sort | tail` git never sees
- the clone survives on main — the one command needing no shell

## Fixes (the reporter's priority order)

1. **A failed pin removes the partial clone** — nothing half-installed is resolvable. Kept clone-into-place + remove-on-fail rather than clone-to-temp-then-move, since a cross-filesystem move is an `EXDEV` copy.
2. **Checkout via `git -C "<dir>"`** (a real flag, no shell), trying v-prefixed then bare, so `@v1.2.3` and `@1.2.3` both land on the tag exactly.
3. **"Available versions:" via `git -C "<dir>" tag -l --sort=-v:refname v*`** — git sorts natively, no pipe, newest first.

`AE_RELEASE_BASE_URL` now also redirects the git clone origin, mirroring the release-artifact path — which is what makes the clone testable off a `file://` tree.

## Verified

Against the real selaenium:

```
$ ae add github.com/aether-lang-dev/selaenium@v0.2.1
Checked out v0.2.1
$ git -C ~/.aether/packages/.../selaenium describe --tags
v0.2.1          # exactly the tag, not the v0.2.1-3-g... the report saw
```

```
$ ae add github.com/aether-lang-dev/selaenium@v9.9.9
Error: Version 'v9.9.9' not found.
Available versions:
v0.2.1
v0.2.0
v0.1.0
# and no directory left in the cache
```

## Testing

New hermetic test: a local bare repo with three tags, served over `file://`, asserting the exact pin, the bare-form pin, and a bad tag that **lists the tags and leaves no cache dir** — no network. **Confirmed to fail on the unfixed `ae`.**

`make test` 409/409; `ae_add_release_artifact` (shares the clone path), `dep_resolution`, and `pkg_nested_resolve` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
