### PR TITLE
test(http): wait for the port instead of sleeping a fixed 0.3s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ version number before tagging the release.
 
 ### Fixed
 
+- **Server tests wait for the port, not for a guess** (part of #1920). Every
+  HTTP server test greps its log for `READY` and then slept a fixed 0.3s,
+  which proves the server PRINTED the line and nothing more: the listen socket
+  can still be a moment behind. That guess is wrong in both directions at
+  once. It waits 0.3s on a server that was ready immediately, and it gives up
+  after 0.3s on a loaded machine, which is the port-not-yet-listening flake
+  the sweep sees under load.
+
+  `tests/lib/wait_port.sh` probes the actual port instead: curl exits 7, and
+  only 7, when the connection could not be made, so any other exit proves
+  something is listening, whatever protocol runs on top (a TLS or HTTP/2 port
+  answers a plain probe with a handshake failure, which still counts). It uses
+  curl because every one of these tests already does, so there is no new
+  dependency on any platform.
+
+  Measured: the probe returns in 0.036s against a live port where the sleep
+  took 0.300s, so about 5.8s across the 22 tests converted. The correctness is
+  the point; the time is a side effect.
+
+
+### Fixed
+
 - **`ae build <bin-name>` works from a subdirectory** (#1905). The walk-up to
   `aether.toml` rebases a relative positional argument so a file path still
   resolves after the chdir, and it did that to a `[[bin]]` NAME as well:

--- a/tests/integration/http_auth/test_http_auth.sh
+++ b/tests/integration/http_auth/test_http_auth.sh
@@ -37,6 +37,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -88,7 +89,8 @@ wait_ready() {
 }
 wait_ready "$SRV_BEARER_PID"  "$TMPDIR/bearer.log"  bearer
 wait_ready "$SRV_SESSION_PID" "$TMPDIR/session.log" session
-sleep 0.3
+wait_port 18273 || exit 1
+wait_port 18274 || exit 1
 
 URL_BEARER="http://127.0.0.1:18273/api/whoami"
 URL_SESSION="http://127.0.0.1:18274/app/me"

--- a/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
+++ b/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
@@ -20,6 +20,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v openssl >/dev/null 2>&1; then
@@ -108,7 +109,7 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
     exit 1
 fi
 
-sleep 0.3
+wait_port 18119 || exit 1
 
 OUT="$TMPDIR/client.out"
 # GOOD_CA is the ROOT CA (not the leaf): the client pins the CA and the server

--- a/tests/integration/http_client_forward_proxy/test_http_client_forward_proxy.sh
+++ b/tests/integration/http_client_forward_proxy/test_http_client_forward_proxy.sh
@@ -20,6 +20,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -52,7 +53,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     sleep 0.1
 done
 grep -q READY "$TMPDIR/origin.log" 2>/dev/null || { echo "  [FAIL] origin never READY"; head -20 "$TMPDIR/origin.log"; exit 1; }
-sleep 0.3
+wait_port 18120 || exit 1
 
 # Run the client with a loopback-IP HTTP_PROXY so case 3 can exercise the SSRF
 # guard. Cases 1 and 2 pin/ignore the proxy explicitly and don't consult env.

--- a/tests/integration/http_client_insecure_tls/test_http_client_insecure_tls.sh
+++ b/tests/integration/http_client_insecure_tls/test_http_client_insecure_tls.sh
@@ -21,6 +21,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v openssl >/dev/null 2>&1; then
@@ -88,7 +89,7 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
 fi
 
 # Settle for the actor to bind the listen socket.
-sleep 0.3
+wait_port 18118 || exit 1
 
 OUT="$TMPDIR/client.out"
 if ! AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then

--- a/tests/integration/http_h2_concurrent_dispatch/test_http_h2_concurrent_dispatch.sh
+++ b/tests/integration/http_h2_concurrent_dispatch/test_http_h2_concurrent_dispatch.sh
@@ -35,6 +35,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -76,7 +77,7 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-sleep 0.3
+wait_port 18280 || exit 1
 
 URL="http://127.0.0.1:18280"
 

--- a/tests/integration/http_handler_user_data/test_http_handler_user_data.sh
+++ b/tests/integration/http_handler_user_data/test_http_handler_user_data.sh
@@ -18,6 +18,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -46,7 +47,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18299 || exit 1
 
 BASE="http://127.0.0.1:18299"
 

--- a/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
+++ b/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
@@ -16,6 +16,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -44,7 +45,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18283 || exit 1
 
 BASE="http://127.0.0.1:18283"
 

--- a/tests/integration/http_real_ip/test_http_real_ip.sh
+++ b/tests/integration/http_real_ip/test_http_real_ip.sh
@@ -35,6 +35,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -63,7 +64,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18272 || exit 1
 
 URL="http://127.0.0.1:18272/whoami"
 

--- a/tests/integration/http_request_conn_accessors/test_http_request_conn_accessors.sh
+++ b/tests/integration/http_request_conn_accessors/test_http_request_conn_accessors.sh
@@ -19,6 +19,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -47,7 +48,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18294 || exit 1
 
 URL="http://127.0.0.1:18294/whoami"
 

--- a/tests/integration/http_request_remote_addr/test_http_request_remote_addr.sh
+++ b/tests/integration/http_request_remote_addr/test_http_request_remote_addr.sh
@@ -24,6 +24,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -52,7 +53,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18293 || exit 1
 
 URL="http://127.0.0.1:18293/whoami"
 

--- a/tests/integration/http_sendfile/test_http_sendfile.sh
+++ b/tests/integration/http_sendfile/test_http_sendfile.sh
@@ -34,6 +34,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -77,7 +78,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 19200 || exit 1
 
 URL="http://127.0.0.1:19200"
 

--- a/tests/integration/http_serve_static_range/test_http_serve_static_range.sh
+++ b/tests/integration/http_serve_static_range/test_http_serve_static_range.sh
@@ -25,6 +25,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -63,7 +64,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18301 || exit 1
 
 URL="http://127.0.0.1:18301/data.bin"
 

--- a/tests/integration/http_server_connect_tunnel/test_http_server_connect_tunnel.sh
+++ b/tests/integration/http_server_connect_tunnel/test_http_server_connect_tunnel.sh
@@ -13,6 +13,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 TMPDIR="$(mktemp -d)"
@@ -46,7 +47,7 @@ grep -q READY "$TMPDIR/srv.log" 2>/dev/null || {
     head -30 "$TMPDIR/srv.log"
     exit 1
 }
-sleep 0.3
+wait_port 18286 || exit 1
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/client.ae" >"$TMPDIR/client.out" 2>&1 || {
     echo "  [FAIL] client exited non-zero:"

--- a/tests/integration/http_server_h2/test_http_server_h2.sh
+++ b/tests/integration/http_server_h2/test_http_server_h2.sh
@@ -43,6 +43,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -81,9 +82,9 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-sleep 0.3
-
 PORT=18260
+wait_port "$PORT" || exit 1
+
 URL_BASE="http://127.0.0.1:$PORT"
 
 # ----------------------------------------------------------------

--- a/tests/integration/http_server_h2_middleware/test_http_server_h2_middleware.sh
+++ b/tests/integration/http_server_h2_middleware/test_http_server_h2_middleware.sh
@@ -33,6 +33,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -74,7 +75,7 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-sleep 0.3
+wait_port 18262 || exit 1
 
 URL="http://127.0.0.1:18262/text"
 HEADERS="$TMPDIR/headers"

--- a/tests/integration/http_server_h2_tls/test_http_server_h2_tls.sh
+++ b/tests/integration/http_server_h2_tls/test_http_server_h2_tls.sh
@@ -28,6 +28,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v openssl >/dev/null 2>&1; then
@@ -82,7 +83,7 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-sleep 0.3
+wait_port 18263 || exit 1
 
 URL="https://127.0.0.1:18263/"
 RESP="$TMPDIR/resp"

--- a/tests/integration/http_server_keepalive/test_http_server_keepalive.sh
+++ b/tests/integration/http_server_keepalive/test_http_server_keepalive.sh
@@ -31,6 +31,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -61,7 +62,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18103 || exit 1
 
 # Three URLs in one curl invocation re-uses a single TCP connection.
 # Use distinct -o files per URL so we can verify each response

--- a/tests/integration/http_server_observability/test_http_server_observability.sh
+++ b/tests/integration/http_server_observability/test_http_server_observability.sh
@@ -29,6 +29,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -61,7 +62,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18108 || exit 1
 
 URL="http://127.0.0.1:18108"
 

--- a/tests/integration/http_server_ops/test_http_server_ops.sh
+++ b/tests/integration/http_server_ops/test_http_server_ops.sh
@@ -33,6 +33,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -65,7 +66,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18107 || exit 1
 
 # --- on_start hook fired ---
 if ! [ -f "$MARKER" ] || ! grep -q STARTED "$MARKER"; then

--- a/tests/integration/http_server_tls/test_http_server_tls.sh
+++ b/tests/integration/http_server_tls/test_http_server_tls.sh
@@ -27,6 +27,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v openssl >/dev/null 2>&1; then
@@ -96,7 +97,7 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
 fi
 
 # Brief settle for the actor to bind the listen socket.
-sleep 0.3
+wait_port 18102 || exit 1
 
 # Drive the HTTPS request. --cacert points curl at our self-signed
 # cert so verification succeeds; --resolve isn't needed because the

--- a/tests/integration/http_server_websocket/test_http_server_websocket.sh
+++ b/tests/integration/http_server_websocket/test_http_server_websocket.sh
@@ -33,6 +33,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -87,7 +88,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-sleep 0.3
+wait_port 18110 || exit 1
 
 # Python client sends 3 text messages and prints each echo on its
 # own line; non-zero exit on any failure.

--- a/tests/integration/http_stream_upload/test_http_stream_upload.sh
+++ b/tests/integration/http_stream_upload/test_http_stream_upload.sh
@@ -25,6 +25,7 @@ esac
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 command -v curl >/dev/null 2>&1 || { echo "  [SKIP] curl not on PATH"; exit 0; }
@@ -60,7 +61,7 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     kill -0 "$SRV_PID" 2>/dev/null || { echo "  [FAIL] server died:"; head -30 "$TMPDIR/srv.log"; exit 1; }
     sleep 0.1
 done
-sleep 0.3
+wait_port 19250 || exit 1
 
 # Single curl invocation: PUT the big body, then GET /ping on the SAME
 # connection (curl reuses the keep-alive socket for sequential URLs).

--- a/tests/lib/wait_port.sh
+++ b/tests/lib/wait_port.sh
@@ -1,0 +1,34 @@
+# wait_port PORT [HOST] [TRIES] — block until something accepts a TCP
+# connection on PORT.
+#
+# Every server test greps its log for READY, which proves the server PRINTED
+# it and nothing more: the listen socket can still be a moment behind. The
+# fixed `sleep 0.3` that followed was covering for exactly that gap, and it
+# is wrong in both directions at once. It waits 0.3s on a server that was
+# ready immediately, and it gives up after 0.3s on a loaded machine, which is
+# the port-not-yet-listening flake the sweep sees under load.
+#
+# curl exits 7, and only 7, when the connection itself could not be made. Any
+# other exit means something accepted the connection, which is the whole of
+# what "the port is up" means. That holds whatever protocol runs on top: a
+# TLS or HTTP/2 port answers a plain HTTP probe with a handshake failure, a
+# different exit code, and that still proves the listener is there.
+#
+# Uses curl because every one of these tests already does; no new dependency,
+# and it behaves the same on Linux, macOS and MSYS2.
+wait_port() {
+    _wp_port="$1"
+    _wp_host="${2:-127.0.0.1}"
+    _wp_tries="${3:-200}"
+    while [ "$_wp_tries" -gt 0 ]; do
+        curl -s -o /dev/null --max-time 1 "http://$_wp_host:$_wp_port/" 2>/dev/null
+        _wp_rc=$?
+        if [ "$_wp_rc" -ne 7 ]; then
+            return 0
+        fi
+        _wp_tries=$((_wp_tries - 1))
+        sleep 0.05
+    done
+    echo "  [FAIL] nothing listening on $_wp_host:$_wp_port"
+    return 1
+}


### PR DESCRIPTION
## What

Every HTTP server test greps its log for `READY` and then slept a fixed `0.3s`.
`READY` proves the server **printed** the line and nothing more: the listen
socket can still be a moment behind, and that sleep was covering the gap.

The guess is wrong in both directions at once:

- it waits 0.3s on a server that was ready immediately, and
- it gives up after 0.3s on a loaded machine, which is the
  port-not-yet-listening flake the sweep sees under load.

`tests/lib/wait_port.sh` probes the port instead. curl exits **7, and only 7**,
when the connection could not be made, so any other exit proves something
accepted it. That holds whatever protocol runs on top: a TLS or HTTP/2 port
answers a plain probe with a handshake failure, a different exit code, and that
still proves the listener is there. It uses curl because all 22 of these tests
already do, so it adds no dependency on Linux, macOS or MSYS2.

## Scope

This is **one item of #1920, not the whole of it**, so it does not close the
issue. The big win there is parallelism, and that needs ephemeral ports first
(the stdlib already supports it: `http_server_bind_raw` does a `getsockname()`
when the port is 0, and `std/http` documents the resolved-port readback). That
is a separate, much larger change.

A correct readiness probe is a prerequisite for it either way: parallel servers
make the "ready yet?" window wider, not narrower.

## On the numbers

Wall-clock on the sweep is far too noisy here to show this. Running the same 22
tests repeatedly gave 66s, 38s, 68s and 82s, so a ~6s change is well inside the
noise, and I am not going to quote a stopwatch difference as if it meant
something.

What I measured instead is the thing that actually changed, against a live port:

```
wait_port on a live port: median 0.036s, min 0.033s
the fixed sleep it replaces:  0.300s
```

So ~0.264s per test, about 5.8s across the 22. The correctness is the point; the
time is a side effect.

## Verification

- All 22 converted tests pass.
- `make test-ae`: **1083 passed, 0 failed**.
- One intermediate run reported 1067 rather than 1083. That was my own doing:
  leftover servers from running these tests by hand were squatting 18120 and
  18260, which is exactly the flake class #1920 describes. After clearing them
  the count returned to 1083. Test discovery is `find tests/integration -name
  'test_*.sh'`, which `wait_port.sh` matches neither by name nor by location,
  so it cannot affect what runs.
- `http_server_h2` needed its probe placed after the line that assigns `PORT`,
  which the first pass got wrong and the test caught immediately.

Part of #1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
