### PR TITLE
test(http): bind an ephemeral port in the server fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ version number before tagging the release.
 
 ### Fixed
 
+- **HTTP server tests bind an ephemeral port instead of a hardcoded one**
+  (part of #1920). Twenty-nine fixtures each owned a fixed port, which is what
+  forced the shell sweep to run serially: two of them even shared 18107, and
+  only serial execution kept that from mattering. A server left behind by an
+  earlier run also starved the next one, which is the "port already in use"
+  flake the sweep sees.
+
+  Each fixture now binds port 0, lets the kernel choose, and prints the
+  resolved port on its READY line for the runner to read. `server_start`
+  reuses a socket the caller already bound, so this also moves READY to
+  AFTER the listen socket exists rather than before it.
+
+  Demonstrated rather than argued: running the same test twice concurrently
+  used to fail one of the two on the bind, and all twenty-nine now run
+  concurrently with no failures.
+
+  Three fixtures whose companion client had the port baked in take it from
+  the environment instead, because `ae run script.ae <arg>` does not forward
+  arguments to the program. One server builds its own redirect targets from
+  its resolved port.
+
+  `SH_NPROC` is deliberately left at 1: nine server fixtures still hold fixed
+  ports, and flipping the switch while any remain would trade a slow suite
+  for a flaky one.
+
+
+### Fixed
+
 - **Server tests wait for the port, not for a guess** (part of #1920). Every
   HTTP server test greps its log for `READY` and then slept a fixed 0.3s,
   which proves the server PRINTED the line and nothing more: the listen socket

--- a/tests/integration/http_client_custom_ca/client.ae
+++ b/tests/integration/http_client_custom_ca/client.ae
@@ -16,7 +16,13 @@ import std.os
 
 extern exit(code: int)
 
-const URL = "https://127.0.0.1:18119/"
+// The server binds port 0 and reports the kernel's choice, so the port
+// arrives in the environment rather than being baked in. It is an env var
+// and not an argument because `ae run script.ae <arg>` does not forward
+// extra arguments to the program.
+get_url() -> string {
+    return "https://127.0.0.1:${os_getenv("AE_TEST_PORT")}/"
+}
 
 fail(msg: string) {
     println("FAIL: ${msg}")
@@ -26,7 +32,7 @@ fail(msg: string) {
 // GET URL with an optional cafile pin (empty = none). insecure stays 0.
 // Returns (status, err).
 do_get(cafile: string) -> {
-    req = client.request("GET", URL)
+    req = client.request("GET", get_url())
     if req == null { fail("request() null") }
     client.set_timeout(req, 10s)
     if cafile != "" {

--- a/tests/integration/http_client_custom_ca/server.ae
+++ b/tests/integration/http_client_custom_ca/server.ae
@@ -10,8 +10,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18119
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -39,7 +39,7 @@ main() {
         exit(1)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -51,7 +51,15 @@ main() {
         println("FAIL: server_set_tls: ${tls_err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_root, 0)
 

--- a/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
+++ b/tests/integration/http_client_custom_ca/test_http_client_custom_ca.sh
@@ -38,9 +38,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Unique port 18119 (18118 is http_client_insecure_tls). `ae run` forks the
-# server child, so the trap can't fully reap it; a distinct port keeps a
-# lingering server from starving the next test.
+# The server binds port 0, so there is no port to keep unique any more. That
+# also defuses the reason this test used to need one: `ae run` forks the server
+# child and the trap cannot fully reap it, and a lingering server used to starve
+# the next test of its fixed port. A leftover now holds a port nobody wants.
 
 # Real CA-signs-a-separate-leaf topology, mirroring a Proxmox VE endpoint
 # (private root CA `pve-root-ca.pem` that signs a distinct server cert). This
@@ -109,14 +110,15 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
     exit 1
 fi
 
-wait_port 18119 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 OUT="$TMPDIR/client.out"
 # GOOD_CA is the ROOT CA (not the leaf): the client pins the CA and the server
 # presents the leaf, so verification must build the chain and trust the CA —
 # the #1110 case.
 if ! AETHER_HOME="$ROOT" GOOD_CA="$CA" BAD_CA="$BADCA" \
-        "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then
+        AE_TEST_PORT="$PORT" "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then
     echo "  [FAIL] client exited non-zero:"
     head -10 "$OUT"
     exit 1

--- a/tests/integration/http_client_insecure_tls/client.ae
+++ b/tests/integration/http_client_insecure_tls/client.ae
@@ -11,14 +11,20 @@
 // (verification never happened) or #2 would also fail (skip is a no-op).
 
 import std.http.client
+import std.os
 
 extern exit(code: int)
 
-const URL = "https://localhost:18118/"
+// The server binds port 0 and reports the kernel's choice, so the port
+// arrives in the environment. An env var and not an argument because
+// `ae run script.ae <arg>` does not forward extra arguments.
+get_url() -> string {
+    return "https://localhost:${os_getenv("AE_TEST_PORT")}/"
+}
 
 main() {
     // 1. Default: self-signed cert must be rejected.
-    r1 = client.request("GET", URL)
+    r1 = client.request("GET", get_url())
     client.set_timeout(r1, 5s)
     resp1, err1 = client.send_request(r1)
     client.request_free(r1)
@@ -30,7 +36,7 @@ main() {
     }
 
     // 2. Insecure: same host, verification skipped, must succeed.
-    r2 = client.request("GET", URL)
+    r2 = client.request("GET", get_url())
     client.set_timeout(r2, 5s)
     ierr = client.set_insecure(r2, 1)
     if ierr != "" {

--- a/tests/integration/http_client_insecure_tls/server.ae
+++ b/tests/integration/http_client_insecure_tls/server.ae
@@ -11,8 +11,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18118
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -40,7 +40,7 @@ main() {
         exit(1)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
 
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
@@ -53,7 +53,15 @@ main() {
         println("FAIL: server_set_tls: ${tls_err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_root, 0)
 

--- a/tests/integration/http_client_insecure_tls/test_http_client_insecure_tls.sh
+++ b/tests/integration/http_client_insecure_tls/test_http_client_insecure_tls.sh
@@ -40,12 +40,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# NOTE: this test binds a UNIQUE port (18118) that no other integration test
+# NOTE: this test binds a UNIQUE port ($PORT) that no other integration test
 # uses. `ae run` forks the compiled server as a child, so the trap above can't
 # fully reap it (the fork outlives the wrapper) — every server test in this
 # suite has that limitation. A unique port is what keeps a lingering server
 # from starving the next test (the collision that surfaced this on macOS, where
-# reaping is slower). Keep 18118 distinct if you add a sibling test.
+# reaping is slower). Keep $PORT distinct if you add a sibling test.
 
 CERT="$TMPDIR/cert.pem"
 KEY="$TMPDIR/key.pem"
@@ -89,10 +89,11 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
 fi
 
 # Settle for the actor to bind the listen socket.
-wait_port 18118 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 OUT="$TMPDIR/client.out"
-if ! AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then
+if ! AETHER_HOME="$ROOT" AE_TEST_PORT="$PORT" "$AE" run "$SCRIPT_DIR/client.ae" >"$OUT" 2>&1; then
     echo "  [FAIL] client exited non-zero:"
     cat "$OUT" | head -10
     exit 1

--- a/tests/integration/http_h2_concurrent_dispatch/server.ae
+++ b/tests/integration/http_h2_concurrent_dispatch/server.ae
@@ -23,8 +23,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18280
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_slow(req: ptr, res: ptr, ud: ptr) {
     // sleep is implemented in std.os and yields the calling thread;
@@ -57,7 +57,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -81,7 +81,15 @@ main() {
             println("FAIL: server_set_h2_concurrent_dispatch: ${cd_err}")
             exit(1)
         }
-        println("READY")
+        // #1920: bind on port 0 so the kernel picks a free one, and report it.
+        // server_start reuses a socket the caller already bound, so this also
+        // means READY is printed AFTER the listen socket exists rather than
+        // before it, which is what the fixed sleep in the runner was covering.
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
     }
 
     http.server_get(raw, "/slow", handle_slow, 0)

--- a/tests/integration/http_h2_concurrent_dispatch/test_http_h2_concurrent_dispatch.sh
+++ b/tests/integration/http_h2_concurrent_dispatch/test_http_h2_concurrent_dispatch.sh
@@ -77,9 +77,10 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-wait_port 18280 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18280"
+URL="http://127.0.0.1:$PORT"
 
 # ------------------------------------------------------------------
 # Test 1 — sanity. /fast must respond over h2.

--- a/tests/integration/http_handler_user_data/server.ae
+++ b/tests/integration/http_handler_user_data/server.ae
@@ -19,8 +19,8 @@ import std.string
 extern exit(code: int)
 extern malloc(n: int) -> ptr
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18299
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 // Per-route context the handler reads back from the user_data slot.
 // Fields stand in for "DB handle + data-dir" — same shape as the
@@ -76,7 +76,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -99,8 +99,15 @@ main() {
     http.server_get(raw, "/a", handle_a, ctx_a)
     http.server_get(raw, "/b", handle_b, ctx_b)
     http.server_get(raw, "/n", handle_no_ctx, 0)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     srv_actor = spawn(SrvActor())

--- a/tests/integration/http_handler_user_data/test_http_handler_user_data.sh
+++ b/tests/integration/http_handler_user_data/test_http_handler_user_data.sh
@@ -47,9 +47,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18299 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-BASE="http://127.0.0.1:18299"
+BASE="http://127.0.0.1:$PORT"
 
 # Test 1 — route /a sees its own ctx (label=alpha db_id=11).
 RESP=$(curl --silent --show-error --max-time 5 "$BASE/a") || {

--- a/tests/integration/http_head_and_middleware/server.ae
+++ b/tests/integration/http_head_and_middleware/server.ae
@@ -9,8 +9,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18107
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -41,7 +41,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     if raw == 0 {
         println("FAIL: server_create returned null")
         exit(1)
@@ -49,7 +49,15 @@ main() {
     http.server_set_host(raw, "127.0.0.1")
     http.server_use_middleware(raw, mw_answer, 0)
     http.server_get(raw, "/", handle_root, 0)
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_head_and_middleware/test_http_head_and_middleware.sh
+++ b/tests/integration/http_head_and_middleware/test_http_head_and_middleware.sh
@@ -24,6 +24,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -43,9 +44,16 @@ trap cleanup EXIT
 fail() { echo "  [FAIL] $1"; [ -f "$TMPDIR/srv.log" ] && head -20 "$TMPDIR/srv.log"; exit 1; }
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
 
-URL="http://127.0.0.1:18107"
+URL="http://127.0.0.1:$PORT"
 
 # Wait for the port to answer, not for a line in the log: the server prints
 # READY before it binds, so a port left busy by an earlier run would otherwise
@@ -53,7 +61,7 @@ URL="http://127.0.0.1:18107"
 deadline=$(($(date +%s) + 20))
 until curl --silent --max-time 2 -o /dev/null "$URL/" 2>/dev/null; do
     kill -0 "$SRV_PID" 2>/dev/null || fail "server exited before it served"
-    [ "$(date +%s)" -lt "$deadline" ] || fail "server never answered on 18107 (port already in use?)"
+    [ "$(date +%s)" -lt "$deadline" ] || fail "server never answered on $PORT (port already in use?)"
     sleep 0.1
 done
 
@@ -79,7 +87,7 @@ get_bytes="$(curl --silent --show-error --max-time 5 -o /dev/null \
 cc "$SCRIPT_DIR/pipeline_client.c" -o "$TMPDIR/pipeline" 2>"$TMPDIR/cc.log" \
     || { sed 's/^/        /' "$TMPDIR/cc.log" | head -5; fail "could not compile pipeline_client.c"; }
 
-if ! "$TMPDIR/pipeline" 127.0.0.1 18107 >"$TMPDIR/pipe.out" 2>"$TMPDIR/pipe.err"; then
+if ! "$TMPDIR/pipeline" 127.0.0.1 $PORT >"$TMPDIR/pipe.out" 2>"$TMPDIR/pipe.err"; then
     sed 's/^/        /' "$TMPDIR/pipe.err" | head -5
     fail "the three requests did not complete on one connection"
 fi

--- a/tests/integration/http_middleware_d1/server.ae
+++ b/tests/integration/http_middleware_d1/server.ae
@@ -12,8 +12,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18105
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -45,7 +45,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
@@ -62,7 +62,15 @@ main() {
     e4 = middleware.use_cors(raw, "*", "GET, POST, OPTIONS",
         "Content-Type, Authorization", 0, 600)
     if e4 != "" { println("FAIL: cors: ${e4}"); exit(1) }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_root, 0)
 

--- a/tests/integration/http_middleware_d1/test_http_middleware_d1.sh
+++ b/tests/integration/http_middleware_d1/test_http_middleware_d1.sh
@@ -34,6 +34,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -52,9 +53,16 @@ cleanup() {
 trap cleanup EXIT
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
 
-URL="http://127.0.0.1:18105/"
+URL="http://127.0.0.1:$PORT/"
 
 # Wait for the server to actually accept connections, not just print
 # READY. server.ae prints READY before the SrvActor receives StartSrv

--- a/tests/integration/http_middleware_d2/server.ae
+++ b/tests/integration/http_middleware_d2/server.ae
@@ -19,8 +19,8 @@ extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
 extern aether_rewrite_opts_new() -> ptr
 extern aether_error_pages_opts_new() -> ptr
-
-const PORT = 18106
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_api(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -48,7 +48,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
@@ -78,8 +78,15 @@ main() {
         "<html><body><h1>Custom Internal Error</h1></body></html>",
         "text/html; charset=utf-8")
     middleware.use_error_pages(raw, ep_opts)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/api/data", handle_api, 0)
     http.server_get(raw, "/kaboom", handle_kaboom, 0)

--- a/tests/integration/http_middleware_d2/test_http_middleware_d2.sh
+++ b/tests/integration/http_middleware_d2/test_http_middleware_d2.sh
@@ -33,6 +33,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -65,9 +66,16 @@ fi
 
 AETHER_HOME="$ROOT" STATIC_ROOT="$STATIC_ROOT" \
     "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
 
-URL_BASE="http://127.0.0.1:18106"
+URL_BASE="http://127.0.0.1:$PORT"
 
 # Wait for the server to actually accept connections, not just print
 # READY. server.ae prints READY before the SrvActor receives StartSrv

--- a/tests/integration/http_park_idle_connections/server.ae
+++ b/tests/integration/http_park_idle_connections/server.ae
@@ -7,8 +7,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18137
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -29,14 +29,22 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     if raw == 0 {
         println("FAIL: server_create returned null")
         exit(1)
     }
     http.server_set_host(raw, "127.0.0.1")
     http.server_get(raw, "/", handle, 0)
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_park_idle_connections/test_http_park_idle_connections.sh
+++ b/tests/integration/http_park_idle_connections/test_http_park_idle_connections.sh
@@ -23,8 +23,8 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
-PORT=18137
 CONNECTIONS="${PARK_TEST_CONNECTIONS:-200}"
 
 if [ ! -x "$AE" ]; then
@@ -63,6 +63,13 @@ cc "$SCRIPT_DIR/park_client.c" -o "$TMP/client" 2>"$TMP/cc.log" \
     || { sed 's/^/        /' "$TMP/cc.log" | head -5; fail "could not compile park_client.c"; }
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMP/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMP/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMP/srv.log") || exit 1
 SRV_PID=$!
 
 deadline=$(($(date +%s) + 25))

--- a/tests/integration/http_query_param_multi/server.ae
+++ b/tests/integration/http_query_param_multi/server.ae
@@ -9,8 +9,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18283
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle(req: ptr, res: ptr, ud: ptr) {
     // Read each key BEFORE building the body so the bug, if reintroduced,
@@ -56,7 +56,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -66,8 +66,15 @@ main() {
     http.server_get(raw, "/multi", handle, 0)
     http.server_get(raw, "/single", handle_single, 0)
     http.server_get(raw, "/missing", handle_missing, 0)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
+++ b/tests/integration/http_query_param_multi/test_http_query_param_multi.sh
@@ -45,9 +45,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18283 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-BASE="http://127.0.0.1:18283"
+BASE="http://127.0.0.1:$PORT"
 
 # Test 1 — the regression. Three params; each must come back distinct.
 RESP=$(curl --silent --show-error --max-time 5 "$BASE/multi?alpha=AAA&beta=BBB&gamma=CCC") || {

--- a/tests/integration/http_real_ip/server.ae
+++ b/tests/integration/http_real_ip/server.ae
@@ -13,8 +13,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18272
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_whoami(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -39,7 +39,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -53,7 +53,15 @@ main() {
         exit(1)
     }
 
-    println("READY")
+    // Bind explicitly on port 0 so the kernel picks a free port, and report
+    // it. server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/whoami", handle_whoami, 0)
 

--- a/tests/integration/http_real_ip/test_http_real_ip.sh
+++ b/tests/integration/http_real_ip/test_http_real_ip.sh
@@ -64,9 +64,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18272 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18272/whoami"
+URL="http://127.0.0.1:$PORT/whoami"
 
 # Test 1 — multi-hop X-Forwarded-For. Leftmost wins.
 RESP1=$(curl --silent --show-error --max-time 5 \

--- a/tests/integration/http_redirect_cross_host/driver.ae
+++ b/tests/integration/http_redirect_cross_host/driver.ae
@@ -6,8 +6,8 @@
 // authorised — and it had no runtime coverage, only an API-surface test.
 //
 // Two hops, one assertion each:
-//   /start -> localhost:18211   (host name differs: must be stripped)
-//   /same  -> 127.0.0.1:18211   (host name identical: must survive)
+//   /start -> localhost:${os_getenv("AE_TEST_PORT")}   (host name differs: must be stripped)
+//   /same  -> 127.0.0.1:${os_getenv("AE_TEST_PORT")}   (host name identical: must survive)
 //
 // Port is deliberately equal on both hops so this test isolates the host.
 // The rule compares the whole origin (scheme, host and port) since #1741;
@@ -17,6 +17,7 @@
 // it, a client that dropped the header unconditionally would also pass.
 
 import std.http.client
+import std.os
 import std.string
 
 check(url: string, want: string, label: string) -> int {
@@ -54,7 +55,7 @@ main() {
     // "localhost" has to reach the same server, or the cross-host hop would
     // fail to connect and prove nothing. Skip rather than report a failure
     // that is about name resolution.
-    probe_req = client.request("GET", "http://localhost:18211/landing")
+    probe_req = client.request("GET", "http://localhost:${os_getenv("AE_TEST_PORT")}/landing")
     probe, probe_err = client.send_request(probe_req)
     client.request_free(probe_req)
     if probe_err != "" {
@@ -65,11 +66,11 @@ main() {
 
     bad = 0
     // The host name differs: the credentials must not be replayed.
-    bad = bad + check("http://127.0.0.1:18211/start",
+    bad = bad + check("http://127.0.0.1:${os_getenv("AE_TEST_PORT")}/start",
         "auth=absent cookie=absent", "cross-host")
     // Same host name: dropping them here would be a regression the other
     // direction, breaking ordinary same-site redirects.
-    bad = bad + check("http://127.0.0.1:18211/same",
+    bad = bad + check("http://127.0.0.1:${os_getenv("AE_TEST_PORT")}/same",
         "auth=present cookie=present", "same-host")
     if bad == 0 {
         println("PASS: credentials dropped across hosts, kept within one")

--- a/tests/integration/http_redirect_cross_host/server.ae
+++ b/tests/integration/http_redirect_cross_host/server.ae
@@ -15,13 +15,18 @@ import std.http
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
-const PORT = 18211
+// The redirect targets name this server's OWN port, and it now binds port 0,
+// so the port is only known after the bind. Held here so the handlers can
+// build the Location header from it.
+var g_port: int = 0
 
 redirect_handler(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 302)
     http.response_set_header(res, "Location",
-        "http://localhost:18211/landing")
+        "http://localhost:${g_port}/landing")
     http.response_set_header(res, "Content-Type", "text/plain")
     http.response_set_body(res, "moved\n")
 }
@@ -30,7 +35,7 @@ redirect_handler(req: ptr, res: ptr, ud: ptr) {
 same_host_handler(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 302)
     http.response_set_header(res, "Location",
-        "http://127.0.0.1:18211/landing")
+        "http://127.0.0.1:${g_port}/landing")
     http.response_set_header(res, "Content-Type", "text/plain")
     http.response_set_body(res, "moved\n")
 }
@@ -55,12 +60,21 @@ echo_handler(req: ptr, res: ptr, ud: ptr) {
 }
 
 main() {
-    s = http.server_create(PORT)
+    s = http.server_create(0)
     http.server_set_host(s, "0.0.0.0")
     http.server_get(s, "/start", redirect_handler, 0)
     http.server_get(s, "/same", same_host_handler, 0)
     http.server_get(s, "/landing", echo_handler, 0)
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(s, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    g_port = http_server_port(s)
+    println("READY ${g_port}")
     http_server_start_raw(s)
     exit(0)
 }

--- a/tests/integration/http_redirect_cross_host/test_http_redirect_cross_host.sh
+++ b/tests/integration/http_redirect_cross_host/test_http_redirect_cross_host.sh
@@ -28,6 +28,7 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if [ ! -x "$AE" ]; then
@@ -54,15 +55,22 @@ fail() { echo "  [FAIL] $1"; [ -f "$TMP/driver.out" ] && sed 's/^/        /' "$T
     || { sed 's/^/        /' "$TMP/build2.log" | head -8; fail "driver.ae did not build"; }
 
 "$TMP/server" >"$TMP/server.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMP/server.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMP/server.log") || exit 1
 ORIGIN_PID=$!
 
 deadline=$(($(date +%s) + 15))
-until curl -s -o /dev/null --max-time 1 "http://127.0.0.1:18211/landing" 2>/dev/null; do
+until curl -s -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/landing" 2>/dev/null; do
     [ "$(date +%s)" -ge "$deadline" ] && fail "server never accepted connections"
     sleep 0.1
 done
 
-"$TMP/driver" >"$TMP/driver.out" 2>&1 || fail "driver exited non-zero"
+AE_TEST_PORT="$PORT" "$TMP/driver" >"$TMP/driver.out" 2>&1 || fail "driver exited non-zero"
 if grep -q "^SKIP:" "$TMP/driver.out"; then
     echo "  [SKIP] http_redirect_cross_host: $(sed -n 's/^SKIP: //p' "$TMP/driver.out" | head -1)"
     exit 0

--- a/tests/integration/http_request_conn_accessors/server.ae
+++ b/tests/integration/http_request_conn_accessors/server.ae
@@ -8,8 +8,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18294
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_whoami(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -40,14 +40,21 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
         exit(1)
     }
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     // Keep-alive on, so the multi-request half of the shell test actually
     // reuses one connection. Without it curl reconnects per request, the

--- a/tests/integration/http_request_conn_accessors/test_http_request_conn_accessors.sh
+++ b/tests/integration/http_request_conn_accessors/test_http_request_conn_accessors.sh
@@ -48,9 +48,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18294 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18294/whoami"
+URL="http://127.0.0.1:$PORT/whoami"
 
 RESP=$(curl --silent --show-error --max-time 5 "$URL" 2>"$TMPDIR/c.err") || {
     echo "  [FAIL] curl failed:"; cat "$TMPDIR/c.err"; exit 1
@@ -70,7 +71,7 @@ VER=$(get_field ver)
 [ "$PEER" = "127.0.0.1" ] || { echo "  [FAIL] peer expected 127.0.0.1, got '$PEER'"; echo "  raw: $RESP"; exit 1; }
 [ "$PEER_PORT_NZ" = "1" ] || { echo "  [FAIL] peer_port should be nonzero (kernel-assigned ephemeral), got '$PEER_PORT_NZ'"; echo "  raw: $RESP"; exit 1; }
 [ "$LOCAL" = "127.0.0.1" ] || { echo "  [FAIL] local expected 127.0.0.1, got '$LOCAL'"; echo "  raw: $RESP"; exit 1; }
-[ "$LOCAL_PORT" = "18294" ] || { echo "  [FAIL] local_port expected 18294, got '$LOCAL_PORT'"; echo "  raw: $RESP"; exit 1; }
+[ "$LOCAL_PORT" = "$PORT" ] || { echo "  [FAIL] local_port expected $PORT, got '$LOCAL_PORT'"; echo "  raw: $RESP"; exit 1; }
 [ "$SCHEME" = "http" ] || { echo "  [FAIL] scheme expected http (cleartext listener), got '$SCHEME'"; echo "  raw: $RESP"; exit 1; }
 [ "$IS_TLS" = "0" ] || { echo "  [FAIL] is_tls expected 0 (cleartext listener), got '$IS_TLS'"; echo "  raw: $RESP"; exit 1; }
 [ "$VER" = "HTTP/1.1" ] || { echo "  [FAIL] ver expected HTTP/1.1, got '$VER'"; echo "  raw: $RESP"; exit 1; }
@@ -103,9 +104,9 @@ MULTI_PEERS=$(echo "$MULTI" | grep -o 'peer=127\.0\.0\.1' | wc -l | tr -d '[:spa
     echo "  [FAIL] expected peer=127.0.0.1 on all 3 keep-alive requests, got $MULTI_PEERS"
     echo "  raw: $MULTI"; exit 1; }
 
-MULTI_LOCALS=$(echo "$MULTI" | grep -o 'local_port=18294' | wc -l | tr -d '[:space:]')
+MULTI_LOCALS=$(echo "$MULTI" | grep -o "local_port=$PORT" | wc -l | tr -d '[:space:]')
 [ "$MULTI_LOCALS" = "3" ] || {
-    echo "  [FAIL] expected local_port=18294 on all 3 keep-alive requests, got $MULTI_LOCALS"
+    echo "  [FAIL] expected local_port=$PORT on all 3 keep-alive requests, got $MULTI_LOCALS"
     echo "  raw: $MULTI"; exit 1; }
 
 echo "  [PASS] http_request_conn_accessors (remote_port + local_addr/port + scheme + is_tls + http_version; cached addrs survive keep-alive)"

--- a/tests/integration/http_request_remote_addr/server.ae
+++ b/tests/integration/http_request_remote_addr/server.ae
@@ -12,8 +12,8 @@ import std.os
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18293
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_whoami(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -39,14 +39,21 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
         exit(1)
     }
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/whoami", handle_whoami, 0)
 

--- a/tests/integration/http_request_remote_addr/test_http_request_remote_addr.sh
+++ b/tests/integration/http_request_remote_addr/test_http_request_remote_addr.sh
@@ -53,9 +53,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18293 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18293/whoami"
+URL="http://127.0.0.1:$PORT/whoami"
 
 # Test 1 — plain loopback request. peer should be 127.0.0.1; xff empty.
 RESP1=$(curl --silent --show-error --max-time 5 "$URL" 2>"$TMPDIR/c1.err") || {

--- a/tests/integration/http_sendfile/server.ae
+++ b/tests/integration/http_sendfile/server.ae
@@ -13,8 +13,8 @@ import std.string
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
 extern exit(code: int)
-
-const PORT = 19200
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_static(req: ptr, res: ptr, ud: ptr) {
     // Resolve path: /static/<filename> → <root>/<filename>.
@@ -53,14 +53,21 @@ main() {
         exit(1)
     }
 
-    s = http.server_create(PORT)
+    s = http.server_create(0)
     if s == 0 { println("FAIL: server_create"); exit(1) }
     http.server_set_host(s, "127.0.0.1")
     http.server_set_keepalive(s, 1, 0, 5000ms)
     // Wildcard match — the handler does its own prefix check.
     http.server_get(s, "/static/*", handle_static, 0)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(s, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(s)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_sendfile/test_http_sendfile.sh
+++ b/tests/integration/http_sendfile/test_http_sendfile.sh
@@ -78,9 +78,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 19200 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:19200"
+URL="http://127.0.0.1:$PORT"
 
 # --- Test 1: byte-identical body over cleartext h1.1 ---
 RESP_BODY="$TMPDIR/got1.bin"

--- a/tests/integration/http_serve_static_range/server.ae
+++ b/tests/integration/http_serve_static_range/server.ae
@@ -9,8 +9,8 @@ import std.fs
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18301
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handler(req: ptr, res: ptr, ud: ptr) {
     http.serve_static(req, res, ud)
@@ -37,15 +37,22 @@ main() {
         exit(0)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create")
         exit(1)
     }
     http.server_get(raw, "/*", handler, base)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
     spawn(SchedHelper())
     a = spawn(SrvActor())
     a ! StartSrv { raw: raw }

--- a/tests/integration/http_serve_static_range/test_http_serve_static_range.sh
+++ b/tests/integration/http_serve_static_range/test_http_serve_static_range.sh
@@ -64,9 +64,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18301 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18301/data.bin"
+URL="http://127.0.0.1:$PORT/data.bin"
 
 # Test 1 — bytes=0-1023 should be 206 with 1024 bytes
 RESP_HEAD="$TMPDIR/h1.txt"

--- a/tests/integration/http_server_actor_dispatch/server.ae
+++ b/tests/integration/http_server_actor_dispatch/server.ae
@@ -13,8 +13,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18104
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_echo(req: ptr, res: ptr, ud: ptr) {
     // Echo a header so the runner can verify the right session got
@@ -37,7 +37,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create")
@@ -50,7 +50,15 @@ main() {
         println("FAIL: keepalive: ${err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/echo", handle_echo, 0)
 

--- a/tests/integration/http_server_actor_dispatch/test_http_server_actor_dispatch.sh
+++ b/tests/integration/http_server_actor_dispatch/test_http_server_actor_dispatch.sh
@@ -25,6 +25,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -43,9 +44,15 @@ cleanup() {
 trap cleanup EXIT
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
 
-PORT=18104
 # Wait for the server to ACTUALLY accept connections, not just print
 # READY. The server prints READY at line 50 of server.ae but doesn't
 # call http_server_start_raw until the SrvActor receives StartSrv —
@@ -97,7 +104,7 @@ run_session() {
     args=""
     n=0
     while [ "$n" -lt "$REQS_PER_SESSION" ]; do
-        args="$args http://127.0.0.1:18104/echo -o $out.$n"
+        args="$args http://127.0.0.1:$PORT/echo -o $out.$n"
         n=$((n + 1))
     done
     # shellcheck disable=SC2086

--- a/tests/integration/http_server_connect_tunnel/client.ae
+++ b/tests/integration/http_server_connect_tunnel/client.ae
@@ -1,11 +1,17 @@
 // Aether-side driver for the #1086 CONNECT tunnel regression.
 
 import std.tcp
+import std.os
 import std.string
 
 extern exit(code: int)
 
-const PORT = 18286
+// The server binds port 0 and reports the kernel's choice, so the port
+// arrives in the environment rather than being baked in.
+get_port() -> int {
+    p, _err = string.to_int(os_getenv("AE_TEST_PORT"))
+    return p
+}
 
 fail(msg: string) {
     println("  [FAIL] ${msg}")
@@ -28,7 +34,7 @@ make_payload() -> string {
 }
 
 main() {
-    denied, derr = tcp.connect("127.0.0.1", PORT)
+    denied, derr = tcp.connect("127.0.0.1", get_port())
     if derr != "" { fail("connect denied case: ${derr}") }
     _, dwerr = tcp.write(denied,
         "CONNECT denied.example:443 HTTP/1.1\r\nHost: denied.example:443\r\n\r\n")
@@ -40,7 +46,7 @@ main() {
         fail("denied CONNECT did not return 403: ${dhead}")
     }
 
-    accepted, aerr = tcp.connect("127.0.0.1", PORT)
+    accepted, aerr = tcp.connect("127.0.0.1", get_port())
     if aerr != "" { fail("connect accepted case: ${aerr}") }
     _, awerr = tcp.write(accepted,
         "CONNECT allowed.example:443 HTTP/1.1\r\nHost: allowed.example:443\r\n\r\n")

--- a/tests/integration/http_server_connect_tunnel/server.ae
+++ b/tests/integration/http_server_connect_tunnel/server.ae
@@ -6,8 +6,8 @@ import std.tcp
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18286
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_connect(req: ptr, res: ptr, ud: ptr) {
     authority = http.request_path(req)
@@ -27,7 +27,7 @@ handle_connect(req: ptr, res: ptr, ud: ptr) {
 
     bytes, n, err = tcp.read_n(tunnel, 128)
     if err == "" {
-        sent, werr = tcp.write_n(tunnel, bytes, n)
+        _sent, werr = tcp.write_n(tunnel, bytes, n)
         if werr != "" {
             tcp.close(tunnel)
             return
@@ -50,7 +50,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -58,7 +58,15 @@ main() {
     }
 
     http.server_add_route(raw, "CONNECT", "*", handle_connect, 0)
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_server_connect_tunnel/test_http_server_connect_tunnel.sh
+++ b/tests/integration/http_server_connect_tunnel/test_http_server_connect_tunnel.sh
@@ -47,9 +47,10 @@ grep -q READY "$TMPDIR/srv.log" 2>/dev/null || {
     head -30 "$TMPDIR/srv.log"
     exit 1
 }
-wait_port 18286 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/client.ae" >"$TMPDIR/client.out" 2>&1 || {
+AETHER_HOME="$ROOT" AE_TEST_PORT="$PORT" "$AE" run "$SCRIPT_DIR/client.ae" >"$TMPDIR/client.out" 2>&1 || {
     echo "  [FAIL] client exited non-zero:"
     cat "$TMPDIR/client.out"
     echo "--- server log ---"

--- a/tests/integration/http_server_h2/server.ae
+++ b/tests/integration/http_server_h2/server.ae
@@ -19,8 +19,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18260
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -98,7 +98,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -117,7 +117,15 @@ main() {
     if h2_err != "" {
         println("READY-NOH2: ${h2_err}")
     } else {
-        println("READY")
+        // #1920: bind on port 0 so the kernel picks a free one, and report it.
+        // server_start reuses a socket the caller already bound, so this also
+        // means READY is printed AFTER the listen socket exists rather than
+        // before it, which is what the fixed sleep in the runner was covering.
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
     }
 
     http.server_get(raw, "/", handle_root, 0)

--- a/tests/integration/http_server_h2/test_http_server_h2.sh
+++ b/tests/integration/http_server_h2/test_http_server_h2.sh
@@ -82,7 +82,8 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-PORT=18260
+PORT=$PORT
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 wait_port "$PORT" || exit 1
 
 URL_BASE="http://127.0.0.1:$PORT"

--- a/tests/integration/http_server_h2_middleware/server.ae
+++ b/tests/integration/http_server_h2_middleware/server.ae
@@ -13,8 +13,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18262
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_text(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -44,7 +44,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -77,7 +77,15 @@ main() {
     if h2_err != "" {
         println("READY-NOH2: ${h2_err}")
     } else {
-        println("READY")
+        // #1920: bind on port 0 so the kernel picks a free one, and report it.
+        // server_start reuses a socket the caller already bound, so this also
+        // means READY is printed AFTER the listen socket exists rather than
+        // before it, which is what the fixed sleep in the runner was covering.
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
     }
 
     http.server_get(raw, "/text", handle_text, 0)

--- a/tests/integration/http_server_h2_middleware/test_http_server_h2_middleware.sh
+++ b/tests/integration/http_server_h2_middleware/test_http_server_h2_middleware.sh
@@ -75,9 +75,10 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-wait_port 18262 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18262/text"
+URL="http://127.0.0.1:$PORT/text"
 HEADERS="$TMPDIR/headers"
 BODY_GZ="$TMPDIR/body.gz"
 HTTPVER=$(curl --silent --show-error --max-time 5 \

--- a/tests/integration/http_server_h2_tls/server.ae
+++ b/tests/integration/http_server_h2_tls/server.ae
@@ -12,8 +12,8 @@ extern exit(code: int)
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
 extern os_getenv(name: string) -> string
-
-const PORT = 18263
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -41,7 +41,7 @@ main() {
         exit(1)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
 
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
@@ -60,7 +60,15 @@ main() {
         // Build doesn't link libnghttp2 — runner detects this and skips.
         println("READY-NOH2: ${h2_err}")
     } else {
-        println("READY")
+        // #1920: bind on port 0 so the kernel picks a free one, and report it.
+        // server_start reuses a socket the caller already bound, so this also
+        // means READY is printed AFTER the listen socket exists rather than
+        // before it, which is what the fixed sleep in the runner was covering.
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
     }
 
     http.server_get(raw, "/", handle_root, 0)

--- a/tests/integration/http_server_h2_tls/test_http_server_h2_tls.sh
+++ b/tests/integration/http_server_h2_tls/test_http_server_h2_tls.sh
@@ -83,9 +83,10 @@ done
     echo "  [FAIL] no READY within timeout"; head -20 "$TMPDIR/srv.log"; exit 1
 }
 case "$ready" in READY-NOH2*) echo "  [SKIP] $ready"; exit 0;; esac
-wait_port 18263 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="https://127.0.0.1:18263/"
+URL="https://127.0.0.1:$PORT/"
 RESP="$TMPDIR/resp"
 # --insecure: self-signed cert. --http2: ask curl to negotiate
 # HTTP/2 via ALPN. -w prints the negotiated http_version.

--- a/tests/integration/http_server_keepalive/server.ae
+++ b/tests/integration/http_server_keepalive/server.ae
@@ -12,8 +12,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18103
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_count(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -34,7 +34,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
         println("FAIL: server_create returned null")
@@ -47,7 +47,15 @@ main() {
         println("FAIL: server_set_keepalive: ${ka_err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_count, 0)
 

--- a/tests/integration/http_server_keepalive/test_http_server_keepalive.sh
+++ b/tests/integration/http_server_keepalive/test_http_server_keepalive.sh
@@ -62,7 +62,8 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18103 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 # Three URLs in one curl invocation re-uses a single TCP connection.
 # Use distinct -o files per URL so we can verify each response
@@ -71,9 +72,9 @@ wait_port 18103 || exit 1
 # keep-alive header check below.
 ERR="$TMPDIR/curl.err"
 if ! curl --silent --show-error --max-time 5 -v \
-        http://127.0.0.1:18103/ -o "$TMPDIR/r1" \
-        http://127.0.0.1:18103/ -o "$TMPDIR/r2" \
-        http://127.0.0.1:18103/ -o "$TMPDIR/r3" \
+        http://127.0.0.1:$PORT/ -o "$TMPDIR/r1" \
+        http://127.0.0.1:$PORT/ -o "$TMPDIR/r2" \
+        http://127.0.0.1:$PORT/ -o "$TMPDIR/r3" \
         2>"$ERR"; then
     echo "  [FAIL] curl failed:"
     cat "$ERR"

--- a/tests/integration/http_server_observability/server.ae
+++ b/tests/integration/http_server_observability/server.ae
@@ -12,8 +12,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18108
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_data(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -38,7 +38,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
@@ -49,8 +49,15 @@ main() {
 
     em = http.server_set_metrics(raw, "/metrics")
     if em != "" { println("FAIL: metrics: ${em}"); exit(1) }
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/api/data", handle_data, 0)
     http.server_get(raw, "/api/error", handle_error, 0)

--- a/tests/integration/http_server_observability/test_http_server_observability.sh
+++ b/tests/integration/http_server_observability/test_http_server_observability.sh
@@ -62,9 +62,10 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18108 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
-URL="http://127.0.0.1:18108"
+URL="http://127.0.0.1:$PORT"
 
 # Drive a few requests across both routes.
 curl -s -o /dev/null --max-time 5 "$URL/api/data"  >/dev/null

--- a/tests/integration/http_server_ops/server.ae
+++ b/tests/integration/http_server_ops/server.ae
@@ -20,8 +20,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18107
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 // Marker-file paths come from env so the runner can tee into a tmp dir.
 @c_callback on_started(server: ptr, ud: ptr) {
@@ -70,7 +70,7 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
@@ -79,8 +79,15 @@ main() {
 
     e = http.server_set_health_probes(raw, "/healthz", "/readyz", ready_check, null)
     if e != "" { println("FAIL: probes: ${e}"); exit(1) }
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/work", handle_work, 0)
 

--- a/tests/integration/http_server_ops/test_http_server_ops.sh
+++ b/tests/integration/http_server_ops/test_http_server_ops.sh
@@ -66,7 +66,8 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18107 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 # --- on_start hook fired ---
 if ! [ -f "$MARKER" ] || ! grep -q STARTED "$MARKER"; then
@@ -75,7 +76,7 @@ if ! [ -f "$MARKER" ] || ! grep -q STARTED "$MARKER"; then
     exit 1
 fi
 
-URL="http://127.0.0.1:18107"
+URL="http://127.0.0.1:$PORT"
 
 # --- /healthz always 200 ---
 status=$(curl -s -o "$TMPDIR/healthz.body" -w '%{http_code}' --max-time 5 "$URL/healthz")

--- a/tests/integration/http_server_sse/server.ae
+++ b/tests/integration/http_server_sse/server.ae
@@ -9,8 +9,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18109
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 @c_callback events_handler(req: ptr, sse: ptr, ud: ptr) {
     http.sse_send(sse, "tick", "1")
@@ -31,13 +31,20 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
     http.server_sse(raw, "/events", events_handler, null)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_server_sse/test_http_server_sse.sh
+++ b/tests/integration/http_server_sse/test_http_server_sse.sh
@@ -29,6 +29,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -47,9 +48,15 @@ cleanup() {
 trap cleanup EXIT
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
 
-PORT=18109
 
 # Wait for the server to actually accept connections, not just for
 # READY to land in the log. server.ae prints READY before sending

--- a/tests/integration/http_server_tls/server.ae
+++ b/tests/integration/http_server_tls/server.ae
@@ -11,8 +11,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18102
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -40,7 +40,7 @@ main() {
         exit(1)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
 
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 {
@@ -53,7 +53,15 @@ main() {
         println("FAIL: server_set_tls: ${tls_err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_root, 0)
 

--- a/tests/integration/http_server_tls/test_http_server_tls.sh
+++ b/tests/integration/http_server_tls/test_http_server_tls.sh
@@ -97,7 +97,8 @@ if ! grep -q READY "$TMPDIR/srv.log" 2>/dev/null; then
 fi
 
 # Brief settle for the actor to bind the listen socket.
-wait_port 18102 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 # Drive the HTTPS request. --cacert points curl at our self-signed
 # cert so verification succeeds; --resolve isn't needed because the
@@ -106,8 +107,8 @@ wait_port 18102 || exit 1
 # actually pin the host with --resolve so cert SAN/CN matches).
 ACTUAL="$TMPDIR/curl.out"
 if ! curl --silent --max-time 5 --cacert "$CERT" \
-          --resolve localhost:18102:127.0.0.1 \
-          https://localhost:18102/ -o "$ACTUAL" 2>"$TMPDIR/curl.err"; then
+          --resolve localhost:$PORT:127.0.0.1 \
+          https://localhost:$PORT/ -o "$ACTUAL" 2>"$TMPDIR/curl.err"; then
     echo "  [FAIL] curl failed:"
     cat "$TMPDIR/curl.err"
     echo "--- server log ---"
@@ -123,7 +124,7 @@ fi
 
 # Sanity: a plain-HTTP request to the same TLS port must fail (the
 # handshake is mandatory; the server should reject the plaintext).
-if curl --silent --max-time 2 http://localhost:18102/ \
+if curl --silent --max-time 2 http://localhost:$PORT/ \
         -o "$TMPDIR/plain.out" 2>/dev/null; then
     # If curl exited 0 it could be that the server responded with
     # garbage or that some proxy intercepted. Check the body.

--- a/tests/integration/http_server_websocket/server.ae
+++ b/tests/integration/http_server_websocket/server.ae
@@ -10,8 +10,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18110
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 @c_callback echo_handler(req: ptr, ws: ptr, ud: ptr) {
     // Echo every message until the peer closes (ws_recv returns -1)
@@ -44,13 +44,20 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
     http.server_websocket(raw, "/echo", echo_handler, null)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_server_websocket/test_http_server_websocket.sh
+++ b/tests/integration/http_server_websocket/test_http_server_websocket.sh
@@ -93,13 +93,17 @@ wait_port "$PORT" || exit 1
 
 # Python client sends 3 text messages and prints each echo on its
 # own line; non-zero exit on any failure.
-python3 - <<'PY' >"$TMPDIR/py.out" 2>"$TMPDIR/py.err"
+# The heredoc is QUOTED, so the shell expands nothing inside it: the port
+# has to arrive through the environment. Unquoting it instead would expand
+# every $ in the Python too.
+AE_TEST_PORT="$PORT" python3 - <<'PY' >"$TMPDIR/py.out" 2>"$TMPDIR/py.err"
+import os
 import asyncio
 import sys
 import websockets
 
 async def main():
-    async with websockets.connect("ws://127.0.0.1:$PORT/echo") as ws:
+    async with websockets.connect("ws://127.0.0.1:" + os.environ["AE_TEST_PORT"] + "/echo") as ws:
         for msg in ("hello", "world", "!"):
             await ws.send(msg)
             reply = await asyncio.wait_for(ws.recv(), timeout=2)

--- a/tests/integration/http_server_websocket/test_http_server_websocket.sh
+++ b/tests/integration/http_server_websocket/test_http_server_websocket.sh
@@ -88,7 +88,8 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     fi
     sleep 0.1
 done
-wait_port 18110 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 # Python client sends 3 text messages and prints each echo on its
 # own line; non-zero exit on any failure.
@@ -98,7 +99,7 @@ import sys
 import websockets
 
 async def main():
-    async with websockets.connect("ws://127.0.0.1:18110/echo") as ws:
+    async with websockets.connect("ws://127.0.0.1:$PORT/echo") as ws:
         for msg in ("hello", "world", "!"):
             await ws.send(msg)
             reply = await asyncio.wait_for(ws.recv(), timeout=2)

--- a/tests/integration/http_sse_upgrade/server.ae
+++ b/tests/integration/http_sse_upgrade/server.ae
@@ -13,8 +13,8 @@ import std.http
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18131
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 @c_callback stream_handler(req: ptr, res: ptr, ud: ptr) {
     q = http.request_query(req)
@@ -57,12 +57,19 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     if raw == 0 { println("FAIL: server_create") exit(1) }
     http.server_set_host(raw, "127.0.0.1")
     http.http_server_get(raw, "/stream", stream_handler, null)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
     spawn(SchedHelper())
     a = spawn(SrvActor())
     a ! StartSrv { raw: raw }

--- a/tests/integration/http_sse_upgrade/test_http_sse_upgrade.sh
+++ b/tests/integration/http_sse_upgrade/test_http_sse_upgrade.sh
@@ -30,6 +30,7 @@ esac
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 command -v curl >/dev/null 2>&1 || { echo "  [SKIP] curl not on PATH"; exit 0; }
 
@@ -44,8 +45,14 @@ cleanup() {
 trap cleanup EXIT
 
 AETHER_HOME="$ROOT" "$AE" run "$SCRIPT_DIR/server.ae" >"$TMPDIR/srv.log" 2>&1 &
+
+# The server binds port 0 and prints the kernel's choice on its READY line.
+for _ in $(seq 1 300); do
+    grep -q "^READY " "$TMPDIR/srv.log" 2>/dev/null && break
+    sleep 0.05
+done
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
 SRV_PID=$!
-PORT=18131
 
 # Probe the port rather than trusting READY: server.ae prints it before the
 # StartSrv message opens the listener, and a curl issued too early returns

--- a/tests/integration/http_stream_upload/server.ae
+++ b/tests/integration/http_stream_upload/server.ae
@@ -28,8 +28,8 @@ extern http_server_post(server: ptr, path: string, handler: ptr, user_data: ptr)
 // a raw extern (not callable via the fs. namespace), so bind it here.
 extern file_close(file: ptr) -> int
 extern exit(code: int)
-
-const PORT = 19250
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_upload(req: ptr, res: ptr, ud: ptr) {
     // #644: a streaming request is not complete at handler entry (the
@@ -37,7 +37,7 @@ handle_upload(req: ptr, res: ptr, ud: ptr) {
     // read loop drains the declared length. Reported to the driver.
     pre = http.request_body_complete(req)
     total = http.request_body_length(req)
-    root = aether_args_get(2)
+    root = aether_args_get(1)
     out_path = "${root}/uploaded.bin"
 
     // Stream chunks → temp file via positional writes. Peak RAM is one
@@ -119,21 +119,30 @@ actor SchedHelper {
 }
 
 main() {
+    // The port is no longer an argument: the server binds 0 and reports the
+    // kernel's choice on the READY line, so only the root remains.
     n = aether_args_count()
-    if n < 3 {
-        println("usage: server <port> <root>")
+    if n < 2 {
+        println("usage: server <root>")
         exit(1)
     }
 
-    s = http.server_create(PORT)
+    s = http.server_create(0)
     if s == 0 { println("FAIL: server_create"); exit(1) }
     http.server_set_host(s, "127.0.0.1")
     http.server_set_keepalive(s, 1, 0, 5000ms)
     http_server_post(s, "/upload", handle_upload, 0)
     http_server_post(s, "/v1body", handle_v1body, 0)
     http.server_get(s, "/ping", handle_ping, 0)
-
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(s, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(s)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())

--- a/tests/integration/http_stream_upload/test_http_stream_upload.sh
+++ b/tests/integration/http_stream_upload/test_http_stream_upload.sh
@@ -52,7 +52,7 @@ if ! "$AE" build "$SCRIPT_DIR/server.ae" -o "$TMPDIR/server" >"$TMPDIR/build.log
     exit 1
 fi
 
-AETHER_HOME="$ROOT" "$TMPDIR/server" 19250 "$TMPDIR" >"$TMPDIR/srv.log" 2>&1 &
+AETHER_HOME="$ROOT" "$TMPDIR/server" "$TMPDIR" >"$TMPDIR/srv.log" 2>&1 &
 SRV_PID=$!
 
 deadline=$(($(date +%s) + 15))
@@ -61,15 +61,16 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     kill -0 "$SRV_PID" 2>/dev/null || { echo "  [FAIL] server died:"; head -30 "$TMPDIR/srv.log"; exit 1; }
     sleep 0.1
 done
-wait_port 19250 || exit 1
+PORT=$(read_ready_port "$TMPDIR/srv.log") || exit 1
+wait_port "$PORT" || exit 1
 
 # Single curl invocation: PUT the big body, then GET /ping on the SAME
 # connection (curl reuses the keep-alive socket for sequential URLs).
 RESP=$(curl --silent --show-error --max-time 30 \
             --data-binary "@$PAYLOAD" \
             -H "Content-Type: application/octet-stream" \
-            -X POST "http://127.0.0.1:19250/upload" \
-            --next "http://127.0.0.1:19250/ping" \
+            -X POST "http://127.0.0.1:$PORT/upload" \
+            --next "http://127.0.0.1:$PORT/ping" \
             2>"$TMPDIR/curl.err") || {
     echo "  [FAIL] curl failed:"; cat "$TMPDIR/curl.err"; head -20 "$TMPDIR/srv.log"; exit 1
 }
@@ -117,8 +118,8 @@ fi
 RESP2=$(curl --silent --show-error --max-time 30 \
             --data-binary "@$PAYLOAD" \
             -H "Content-Type: application/octet-stream" \
-            -X POST "http://127.0.0.1:19250/v1body" \
-            --next "http://127.0.0.1:19250/ping" \
+            -X POST "http://127.0.0.1:$PORT/v1body" \
+            --next "http://127.0.0.1:$PORT/ping" \
             2>"$TMPDIR/curl2.err") || {
     echo "  [FAIL] v1body curl failed:"; cat "$TMPDIR/curl2.err"; head -20 "$TMPDIR/srv.log"; exit 1
 }
@@ -154,7 +155,7 @@ SMALL_LEN=$(wc -c < "$SMALL" | tr -d ' ')
 RESP3=$(curl --silent --show-error --max-time 10 \
             --data-binary "@$SMALL" \
             -H "Content-Type: application/octet-stream" \
-            -X POST "http://127.0.0.1:19250/v1body" \
+            -X POST "http://127.0.0.1:$PORT/v1body" \
             2>"$TMPDIR/curl3.err") || {
     echo "  [FAIL] small v1body curl failed:"; cat "$TMPDIR/curl3.err"; exit 1
 }

--- a/tests/integration/https_pure_tls_vertical/client.ae
+++ b/tests/integration/https_pure_tls_vertical/client.ae
@@ -20,7 +20,9 @@ extern exit(code: int)
 
 main() {
     host = "127.0.0.1" // exercises iPAddress-SAN matching
-    port = 18447
+    // The server binds port 0 and reports the kernel's choice on its READY
+    // line; the runner passes it here.
+    port, _perr = string.to_int(os_getenv("AE_TEST_PORT"))
 
     priv = bytes.new(32)
     i = 0

--- a/tests/integration/https_pure_tls_vertical/server.ae
+++ b/tests/integration/https_pure_tls_vertical/server.ae
@@ -14,8 +14,8 @@ extern exit(code: int)
 // Use raw form: actor receive handlers can't cleanly discard the
 // wrapper's string return without an unused-result warning.
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18447
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_root(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -43,7 +43,7 @@ main() {
         exit(1)
     }
 
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
 
     // Bind all interfaces: `localhost` resolves to ::1 on some boxes and
     // 127.0.0.1 on others, and the client must reach it either way.
@@ -60,7 +60,15 @@ main() {
         println("FAIL: server_set_tls: ${tls_err}")
         exit(1)
     }
-    println("READY")
+    // #1920: bind on port 0 so the kernel picks a free one, and report it.
+    // server_start reuses a socket the caller already bound, so this also
+    // means READY is printed AFTER the listen socket exists rather than
+    // before it, which is what the fixed sleep in the runner was covering.
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     http.server_get(raw, "/", handle_root, 0)
 

--- a/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
+++ b/tests/integration/https_pure_tls_vertical/test_https_pure_tls_vertical.sh
@@ -25,8 +25,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
-PORT=18447
 
 [ -x "$AE" ] || { echo "  [SKIP] https_pure_tls_vertical: ae not built"; exit 0; }
 command -v openssl >/dev/null 2>&1 || { echo "  [SKIP] https_pure_tls_vertical: no openssl to make a cert"; exit 0; }
@@ -78,9 +78,10 @@ grep -q READY "$TMP/srv.log" 2>/dev/null || {
     sed -n '1,10p' "$TMP/srv.log"
     fail "the TLS server never became READY"
 }
+PORT=$(read_ready_port "$TMP/srv.log") || exit 1
 
 # --- Permutation 1: Pure Client -> OpenSSL Server ---
-OUT=$(SSL_CERT_FILE="$TMP/cert.pem" "$TMP/cli" 2>&1) || {
+OUT=$(SSL_CERT_FILE="$TMP/cert.pem" AE_TEST_PORT="$PORT" "$TMP/cli" 2>&1) || {
     printf '%s\n' "$OUT" | grep -vE 'warning: unresolved|-->' | sed 's/^/    cli: /'
     sed -n '1,6p' "$TMP/srv.log" | sed 's/^/    srv: /'
     fail "Permutation 1 (Pure client -> OpenSSL server) failed"
@@ -115,9 +116,10 @@ grep -q READY "$TMP/srv_pure.log" 2>/dev/null || {
     sed -n '1,10p' "$TMP/srv_pure.log"
     fail "the pure-Aether TLS server never became READY"
 }
+PORT=$(read_ready_port "$TMP/srv_pure.log") || exit 1
 
 # --- Permutation 3: Pure Client -> Pure-Aether TLS Server ---
-OUT3=$(SSL_CERT_FILE="$TMP/cert.pem" "$TMP/cli" 2>&1) || {
+OUT3=$(SSL_CERT_FILE="$TMP/cert.pem" AE_TEST_PORT="$PORT" "$TMP/cli" 2>&1) || {
     printf '%s\n' "$OUT3" | grep -vE 'warning: unresolved|-->' | sed 's/^/    cli: /'
     cat "$TMP/srv_pure.log" | sed 's/^/    srv_pure: /'
     fail "Permutation 3 (Pure client -> Pure server) failed"

--- a/tests/lib/wait_port.sh
+++ b/tests/lib/wait_port.sh
@@ -32,3 +32,18 @@ wait_port() {
     echo "  [FAIL] nothing listening on $_wp_host:$_wp_port"
     return 1
 }
+
+# read_ready_port LOGFILE reads the port from a server's "READY <port>" line.
+#
+# Fixtures bind port 0 so the kernel picks a free port, which is what lets
+# these tests run in parallel and removes the port-squatting class entirely:
+# no two runs can collide on a number nobody chose. The server prints the
+# resolved port; this reads it back.
+read_ready_port() {
+    _rp_port=$(sed -n 's/^READY \([0-9][0-9]*\).*$/\1/p' "$1" 2>/dev/null | head -1)
+    if [ -z "$_rp_port" ]; then
+        echo "  [FAIL] no 'READY <port>' line in $1"
+        return 1
+    fi
+    echo "$_rp_port"
+}


### PR DESCRIPTION
## The root cause

Twenty-nine HTTP server fixtures each owned a **hardcoded port**. That is what
forces the shell sweep to run serially (`SH_NPROC=1`), and it is the root of the
port-squatting flake class: a server left behind by an earlier run starves the
next one of its port.

Two fixtures even shared **18107** (`http_server_ops` and
`http_head_and_middleware`). Only serial execution kept that from mattering.

## The change

Each fixture binds **port 0**, lets the kernel choose, and prints the resolved
port on its `READY` line for the runner to read back.

The stdlib already supported this end to end, which is what made the change
mechanical rather than speculative:

- `http_server_bind_raw` does a `getsockname()` when the port is 0,
- `std/http` documents the resolved-port readback, and
- `server_start` **skips the bind when the caller already bound** (the check at
  `aether_http_server.c:5310`).

That last point matters twice: it lets a fixture bind explicitly and still start
normally, and it moves `READY` to *after* the listen socket exists rather than
before it, which is what the fixed sleep in each runner was covering for.

## Demonstrated, not argued

Running one test twice concurrently:

| | run A | run B |
|---|---|---|
| before | PASS | **FAIL: nothing listening on 127.0.0.1:18272** |
| after | PASS | PASS |

And all 29 converted tests run **concurrently, 0 failures**.

## Awkward cases

- Three fixtures have a companion client with the port baked in. They take it
  from the environment, because `ae run script.ae <arg>` does **not** forward
  arguments to the program at all (`aether_args_count()` is 1). Worth knowing
  independently of this PR.
- `http_redirect_cross_host`'s server builds its own redirect targets, and
  those URLs are the thing under test, so it holds its resolved port in a
  module global and builds them from it.
- `http_stream_upload` took the port as `argv[1]`; it no longer takes one.

## What this deliberately does not do

**`SH_NPROC` stays at 1.** Nine server fixtures still hold fixed ports
(websocket clients, the script gateway, tinyweb TLS, tcp_poll). Flipping the
switch while any remain trades a slow suite for a flaky one, which is a bad
trade. Converting those nine and then flipping it is the follow-up, and it is
what actually collects the speed win #1920 is after.

## Verification

- `make test-ae`: **1083 passed, 0 failed**.
- All 29 converted tests pass serially and concurrently.
- `fmt_gate` caught that my edits were not canonically formatted; `ae fmt` on
  the 34 files I touched fixed it, and the tests still pass afterwards.
- Two other sweep failures during development turned out to be my own leftover
  servers squatting ports, which is the flake this PR removes.

Part of #1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
