### PR TITLE
fix(codegen): reclaim a string field assigned through a nested path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A heap string field assigned through a nested path is reclaimed** (#1879,
+  follow-up to #1866). Codegen recognised a field assignment only when its
+  object was a bare identifier, so `o.inner.name = ...`, whose object is itself
+  a member access, fell through to a plain store that set no
+  `_heap_<field>` tracker. `heap.free(o.inner)` then skipped the field and the
+  string leaked, while the identical write spelled `inner.name = ...` was
+  reclaimed: ownership followed how the assignment was SPELLED rather than the
+  type, which is what made it undiscoverable. Reaching a field through an owned
+  sub-object is ordinary, so this was reachable from any
+  `model.material.texture_path = ...`.
+
+  The owner is now bound once, so the store and the tracker cannot evaluate the
+  path twice, and the tracker is set without reading the previous value. That
+  last part is #1873's rule: nothing here proves the inner box came from
+  `heap.new`, and on a hand-malloc'd box the tracker is uninitialised, so acting
+  on it would free a garbage pointer.
+
+
 ## [0.635.0]
 
 ### Added

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -1474,7 +1474,15 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
     if (!gen || !lhs || !rhs) return 0;
     if (lhs->type != AST_MEMBER_ACCESS || !lhs->value) return 0;
     if (lhs->child_count != 1 || !lhs->children[0]) return 0;
-    if (lhs->children[0]->type != AST_IDENTIFIER || !lhs->children[0]->value) return 0;
+    if (!lhs->children[0]->value) return 0;
+    /* #1879: the object may itself be a member access (`o.inner.name = ...`).
+     * Requiring a bare identifier here meant a nested path fell through to a
+     * plain store with NO `_heap_<field>` tracker set, so the destructor
+     * skipped the field and the string leaked, while the identical write
+     * spelled `inner.name = ...` was reclaimed. Ownership followed how the
+     * assignment was spelled rather than the type. */
+    int obj_is_nested = (lhs->children[0]->type == AST_MEMBER_ACCESS);
+    if (lhs->children[0]->type != AST_IDENTIFIER && !obj_is_nested) return 0;
     ASTNode* obj = lhs->children[0];
     Type* obj_type = obj->node_type;
     if (!obj_type) return 0;
@@ -1496,7 +1504,8 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
     } else if (obj_type->kind == TYPE_PTR && obj_type->element_type &&
                obj_type->element_type->kind == TYPE_STRUCT &&
                obj_type->element_type->struct_name &&
-               (is_heap_box_var(gen, obj->value) ||
+               (obj_is_nested ||
+                is_heap_box_var(gen, obj->value) ||
                 is_ptr_struct_param(gen, obj->value))) {
         /* #1873: a PARAMETER is not a promise that the box was zeroed — the
          * caller may have handed us `malloc(n) as *T`, whose `_heap_<field>`
@@ -1531,6 +1540,26 @@ static int emit_struct_field_heap_assign(CodeGenerator* gen, ASTNode* lhs, ASTNo
 
     int rhs_is_heap = is_heap_string_expr(gen, rhs);
     print_indent(gen);
+    if (obj_is_nested) {
+        /* The owner is reached through an expression, so bind it ONCE: the
+         * store and the tracker must not evaluate the path twice.
+         *
+         * The tracker is SET but the previous value is not read, for #1873's
+         * reason: nothing here proves the inner box came from heap.new, and
+         * on a hand-malloc'd box the tracker is uninitialised, so acting on
+         * it would free a garbage pointer. Setting it is what reclaims the
+         * field; not reading it can leak a previous value on a box that was
+         * genuinely zeroed, which is strictly better than a segfault. */
+        fprintf(gen->output, "{ %s* _ae_owner = ", struct_name);
+        if (acc[0] == '.') fprintf(gen->output, "&(");
+        generate_expression(gen, obj);
+        if (acc[0] == '.') fprintf(gen->output, ")");
+        fprintf(gen->output, "; _ae_owner->%s = ", lhs->value);
+        generate_expression(gen, rhs);
+        fprintf(gen->output, "; _ae_owner->_heap_%s = %d; }\n",
+                lhs->value, rhs_is_heap ? 1 : 0);
+        return 1;
+    }
     if (!tracker_is_trustworthy) {
         /* #1873: store and SET the tracker (so the destructor still reclaims
          * this value — #1866's leak fix is preserved), but do not read the

--- a/tests/regression/test_nested_path_string_field.ae
+++ b/tests/regression/test_nested_path_string_field.ae
@@ -1,0 +1,75 @@
+// Regression (#1879, follow-up to #1866): a heap STRING field assigned
+// through a NESTED path (`o.inner.name = ...`) must be reclaimed by the
+// destructor, exactly as one assigned on the inner pointer directly.
+//
+// Pre-fix, codegen only recognised an assignment whose object was a bare
+// identifier. `o.inner.name = ...` has a member access as its object, so it
+// fell through to a plain store with no `_heap_name` tracker set, and
+// `heap.free(o.inner)` then skipped the field: the string leaked. The
+// identical write spelled `inner.name = ...` was reclaimed, so ownership
+// followed how the assignment was SPELLED rather than the type, which is
+// what made it undiscoverable.
+//
+// This is a LEAK gate, so the assertion that matters is made by the leak
+// checkers that run this suite (macOS leaks(1), Linux valgrind and ASan).
+// The behavioural half here guards the other direction: reclaiming the
+// field must not corrupt or double-free it, so both values are read back
+// after every assignment and compared.
+
+import std.heap
+import std.string
+
+extern exit(code: int)
+
+struct Inner { name: string }
+struct Outer { inner: *Inner }
+
+own(previous: string, value: string) -> string {
+    if previous != null { string.free(previous) }
+    return string.copy(value)
+}
+
+set_through_outer(o: *Outer, v: string) {
+    o.inner.name = own(o.inner.name, v)
+}
+
+set_direct(i: *Inner, v: string) {
+    i.name = own(i.name, v)
+}
+
+check(got: string, want: string, what: string) {
+    if got != want {
+        println("FAIL: ${what}: got '${got}', want '${want}'")
+        exit(1)
+    }
+}
+
+main() {
+    a = heap.new(Outer)
+    a.inner = heap.new(Inner)
+    set_through_outer(a, "assigned-through-a-nested-path")
+    check(a.inner.name, "assigned-through-a-nested-path", "nested path stores the value")
+    // Re-assign: the second write must not disturb the first's ownership.
+    set_through_outer(a, "nested-again")
+    check(a.inner.name, "nested-again", "nested path re-assigns")
+    heap.free(a.inner)
+    heap.free(a)
+
+    b = heap.new(Outer)
+    b.inner = heap.new(Inner)
+    set_direct(b.inner, "assigned-on-the-inner-pointer")
+    check(b.inner.name, "assigned-on-the-inner-pointer", "direct pointer stores the value")
+    heap.free(b.inner)
+    heap.free(b)
+
+    // Inline, with no function boundary: the report notes the leak is the
+    // path shape, not the call, so the inline form is gated too.
+    c = heap.new(Outer)
+    c.inner = heap.new(Inner)
+    c.inner.name = string.copy("assigned-inline-through-a-nested-path")
+    check(c.inner.name, "assigned-inline-through-a-nested-path", "inline nested path")
+    heap.free(c.inner)
+    heap.free(c)
+
+    println("nested path string field ownership OK")
+}


### PR DESCRIPTION
## Root cause

`emit_struct_field_heap_assign` recognised a struct-field assignment only when
its object was a bare `AST_IDENTIFIER`. `o.inner.name = ...` has a *member
access* as its object, so it fell through to a plain store that set no
`_heap_<field>` ownership tracker. The destructor releases a field only when
that tracker is set, so `heap.free(o.inner)` skipped it and the string leaked.

The generated C shows it exactly. Direct assignment:

```c
{ i->name = own(i->name, v); i->_heap_name = 1; }
```

Nested, before this change:

```c
(o->inner->name = own(o->inner->name, v));
```

Ownership therefore followed **how the assignment was spelled** rather than the
type, which is what made it undiscoverable. Reaching a field through an owned
sub-object is ordinary, so any `model.material.texture_path = ...` leaked while
the identical write on the inner pointer did not.

## Fix

After:

```c
{ Inner* _ae_owner = o->inner; _ae_owner->name = own(o->inner->name, v); _ae_owner->_heap_name = 1; }
```

Two deliberate details:

- **The owner is bound once.** The store and the tracker must not evaluate the
  path twice, since a path reached through an expression may not be free of
  side effects.
- **The tracker is set, but the previous value is not read.** That is #1873's
  rule, and it applies with more force here: nothing proves the inner box came
  from `heap.new`, and on a hand-malloc'd box the tracker is uninitialised, so
  acting on it would free a garbage pointer. Setting it is what reclaims the
  field; not reading it can leak a *previous* value on a box that was genuinely
  zeroed, which is strictly better than a segfault.

Both shapes the report distinguishes now emit the tracker: through a function,
and inlined with no call boundary.

## Verification

`leaks(1)` does not work in my sandbox: it fails to report even a deliberate
1234-byte `malloc` in a three-line C program. So the leak assertion is carried
by a regression test rather than by a local run.

`tests/regression/test_nested_path_string_field.ae` covers the nested path
through a function, a re-assignment through it, the direct-pointer control, and
the inline nested form. It is absent from `tests/leaks_known.txt`, so the leak
gates that run this suite (macOS `leaks(1)`, Linux valgrind and ASan) require
**zero** leaks from it. Its behavioural half guards the other direction:
reclaiming the field must not corrupt or double-free it, so every value is read
back after assignment.

Locally, on the fix:

- `make test`: 409 passed, 0 failed.
- `make test-ae`: 1068 passed, 0 failed.
- `make examples`: 90 passed, 0 failed.
- `make release` (`-O3 -DNDEBUG -flto -Werror`): clean.

Closes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
