### PR TITLE
test(http): ephemeral ports for the auth and websocket fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Three more server fixtures bind an ephemeral port** (part of #1920):
+  `http_auth`, which runs two servers from one binary, and the two websocket
+  fixtures, including the python peer `ws_client_conformance` dials. Their
+  clients take the port from the environment, since `ae run script.ae <arg>`
+  does not forward arguments to the program.
+
+### Notes
+
+- **Running the shell tests in parallel is blocked by the build cache, not by
+  ports.** Raising `SH_NPROC` from 1 was measured at 10 or more failures and
+  630s against 312s serial, so it is left at 1. `cache_build_flags`,
+  `cache_libdir_invalidation` and `cache_subdir_entry_root_module` assert cache
+  HIT and MISS against the one shared cache directory, so any other test
+  compiling at the same moment makes them non-deterministic: each passes alone
+  and fails in the parallel sweep. #1920 lists five strategies and all of them
+  treat ports as the throttle. Per-test cache isolation is the prerequisite,
+  and the Makefile now records that measurement where the next person will
+  look.
+
+
 ## [0.647.0]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1220,6 +1220,15 @@ test-windows-wine: ae stdlib
 	@bash tests/scripts/windows_wine_sweep.sh
 
 # Test .ae source files - compiles and runs each test file
+#
+# The shell tests run SERIALLY (SH_NPROC defaults to 1 below). Hardcoded ports
+# used to be the reason, and the HTTP server fixtures now bind port 0 (#1920),
+# but ports are not the only shared resource: cache_build_flags,
+# cache_libdir_invalidation and cache_subdir_entry_root_module assert cache
+# HIT/MISS against the one shared build cache, so any other test compiling at
+# the same moment makes them non-deterministic. Raising SH_NPROC was measured
+# at 10+ failures and 630s against 312s serial. Per-test cache isolation is
+# the prerequisite, not more port work.
 ifdef WINDOWS_NATIVE
 test-ae: compiler ae stdlib
 	@echo ===================================

--- a/tests/integration/http_auth/server.ae
+++ b/tests/integration/http_auth/server.ae
@@ -6,8 +6,8 @@
 // middlewares on the same server would gate every route on BOTH
 // credentials at once, which isn't what either contract claims.
 //
-//   bearer  -> :18273  /api/whoami
-//   session -> :18274  /app/me
+//   bearer  -> an ephemeral port, /api/whoami
+//   session -> an ephemeral port, /app/me
 //
 // Verifier callbacks live in shim.c so they receive the raw
 // `const char*` the C middleware passes, without needing
@@ -24,6 +24,8 @@ extern http_server_start_raw(server: ptr) -> int
 
 extern aether_test_bearer_verify(token: ptr, ud: ptr) -> int
 extern aether_test_session_verify(cookie_value: ptr, ud: ptr) -> int
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 handle_whoami(req: ptr, res: ptr, ud: ptr) {
     http.response_set_status(res, 200)
@@ -66,7 +68,7 @@ main() {
     mode = aether_args_get(1)
 
     if mode == "bearer" {
-        raw = http.server_create(18273)
+        raw = http.server_create(0)
         http.server_set_host(raw, "127.0.0.1")
         if raw == 0 {
             println("FAIL: server_create returned null")
@@ -79,13 +81,17 @@ main() {
             exit(1)
         }
         http.server_get(raw, "/api/whoami", handle_whoami, 0)
-        println("READY")
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
         run_server(raw)
         return
     }
 
     if mode == "session" {
-        raw = http.server_create(18274)
+        raw = http.server_create(0)
         http.server_set_host(raw, "127.0.0.1")
         if raw == 0 {
             println("FAIL: server_create returned null")
@@ -98,7 +104,11 @@ main() {
             exit(1)
         }
         http.server_get(raw, "/app/me", handle_me, 0)
-        println("READY")
+        if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+            println("FAIL: bind")
+            exit(1)
+        }
+        println("READY ${http_server_port(raw)}")
         run_server(raw)
         return
     }

--- a/tests/integration/http_auth/test_http_auth.sh
+++ b/tests/integration/http_auth/test_http_auth.sh
@@ -89,11 +89,13 @@ wait_ready() {
 }
 wait_ready "$SRV_BEARER_PID"  "$TMPDIR/bearer.log"  bearer
 wait_ready "$SRV_SESSION_PID" "$TMPDIR/session.log" session
-wait_port 18273 || exit 1
-wait_port 18274 || exit 1
+PORT_BEARER=$(read_ready_port "$TMPDIR/bearer.log")  || exit 1
+PORT_SESSION=$(read_ready_port "$TMPDIR/session.log") || exit 1
+wait_port "$PORT_BEARER"  || exit 1
+wait_port "$PORT_SESSION" || exit 1
 
-URL_BEARER="http://127.0.0.1:18273/api/whoami"
-URL_SESSION="http://127.0.0.1:18274/app/me"
+URL_BEARER="http://127.0.0.1:$PORT_BEARER/api/whoami"
+URL_SESSION="http://127.0.0.1:$PORT_SESSION/app/me"
 
 # Helper — fetch HTTP status + WWW-Authenticate header.
 status_and_auth() {

--- a/tests/integration/ws_client_conformance/peer.py
+++ b/tests/integration/ws_client_conformance/peer.py
@@ -13,9 +13,11 @@ async def echo(ws, path=None):
         pass
 
 async def main():
-    port = int(sys.argv[1])
-    async with websockets.serve(echo, "127.0.0.1", port):
-        print("READY", flush=True)
+    # Bind port 0 and report the kernel's choice, so parallel runs cannot
+    # collide on a number nobody chose.
+    async with websockets.serve(echo, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        print("READY", port, flush=True)
         await asyncio.Future()
 
 asyncio.run(main())

--- a/tests/integration/ws_client_conformance/test_ws_client_conformance.sh
+++ b/tests/integration/ws_client_conformance/test_ws_client_conformance.sh
@@ -16,8 +16,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
-PORT=18146
 
 [ -x "$AE" ] || { echo "  [SKIP] ws_client_conformance: ae not built"; exit 0; }
 
@@ -75,7 +75,7 @@ fi
 "$AE" build "$SCRIPT_DIR/ws_conformance.ae" -o "$TMP/wscli" >"$TMP/b.log" 2>&1 \
     || { sed -n '1,10p' "$TMP/b.log"; fail "client did not build"; }
 
-python3 "$SCRIPT_DIR/peer.py" "$PORT" > "$TMP/srv.log" 2>&1 &
+python3 "$SCRIPT_DIR/peer.py" > "$TMP/srv.log" 2>&1 &
 SRV_PID=$!
 
 i=0
@@ -88,8 +88,9 @@ grep -q READY "$TMP/srv.log" 2>/dev/null || {
     sed -n '1,10p' "$TMP/srv.log"
     fail "python websockets peer never became READY"
 }
+PORT=$(read_ready_port "$TMP/srv.log") || exit 1
 
-OUT=$($TIMEOUT "$TMP/wscli" 2>&1) || {
+OUT=$(AE_TEST_PORT="$PORT" $TIMEOUT "$TMP/wscli" 2>&1) || {
     echo "$OUT" | sed 's/^/         /'
     sed -n '1,10p' "$TMP/srv.log" | sed 's/^/    srv: /'
     fail "client exited non-zero"

--- a/tests/integration/ws_client_conformance/ws_conformance.ae
+++ b/tests/integration/ws_client_conformance/ws_conformance.ae
@@ -6,11 +6,14 @@
 
 import std.http
 import std.string
+import std.os
 
 extern exit(code: int)
 
 main() {
-    port = 18146
+    // The peer binds port 0 and reports the kernel's choice; the runner
+    // passes it here.
+    port, _perr = string.to_int(os_getenv("AE_TEST_PORT"))
     w = http.ws_connect("ws://127.0.0.1:${port}/")
     if w == null {
         println("FAIL: ws_connect returned null")

--- a/tests/integration/ws_client_loopback/test_ws_client_loopback.sh
+++ b/tests/integration/ws_client_loopback/test_ws_client_loopback.sh
@@ -16,6 +16,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+. "$ROOT/tests/lib/wait_port.sh"
 AE="$ROOT/build/ae"
 
 [ -x "$AE" ] || { echo "  [SKIP] ws_client_loopback: ae not built"; exit 0; }
@@ -66,8 +67,9 @@ grep -q READY "$TMP/srv.log" 2>/dev/null || {
     sed -n '1,10p' "$TMP/srv.log"
     fail "ws echo server never became READY"
 }
+PORT=$(read_ready_port "$TMP/srv.log") || exit 1
 
-OUT=$($TIMEOUT "$TMP/wscli" 2>&1) || {
+OUT=$(AE_TEST_PORT="$PORT" $TIMEOUT "$TMP/wscli" 2>&1) || {
     echo "$OUT" | sed 's/^/         /'
     fail "client exited non-zero"
 }

--- a/tests/integration/ws_client_loopback/wsclient.ae
+++ b/tests/integration/ws_client_loopback/wsclient.ae
@@ -1,11 +1,12 @@
 // The client half: dial the echo peer, round-trip a message, close.
 import std.http
+import std.os
 import std.string
 
 extern exit(code: int)
 
 main() {
-    w = http.ws_connect("ws://127.0.0.1:18142/echo")
+    w = http.ws_connect("ws://127.0.0.1:${os_getenv("AE_TEST_PORT")}/echo")
     if w == null {
         println("FAIL: ws_connect returned null")
         exit(1)

--- a/tests/integration/ws_client_loopback/wsserver.ae
+++ b/tests/integration/ws_client_loopback/wsserver.ae
@@ -9,8 +9,8 @@ import std.http
 
 extern exit(code: int)
 extern http_server_start_raw(server: ptr) -> int
-
-const PORT = 18142
+extern http_server_bind_raw(server: ptr, host: string, port: int) -> int
+extern http_server_port(server: ptr) -> int
 
 @c_callback echo_handler(req: ptr, ws: ptr, ud: ptr) {
     n = 0
@@ -39,12 +39,16 @@ actor SchedHelper {
 }
 
 main() {
-    raw = http.server_create(PORT)
+    raw = http.server_create(0)
     http.server_set_host(raw, "127.0.0.1")
     if raw == 0 { println("FAIL: server_create"); exit(1) }
 
     http.server_websocket(raw, "/echo", echo_handler, null)
-    println("READY")
+    if http_server_bind_raw(raw, "127.0.0.1", 0) < 0 {
+        println("FAIL: bind")
+        exit(1)
+    }
+    println("READY ${http_server_port(raw)}")
 
     spawn(SchedHelper())
     a = spawn(SrvActor())


### PR DESCRIPTION
## What

Three more server fixtures bind port 0 and report the kernel's choice:

- **`http_auth`**, which starts two servers from one binary, so it reads two
  ports from two logs.
- **`ws_client_loopback`** and **`ws_client_conformance`**, including the python
  peer the latter dials, which now binds 0 and prints the port its socket
  actually got.

Their clients take the port from the environment, since `ae run script.ae <arg>`
does not forward arguments to the program at all.

## The finding: parallelism is blocked by the cache, not by ports

I tried raising `SH_NPROC` from 1, which is what #1920 is ultimately after, and
measured it:

| | failures | wall |
|---|---|---|
| serial | 0 | 312s |
| `SH_NPROC=8` | **10+** | **630s** |

Parallel was both broken *and slower*. The failures cluster on
`cache_build_flags`, `cache_libdir_invalidation` and
`cache_subdir_entry_root_module`. Each **passes alone and fails in the parallel
sweep**, because each asserts cache HIT/MISS against the one shared build cache
directory, and any other test compiling at that moment changes what they
observe.

This is worth recording because **all five strategies in #1920 treat ports as
the throttle**. They are not the binding constraint. Per-test cache isolation
is the prerequisite for parallelism, and it is a different piece of work from
anything the issue lists.

So `SH_NPROC` stays at 1, and the measurement now sits in the Makefile beside
the default, where the next person to try this will look first.

## Verification

- `make test-ae`: **1083 passed, 0 failed** (serial).
- The websocket tests were run with `websockets` installed in a venv, so they
  actually executed rather than skipping. That matters: skipping is exactly how
  the quoted-heredoc bug in #1936 reached CI.
- `make -n test-ae` parses. An earlier attempt at the Makefile comment put it
  *inside* the `\`-continued recipe, which split it so `sh_nproc` was set in a
  different shell than the code using it; the comment now sits above the target.

Part of #1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
