### PR TITLE
fix(cli): do not rebase a [[bin]] name when walking up to aether.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`ae build <bin-name>` works from a subdirectory** (#1905). The walk-up to
+  `aether.toml` rebases a relative positional argument so a file path still
+  resolves after the chdir, and it did that to a `[[bin]]` NAME as well:
+  `widget` became `sub/widget`, which is not a file, so the build failed with
+  "File not found: sub/widget" while the identical command from the project
+  root worked. The name is now resolved against the manifest first, in the
+  directory the walk-up just moved to, and only a non-bin argument is rebased.
+
+  An argument that is neither a bin name nor a file is also reported as what
+  the user typed rather than as a path they never mentioned: a typo said
+  "File not found: sub/widgett", naming a directory the user was not thinking
+  about.
+
+
 ## [0.646.0]
 
 ### Fixed

--- a/tests/integration/bin_name_lookup_and_walkup/test_bin_name_lookup_and_walkup.sh
+++ b/tests/integration/bin_name_lookup_and_walkup/test_bin_name_lookup_and_walkup.sh
@@ -7,6 +7,12 @@
 #       subdirectory where the toml lives in an ancestor directory
 #       finds and uses that toml — extra_sources are applied, the
 #       link succeeds.
+#   (3) The two TOGETHER (#1905): `ae build <bin-name>` from a
+#       subdirectory. The walk-up rebases a relative positional so a
+#       file path still resolves after the chdir, and it used to do
+#       that to a bin NAME as well: `myprobe` became `ae/myprobe`,
+#       which is not a file, so the build failed from a subdirectory
+#       while the identical command worked from the root.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -52,6 +58,37 @@ if "$AE" build myprobe.ae -o "$TMPDIR/probe2" >"$TMPDIR/build2.log" 2>&1; then
 else
     echo "  [FAIL] ae build myprobe.ae from subdir failed"
     cat "$TMPDIR/build2.log"
+    fail=$((fail + 1))
+fi
+
+# Case 3 (#1905): ae build <bin-name> from a subdir. The name must NOT be
+# rebased into a path.
+cd "$SCRIPT_DIR/ae" || exit 1
+if "$AE" build myprobe -o "$TMPDIR/probe3" >"$TMPDIR/build3.log" 2>&1; then
+    if "$TMPDIR/probe3" 2>&1 | grep -q "^42$"; then
+        echo "  [PASS] ae build <bin-name> works from a subdirectory"
+        pass=$((pass + 1))
+    else
+        echo "  [FAIL] subdir bin-name built but didn't print 42"
+        fail=$((fail + 1))
+    fi
+else
+    echo "  [FAIL] ae build myprobe from a subdir failed"
+    cat "$TMPDIR/build3.log"
+    fail=$((fail + 1))
+fi
+
+# Case 4: an argument that is neither a bin name nor a file is reported as
+# what the user TYPED, not as a path they never mentioned.
+cd "$SCRIPT_DIR/ae" || exit 1
+"$AE" build nosuchthing -o "$TMPDIR/probe4" >"$TMPDIR/build4.log" 2>&1
+if grep -q "nosuchthing" "$TMPDIR/build4.log" && \
+   ! grep -q "ae/nosuchthing" "$TMPDIR/build4.log"; then
+    echo "  [PASS] an unknown positional is reported as typed"
+    pass=$((pass + 1))
+else
+    echo "  [FAIL] unknown positional was rebased in the error message"
+    cat "$TMPDIR/build4.log"
     fail=$((fail + 1))
 fi
 

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2261,6 +2261,8 @@ const char* get_cflags(void) {
 // the project's toml found automatically and `foo.ae` re-resolved
 // relative to the project root. Users with no project toml at all
 // see no behaviour change.
+static int find_bin_path_by_name(const char* bin_name, char* out, size_t out_size);
+
 static int find_and_chdir_to_aether_toml(const char** file_inout) {
     if (path_exists("aether.toml")) return 0;  /* already present */
 
@@ -2292,7 +2294,17 @@ static int find_and_chdir_to_aether_toml(const char** file_inout) {
              * becomes `ae/myprobe.ae`. */
             if (file_inout && *file_inout) {
                 const char* f = *file_inout;
-                if (f[0] != '/' && f[0] != '\\') {
+                /* #1905: the positional may be a [[bin]] NAME rather than a
+                 * path, and a name must not be rebased. `ae build widget`
+                 * from a subdirectory became `sub/widget`, which is not a
+                 * file, so it failed with "File not found: sub/widget" while
+                 * the identical command from the project root worked. The
+                 * manifest is in the directory we just chdir'd to, so the
+                 * name resolves here. */
+                char bin_probe[1024];
+                int names_a_bin =
+                    find_bin_path_by_name(f, bin_probe, sizeof(bin_probe));
+                if (!names_a_bin && f[0] != '/' && f[0] != '\\') {
                     /* relative — splice the subdir we walked out of */
                     size_t walk_len = strlen(walk);
                     if (strncmp(start_cwd, walk, walk_len) == 0 &&
@@ -2301,7 +2313,11 @@ static int find_and_chdir_to_aether_toml(const char** file_inout) {
                         const char* sub = start_cwd + walk_len + 1;
                         static char rebased[1024];
                         snprintf(rebased, sizeof(rebased), "%s/%s", sub, f);
-                        *file_inout = rebased;
+                        /* Only when it lands on something. Otherwise keep what
+                         * the user typed, so a typo is reported as the word
+                         * they wrote rather than as a path they never
+                         * mentioned. */
+                        if (path_exists(rebased)) *file_inout = rebased;
                     }
                 }
             }


### PR DESCRIPTION
## The bug

```sh
ae build widget            # from the project root: works
cd sub && ae build widget  # fails: File not found: sub/widget
```

`find_and_chdir_to_aether_toml` walks up to the project root, chdirs there, and
then rebases a relative positional argument so a relative **file path** still
resolves after the move (`myprobe.ae` becomes `sub/myprobe.ae`, which is
right). It did the same to a `[[bin]]` **name**, and `sub/widget` is not a
file. From the root no rebase happens, which is exactly why the same command
worked there.

## The fix

Resolve the positional against the manifest **before** rebasing, in the
directory the walk-up just moved to, and rebase only an argument that names no
bin.

Preferring the bin name is also what the root already does when a file of that
name happens to sit next to it, so the two agree.

Second, an argument that is neither a bin name nor a file is now reported as
**what the user typed**. The old message for a typo named a subdirectory the
user was not thinking about:

```
before:  Error: File not found: sub/widgett
after:   Error: File not found: widgett
```

## Verification

Red then green, on the issue's own reproducer:

| | unfixed | fixed |
|---|---|---|
| `ae build widget` from root | Built | Built |
| `ae build widget` from `sub/` | **File not found: sub/widget** | Built |
| `ae build probe.ae` from `sub/` | Built (rebased) | Built (rebased) |
| `ae build nosuchthing` from `sub/` | File not found: **sub/**nosuchthing | File not found: nosuchthing |

`bin_name_lookup_and_walkup` already covered a bin name from the root and a
file path from a subdirectory. The missing case is the two together, so it
gains that plus the typo case rather than a new test directory. Both new cases
**fail** against a binary built without this change:

```
  [FAIL] ae build myprobe from a subdir failed
  Error: File not found: ae/myprobe
  [FAIL] unknown positional was rebased in the error message
  Error: File not found: ae/nosuchthing
```

and pass with it (4 passed, 0 failed).

- `make test`: 409 passed, 0 failed.
- `make test-ae`: 1083 passed, 0 failed.
- `make examples`: 90 passed, 0 failed.

Closes #1905

🤖 Generated with [Claude Code](https://claude.com/claude-code)
