### PR TITLE
ci(windows): build and run the contrib series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,10 @@ jobs:
         # ca-certificates ships /mingw64/etc/ssl/certs/ca-bundle.crt — required
         # for HTTPS in std.net (without it the OpenSSL handshake completes but
         # cert verification fails for lack of a trust anchor on Windows).
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib mingw-w64-x86_64-openssl mingw-w64-x86_64-ca-certificates pkg-config make bc
+        # sqlite3 and the Vulkan headers are what the contrib series needs to
+        # build here; without them contrib-check skips those entries and the
+        # coverage this leg exists for is silently absent.
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib mingw-w64-x86_64-openssl mingw-w64-x86_64-ca-certificates mingw-w64-x86_64-sqlite3 mingw-w64-x86_64-vulkan-headers mingw-w64-x86_64-vulkan-loader pkg-config make bc
 
     # Windows Defender real-time scanning of every compiler-produced
     # file is the dominant Windows-CI tax: `make ci` builds ~585 separate
@@ -616,6 +619,34 @@ jobs:
         echo "SSL_CERT_FILE=$SSL_CERT_FILE"
         ls -la "$(cygpath -u "$SSL_CERT_FILE")"
         make ci
+
+    # contrib on Windows. Every contrib module is built and run on the Linux
+    # legs and none of them were built here, which is how contrib/vulkan came to
+    # ship a `_WIN32` branch that had never been compiled anywhere: it opens the
+    # loader with LoadLibraryA where every other platform uses dlopen. The
+    # compiler this job already built is what type-checks and runs them, so this
+    # is a few minutes on top rather than another runner. (#1511)
+    - name: Type-check every contrib module
+      run: make check-contrib-modules
+
+    - name: Build and run the contrib series
+      # contrib_check.sh probes for each entry's libraries with pkg-config and
+      # skips the entries whose dependency is absent, so this reports what this
+      # runner can build rather than failing on what it cannot.
+      #
+      # The Linux leg installs lavapipe, Mesa's CPU driver, so the Vulkan
+      # entries run on a runner with no GPU. Windows has no equivalent in MSYS2
+      # (SwiftShader is not packaged) and these runners have no Vulkan device,
+      # so the loader branch is COMPILED here and not executed. That is said out
+      # loud below rather than left to be discovered later; if a CPU driver
+      # becomes available, install it above and this becomes real coverage with
+      # no other change.
+      run: |
+        make contrib-check 2>&1 | tee contrib-windows.log
+        echo ""
+        echo "contrib/vulkan on this runner:"
+        grep -E '^\s+(PASS|SKIP|FAIL)\s+vulkan/' contrib-windows.log || \
+          echo "  no vulkan entries reported"
 
   # ============================================================
   # Platform portability — cooperative scheduler, WASM, embedded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **The Windows leg builds and runs the contrib series.** `contrib-check` ran on
+  Linux only, so no CI leg built any contrib module on Windows: `contrib/vulkan`
+  shipped a `_WIN32` branch opening the loader with `LoadLibraryA`, where every
+  other platform uses `dlopen`, that had never been compiled anywhere. The
+  existing Windows job now type-checks every contrib module and runs the contrib
+  series, which costs minutes on a compiler it already built rather than another
+  runner. The Vulkan entries compile there and do not execute, because the
+  runners have no Vulkan device and MSYS2 packages no CPU driver; the leg says
+  which entries ran and which skipped rather than leaving that to be found
+  later. (#1511)
+
 ## [0.648.0]
 
 ### Fixed

--- a/tests/integration/contrib_vulkan_portability/test_contrib_vulkan_portability.sh
+++ b/tests/integration/contrib_vulkan_portability/test_contrib_vulkan_portability.sh
@@ -70,14 +70,29 @@ if ! $CC_WIN -std=c99 -O2 -Wall -Wextra -Werror $INC -Icontrib/vulkan \
     exit 1
 fi
 
+# Whichever nm can read the object that was just built. A cross toolchain ships
+# a prefixed one; on a MinGW host the compiler is x86_64-w64-mingw32-gcc but the
+# binutils are unprefixed, and reaching for the prefixed name there failed with
+# "command not found" -- which the pipeline turned into "the _WIN32 arm was
+# compiled out", a wrong answer to a question that was never asked.
+NM_WIN=""
+for cand in "${CC_WIN%gcc}nm" nm llvm-nm; do
+    command -v "$cand" >/dev/null 2>&1 || continue
+    if "$cand" -u "$TMP/win.o" >/dev/null 2>&1; then NM_WIN="$cand"; break; fi
+done
+if [ -z "$NM_WIN" ]; then
+    echo "  [SKIP] contrib_vulkan_portability: no nm reads the cross-built object"
+    exit 0
+fi
+
 # It must reach the Win32 loader API, not dlopen: a #ifdef that silently took
 # the POSIX arm would compile and then fail to find a loader on Windows.
-if ! x86_64-w64-mingw32-nm -u "$TMP/win.o" | grep -q 'LoadLibraryA'; then
+if ! "$NM_WIN" -u "$TMP/win.o" | grep -q 'LoadLibraryA'; then
     echo "  [FAIL] contrib_vulkan_portability: the object does not reference LoadLibraryA"
     echo "        the _WIN32 arm was compiled out"
     exit 1
 fi
-if x86_64-w64-mingw32-nm -u "$TMP/win.o" | grep -q '\bdlopen\b'; then
+if "$NM_WIN" -u "$TMP/win.o" | grep -q '\bdlopen\b'; then
     echo "  [FAIL] contrib_vulkan_portability: the Windows object references dlopen"
     exit 1
 fi


### PR DESCRIPTION
`contrib-check` ran on the Linux legs only, so no CI leg built any contrib module on Windows. That is how `contrib/vulkan` came to ship a `_WIN32` branch that had never been compiled anywhere: it opens the loader with `LoadLibraryA` where every other platform uses `dlopen`.

## What this does

The Windows job already builds the compiler, so the contrib work costs a few minutes there rather than another runner:

- **Type-checks every contrib module** (`make check-contrib-modules`).
- **Builds and runs the contrib series** (`make contrib-check`), which probes each entry's libraries with pkg-config and skips the ones whose dependency is absent, so the leg reports what the runner can build rather than failing on what it cannot.
- `mingw-w64-x86_64-sqlite3`, `-vulkan-headers` and `-vulkan-loader` join the MSYS2 install list. Without them those entries skip and the coverage this exists for would be silently absent.

## contrib/vulkan specifically

The acceptance criterion allows either running the loader path on Windows or recording why not. It is the second: the runners have no Vulkan device and MSYS2 packages no CPU driver, where the Linux leg installs lavapipe. So the `_WIN32` branch is **compiled** there and not executed, and the leg prints which entries ran and which skipped rather than leaving that to be discovered later. If a CPU driver becomes available for these runners, installing it above turns this into real coverage with no other change.

Verified locally on macOS: `make check-contrib-modules` reports 9 ok, 0 failed, and `make contrib-check` passes every entry, including the vulkan ones via MoltenVK, which is what the new grep reads.

Closes #1511