### PR TITLE
Place heap trackers inline so struct-prefix punning stays sound (#1879 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Heap-string trackers corrupted structs that share a punned field prefix.**
+  The nested-path leak fix (#1879) appended a hidden `int _heap_<field>` after
+  each struct's declared fields; when a wide struct was allocated and written
+  through a pointer to a narrower struct that shares its leading fields, the two
+  placed the tracker at different offsets, so a string write through the narrow
+  view stamped a real data field of the wide object — silent corruption, no
+  diagnostic. Pure-Aether structs now emit each `_heap_<field>` immediately
+  after its string field, making the narrow struct a true memory prefix of the
+  wide one; extern structs keep their trailing layout. Found via a shared
+  options-struct prefix in the datastar SDK.
+
 ## [0.642.0]
 
 ### Fixed

--- a/compiler/codegen/codegen_func.c
+++ b/compiler/codegen/codegen_func.c
@@ -2049,6 +2049,24 @@ void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def) {
      * fields as `ptr` instead of `string` (no tracker emitted). */
     int has_string_field = 0;
     int first_string_idx = -1;
+    /* #1879-regression: for a pure-Aether struct, place each `_heap_<field>`
+     * tracker IMMEDIATELY AFTER its string field rather than appending all
+     * trackers at the end. Trailing placement kept the NAMED fields' offsets
+     * stable, but it moved the trackers to a different offset in two structs
+     * that share a named-field prefix — the deliberate punning idiom of
+     * allocating a wide struct and writing it through a narrow prefix type
+     * (`heap.new(SignalOptions)` written via `*CommonOptions`). A tracker
+     * store through the narrow view then landed on a real data field of the
+     * wide object: silent corruption. Inline placement makes the narrow
+     * struct a true MEMORY prefix of the wide one — its tracker sits at the
+     * same offset in both — so the pun is sound again.
+     *
+     * Extern structs keep the trailing layout: a hand-declared C counterpart
+     * has no trackers, and trailing placement keeps the declared fields at
+     * their C offsets up to the last one. An extern struct that needs strict
+     * binary layout still opts out entirely by declaring `ptr` not `string`
+     * (no tracker emitted at all). */
+    int inline_trackers = !is_extern;
     for (int i = 0; i < struct_def->child_count; i++) {
         ASTNode* field = struct_def->children[i];
         int is_last = (i == struct_def->child_count - 1);
@@ -2061,14 +2079,17 @@ void generate_struct_definition(CodeGenerator* gen, ASTNode* struct_def) {
                 field->node_type && field->node_type->kind == TYPE_STRING) {
                 has_string_field = 1;
                 if (first_string_idx < 0) first_string_idx = i;
+                if (inline_trackers) {
+                    print_indent(gen);
+                    fprintf(gen->output, "int _heap_%s;\n", field->value);
+                }
             }
         }
     }
 
-    /* Append the heap-tracker fields AFTER all user-declared fields
-     * so the struct's user-visible layout (offsets of the named
-     * fields) stays stable. */
-    if (has_string_field) {
+    /* Extern structs still append trackers after all declared fields, to keep
+     * the declared-field offsets matching a hand-written C struct. */
+    if (has_string_field && !inline_trackers) {
         for (int i = 0; i < struct_def->child_count; i++) {
             ASTNode* field = struct_def->children[i];
             if (field->type == AST_STRUCT_FIELD &&

--- a/tests/integration/heap_tracker_struct_prefix_pun/prog.ae
+++ b/tests/integration/heap_tracker_struct_prefix_pun/prog.ae
@@ -1,0 +1,56 @@
+// A wide struct written through a narrow PREFIX-view pointer keeps its own
+// fields intact (#1879-regression).
+//
+// `CommonOptions` holds the first two fields of `SignalOptions`; the setter
+// casts to `*CommonOptions` and the caller allocates a `SignalOptions` -- a
+// deliberate punning idiom (one setter serves every option struct sharing the
+// prefix). #1879 appended a hidden `_heap_<field>` tracker AFTER a struct's
+// declared fields, so the tracker sat at a different offset in the two
+// structs; writing the string field through the narrow view stamped a real
+// data field of the wide object. Placing each tracker immediately after its
+// string field makes the narrow struct a true memory prefix of the wide one,
+// so the punned write lands where it should.
+import std.heap
+import std.string
+
+struct CommonOptions { event_id: string, retry_ms: int }
+struct SignalOptions { event_id: string, retry_ms: int, only_if_missing: int }
+
+new_signal() -> ptr {
+    o = heap.new(SignalOptions)
+    o.event_id = ""
+    o.retry_ms = 0
+    o.only_if_missing = 0
+    return o as ptr
+}
+
+// Sets an int field of the wide struct.
+set_only_if_missing(ctx: ptr, v: int) {
+    o = ctx as *SignalOptions
+    o.only_if_missing = v
+}
+
+// Sets the string field through the NARROW prefix view -- the pun.
+set_event_id(ctx: ptr, id: string) {
+    o = ctx as *CommonOptions
+    o.event_id = id
+}
+
+read_only_if_missing(ctx: ptr) -> int {
+    o = ctx as *SignalOptions
+    return o.only_if_missing
+}
+
+main() {
+    o = new_signal()
+    set_only_if_missing(o, 1) // wide field := 1
+    set_event_id(o, "evt") // string set through *CommonOptions
+    got = read_only_if_missing(o) // must still be 1, not clobbered to 0
+    if got == 1 {
+        println("ok: only_if_missing survived the prefix-view string write")
+    } else {
+        println("CLOBBERED: only_if_missing = ${got}, expected 1")
+    }
+    heap.free(o)
+    return 0
+}

--- a/tests/integration/heap_tracker_struct_prefix_pun/test_heap_tracker_struct_prefix_pun.sh
+++ b/tests/integration/heap_tracker_struct_prefix_pun/test_heap_tracker_struct_prefix_pun.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# A wide struct written through a narrow prefix-view pointer keeps its fields
+# intact (#1879-regression).
+#
+# #1879 appended `_heap_<field>` trackers after a struct's declared fields.
+# Two structs sharing a named prefix (the punning idiom: allocate the wide
+# one, write it through the narrow prefix type) then disagreed on the
+# tracker's offset, so a string write through the narrow view stamped a real
+# data field of the wide object -- silent corruption. The fix places each
+# tracker immediately after its string field, making the narrow struct a true
+# memory prefix of the wide one.
+#
+# Two assertions: the program prints "ok" at runtime (a clobbered field prints
+# CLOBBERED), and -- so this means something with no run -- the two structs
+# agree on the tracker's position in the generated C.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+AETHERC="$ROOT/build/aetherc"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+if ! "$AETHERC" "$SCRIPT_DIR/prog.ae" "$TMP/out.c" > "$TMP/gen.log" 2>&1; then
+    echo "  [FAIL] heap_tracker_struct_prefix_pun: codegen failed"
+    sed 's/^/        /' "$TMP/gen.log" | head -8
+    exit 1
+fi
+
+# The tracker must sit at the same field index in both structs. With inline
+# placement CommonOptions is { event_id; _heap_event_id; retry_ms }, so
+# `_heap_event_id` precedes `retry_ms` -- i.e. the narrow struct is a genuine
+# prefix of the wide one. If the tracker were appended (the bug), it would
+# follow retry_ms in CommonOptions and follow only_if_missing in SignalOptions,
+# at different offsets.
+common_body=$(awk '/typedef struct CommonOptions \{/{p=1} p{print} /} CommonOptions;/{if(p)exit}' "$TMP/out.c")
+if ! printf '%s\n' "$common_body" | grep -q '_heap_event_id'; then
+    echo "  [FAIL] heap_tracker_struct_prefix_pun: no tracker in CommonOptions"
+    printf '%s\n' "$common_body" | sed 's/^/        /'
+    exit 1
+fi
+# _heap_event_id must come BEFORE retry_ms in CommonOptions (inline placement).
+heap_line=$(printf '%s\n' "$common_body" | grep -n '_heap_event_id' | head -1 | cut -d: -f1)
+retry_line=$(printf '%s\n' "$common_body" | grep -n 'retry_ms' | head -1 | cut -d: -f1)
+if [ "$heap_line" -gt "$retry_line" ]; then
+    echo "  [FAIL] heap_tracker_struct_prefix_pun: tracker appended, not inline --"
+    echo "         CommonOptions is not a memory prefix of SignalOptions, the pun corrupts"
+    printf '%s\n' "$common_body" | sed 's/^/        /'
+    exit 1
+fi
+
+# Compile and run: the field must survive the punned string write.
+if ! "$AE" run "$SCRIPT_DIR/prog.ae" > "$TMP/run.log" 2>&1; then
+    echo "  [FAIL] heap_tracker_struct_prefix_pun: program failed to run"
+    sed 's/^/        /' "$TMP/run.log" | head -8
+    exit 1
+fi
+if ! grep -q '^ok:' "$TMP/run.log"; then
+    echo "  [FAIL] heap_tracker_struct_prefix_pun: field was clobbered"
+    sed 's/^/        /' "$TMP/run.log" | head -4
+    exit 1
+fi
+
+echo "  [PASS] heap_tracker_struct_prefix_pun: prefix-view string write leaves the wide field intact"


### PR DESCRIPTION
Fixes a silent-corruption regression introduced by the #1879 nested-path leak
fix.

## The bug

#1879 appended a hidden `int _heap_<field>` tracker **after** each struct's
declared fields. That preserved the named fields' offsets, but broke structs
that share a named-field **prefix** and are punned — allocate the wide struct,
write it through a pointer to the narrow prefix type. The two structs then
placed the tracker at different offsets, so a string write through the narrow
view stamped a real data field of the wide object. No diagnostic.

Found via the datastar SDK, which shares one `CommonOptions { event_id,
retry_ms }` prefix across every option struct. `with_event_id` casts to
`*CommonOptions` and writes the string; the appended `_heap_event_id` (Common
offset 2) landed on `SignalOptions`' `only_if_missing` (offset 2). Two datastar
tests that were green at 0.638.0 failed at 0.640.0.

## The fix

For a pure-Aether struct, emit each `_heap_<field>` **immediately after its
string field** rather than appending all trackers at the end. The narrow struct
is then a true memory prefix of the wide one — the tracker sits at the same
offset in both — and the punned write is sound.

Extern structs keep their trailing layout (a hand-declared C counterpart has no
trackers, and trailing placement keeps declared fields at their C offsets; a
strict-ABI extern still opts out entirely by declaring `ptr` not `string`).
Only pure-Aether heap-string structs change layout, and those never cross an
FFI boundary.

The setter-side alternative (suppress the tracker store through an untrustworthy
pointer) was rejected: it fixes the corruption but drops the leak protection
#1879 added, failing `heap_nested_path_ownership`. The layout fix has no such
trade — that test still passes.

## Verification

- Regression test asserts both halves: the generated C keeps `_heap_event_id`
  before `retry_ms` in the prefix struct (a genuine memory prefix), and the
  program reads the wide field back intact after the punned write. Independently
  confirmed to **FAIL on the unfixed compiler** (tracker appended after
  `retry_ms`) and **PASS on the fixed one**.
- `make test` — 409/409
- `ae fmt` gate — clean
- `make test-ae` running; the only non-flaky item is this new test (passing).
  Known env flakes excluded (windows_crt_symbols on Linux, h2 curl stress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)