### PR TITLE
fix(cryptography): stream digests without OpenSSL, and stop every *_hex call leaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,6 +665,48 @@ jobs:
     - name: Run cooperative scheduler CI
       run: make ci-coop
 
+  ci-no-openssl:
+    name: Source build without OpenSSL
+    runs-on: ubuntu-22.04
+
+    # std.cryptography falls back to pure-Aether implementations when the
+    # toolchain is built without libcrypto -- the default for a Windows source
+    # build, and the configuration that leaves sha256(), std.cas and every
+    # caller that hashes either working or permanently broken. Every other leg
+    # in this matrix installs OpenSSL, so nothing exercised that fallback: it
+    # could rot to a stub and stay green everywhere. OPENSSL=0 forces the
+    # detection off regardless of what is installed on the runner.
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+
+    - name: Build without OpenSSL
+      run: make -j"$(nproc)" OPENSSL=0
+
+    - name: Confirm the build really has no libcrypto
+      run: |
+        if nm -u build/libaether.a 2>/dev/null | grep -q EVP_DigestInit; then
+          echo "OPENSSL=0 still linked libcrypto - this leg would prove nothing"
+          exit 1
+        fi
+        echo "confirmed: no OpenSSL symbols"
+
+    - name: Unit tests
+      run: make test
+
+    # The suites that must work on the pure path. They assert digests against
+    # published vectors and no longer accept a skip, so a fallback that stops
+    # answering fails here rather than reporting "skipped".
+    - name: Digest suites on the pure backend
+      run: |
+        set -e
+        for t in cryptography_digest_stream cryptography_sha cryptography_v2 \
+                 cryptography_random_hex; do
+          sh "tests/integration/$t/test_$t.sh"
+        done
+
   ci-wasm:
     name: WebAssembly (Emscripten)
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Every `*_hex` call in `std.cryptography` leaked its result.** The C side
+  returns a `malloc`'d hex buffer the caller owns, but the extern was declared
+  without `@heap`, so the compiler classified the result as borrowed, copied it
+  into a fresh owned string at the boundary, and never freed the original. One
+  80-byte buffer per call, on the hot path of anything that hashes: `sha1_hex`,
+  `sha256_hex`, `hash_hex`, `md4_hex`, `md5_hex`, `hmac_sha256_hex` and
+  `digest_final_hex`. Measured under `leaks(1)`: a 50-round loop over four of
+  them leaked 200 allocations before, 0 after. The seven externs now carry the
+  `@heap` annotation that exists for exactly this, which is also why the fix is
+  a declaration change rather than a new copy-and-release dance in each wrapper.
+  Found while adding the streaming fallback below; it predates that work and
+  was not caused by it.
+
 ### Added
 
 - **The streaming digest API works without OpenSSL.** `digest_new` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ version number before tagging the release.
 
 ## [current]
 
+### Added
+
+- **The streaming digest API works without OpenSSL.** `digest_new` /
+  `digest_update` / `digest_final_*` were libcrypto-only, so on a build without
+  it -- the default for a Windows source build -- they returned "openssl
+  unavailable" while the one-shot digests had already grown a pure-Aether
+  fallback. The gap mattered most to the caller who cannot work around it: you
+  reach for a streaming context precisely when the object is too big to hold
+  whole, so "use the one-shot form instead" is not advice that applies.
+
+  A digest handle now carries its backend, and update / final dispatch on it.
+  The pure path reuses the streaming contexts already in
+  `std.cryptography.{sha1,sha2,md5,md4}` rather than adding a second
+  implementation of anything, and covers the same algorithm set as the one-shot
+  fallback: an algorithm you can one-shot without OpenSSL is one you can stream
+  without OpenSSL.
+
+  The regression test no longer accepts a skip. It used to pass by not running
+  when there was no backend, which would have been a green tick for a fallback
+  nobody exercised. A new `ci-no-openssl` job builds with `OPENSSL=0` and runs
+  the digest suites against the pure path, because every other leg in the
+  matrix installs OpenSSL and none of them covered it.
+
 ## [0.651.0]
 
 ### Fixed

--- a/std/cryptography/module.ae
+++ b/std/cryptography/module.ae
@@ -62,9 +62,9 @@ exports(
     digest_free
 )
 
-extern cryptography_sha1_hex_raw(data: string, length: int) -> string
-extern cryptography_sha256_hex_raw(data: string, length: int) -> string
-extern cryptography_hash_hex_raw(algo: string, data: string, length: int) -> string
+extern cryptography_sha1_hex_raw(data: string, length: int) -> string @heap
+extern cryptography_sha256_hex_raw(data: string, length: int) -> string @heap
+extern cryptography_hash_hex_raw(algo: string, data: string, length: int) -> string @heap
 // Bound under a _raw name like its siblings. The module function below is
 // called `hash_supported`, which mangles to `cryptography_hash_supported` --
 // exactly this C symbol. The two collided, and the extern won, so every
@@ -72,10 +72,10 @@ extern cryptography_hash_hex_raw(algo: string, data: string, length: int) -> str
 // the source read as though it worked. Invisible until the body did more than
 // forward to the extern, which is why it survived this long.
 extern cryptography_hash_supported_raw(algo: string) -> int
-extern cryptography_md4_hex_raw(data: string, length: int) -> string
-extern cryptography_md5_hex_raw(data: string, length: int) -> string
+extern cryptography_md4_hex_raw(data: string, length: int) -> string @heap
+extern cryptography_md5_hex_raw(data: string, length: int) -> string @heap
 extern cryptography_hmac_sha256_hex_raw(key: string, key_len: int,
-    msg: string, msg_len: int) -> string
+    msg: string, msg_len: int) -> string @heap
 extern cryptography_hmac_sha256_bytes_raw(key: string, key_len: int,
     msg: string, msg_len: int) -> int
 extern cryptography_md4_bytes_raw(data: string, length: int) -> int
@@ -93,7 +93,7 @@ extern cryptography_release_random_bytes()
 
 extern cryptography_digest_new_raw(algo: string) -> ptr
 extern cryptography_digest_update_raw(handle: ptr, data: string, length: int) -> int
-extern cryptography_digest_final_hex_raw(handle: ptr) -> string
+extern cryptography_digest_final_hex_raw(handle: ptr) -> string @heap
 extern cryptography_digest_final_bytes_raw(handle: ptr) -> int
 extern cryptography_digest_free_raw(handle: ptr)
 extern malloc(size: int) -> ptr

--- a/std/cryptography/module.ae
+++ b/std/cryptography/module.ae
@@ -16,10 +16,13 @@
 // to the pure-Aether implementations under std.cryptography.*, so they keep
 // working and hash_supported() answers for them either way.
 //
+// The STREAMING context API (digest_new / digest_update / digest_final_*)
+// falls back the same way, over the same algorithm set, so hashing a large
+// object in windows keeps working without OpenSSL too.
+//
 // Still OpenSSL-only, and still returning a non-empty error rather than
-// crashing: the STREAMING context API (digest_new / digest_update /
-// digest_final_*) and any algorithm without a pure implementation. Callers
-// should check the error slot.
+// crashing: any algorithm without a pure implementation. Callers should check
+// the error slot.
 
 import std.string
 import std.bytes
@@ -93,6 +96,8 @@ extern cryptography_digest_update_raw(handle: ptr, data: string, length: int) ->
 extern cryptography_digest_final_hex_raw(handle: ptr) -> string
 extern cryptography_digest_final_bytes_raw(handle: ptr) -> int
 extern cryptography_digest_free_raw(handle: ptr)
+extern malloc(size: int) -> ptr
+extern free(p: ptr)
 
 extern string_new_with_length(data: string, length: int) -> ptr
 
@@ -525,6 +530,90 @@ random_base64(n: int) -> {
 // no explicit free; call digest_free only when bailing out before
 // finalizing (e.g. an aborted upload).
 
+// A digest handle carries its backend, because there are two and the caller
+// must not have to care which one answered. `inner` is an OpenSSL EVP context
+// or a pure-Aether streaming context; `kind` says whose it is so update and
+// final can dispatch. Wrapping BOTH backends keeps the handle opaque exactly
+// as documented, rather than making the pure path a special case a caller
+// could stumble into.
+struct DigestCtx {
+    kind: int
+    inner: ptr
+    dlen: int
+}
+
+// Backend tags. 0 is OpenSSL; the rest name the pure module that owns `inner`.
+// Kept as ints rather than strings so dispatch is a compare, not a strcmp, on
+// a path that runs once per chunk.
+
+// Open a pure streaming context for `algo`. Returns (kind, ctx, "") on
+// success and (0, null, err) when no pure implementation covers `algo`.
+// The set matches pure_hash_hex deliberately: an algorithm you can one-shot
+// without OpenSSL is one you can stream without OpenSSL.
+pure_digest_new(algo: string) -> {
+    if algo == "sha1" {
+        c, e = sha1.new()
+        if e != "" { return 0, null, 0, e }
+        return 1, c, 20, ""
+    }
+    if algo == "sha256" {
+        c, e = sha2.new(algo)
+        if e != "" { return 0, null, 0, e }
+        return 2, c, 32, ""
+    }
+    if algo == "sha224" {
+        c, e = sha2.new(algo)
+        if e != "" { return 0, null, 0, e }
+        return 2, c, 28, ""
+    }
+    if algo == "sha384" {
+        c, e = sha2.new(algo)
+        if e != "" { return 0, null, 0, e }
+        return 2, c, 48, ""
+    }
+    if algo == "sha512" {
+        c, e = sha2.new(algo)
+        if e != "" { return 0, null, 0, e }
+        return 2, c, 64, ""
+    }
+    if algo == "md5" {
+        c, e = md5.new()
+        if e != "" { return 0, null, 0, e }
+        return 3, c, 16, ""
+    }
+    if algo == "md4" {
+        c, e = md4.new()
+        if e != "" { return 0, null, 0, e }
+        return 4, c, 16, ""
+    }
+    return 0, null, 0, "unknown algorithm"
+}
+
+// Wrap a backend handle so update / final can dispatch on it.
+digest_wrap(kind: int, inner: ptr, dlen: int) -> ptr {
+    w = malloc(sizeof(DigestCtx)) as *DigestCtx
+    if w == null {
+        return null
+    }
+    w.kind = kind
+    w.inner = inner
+    w.dlen = dlen
+    return w as ptr
+}
+
+// Release a pure context that will never be finalized (the bail-out path).
+// The pure final_* calls free their own context, so this is only for
+// abandonment, exactly like digest_free is for the OpenSSL handle.
+pure_digest_free(kind: int, inner: ptr) {
+    if inner == null {
+        return
+    }
+    if kind == 1 { sha1.free_ctx(inner) }
+    if kind == 2 { sha2.free_ctx(inner) }
+    if kind == 3 { md5.free_ctx(inner) }
+    if kind == 4 { md4.free_ctx(inner) }
+}
+
 // Create a streaming digest context for `algo` ("md5", "sha256",
 // "sha1", "md4", or any name OpenSSL's by-name lookup recognizes —
 // same rules as hash_hex). Returns (ctx, "") on success, (null, error)
@@ -532,13 +621,28 @@ random_base64(n: int) -> {
 // opaque; thread it through digest_update / digest_final_*.
 digest_new(algo: string) -> {
     ctx = cryptography_digest_new_raw(algo)
-    if ctx == null {
-        if cryptography_hash_supported_raw(algo) == 0 {
-            return null, "unknown algorithm"
+    if ctx != null {
+        w = digest_wrap(0, ctx, 0)
+        if w == null {
+            cryptography_digest_free_raw(ctx)
+            return null, "allocation failed"
         }
-        return null, "openssl unavailable"
+        return w, ""
     }
-    return ctx, ""
+    // No OpenSSL in this build, or OpenSSL does not carry this algorithm:
+    // stream it in Aether instead of failing. The one-shot digests already
+    // fall back this way; a caller hashing a 4GB upload in windows is exactly
+    // the one who cannot switch to the one-shot form as a workaround.
+    kind, inner, dlen, perr = pure_digest_new(algo)
+    if perr != "" {
+        return null, perr
+    }
+    w = digest_wrap(kind, inner, dlen)
+    if w == null {
+        pure_digest_free(kind, inner)
+        return null, "allocation failed"
+    }
+    return w, ""
 }
 
 // Feed `length` bytes of `data` into the context. Binary-safe (`data`
@@ -546,10 +650,21 @@ digest_new(algo: string) -> {
 // NULs survive). Returns (1, "") on success, (0, error) on failure.
 // Feeding 0 bytes is a no-op success. Does NOT free the context.
 digest_update(ctx: ptr, data: string, length: int) -> {
-    ok = cryptography_digest_update_raw(ctx, data, length)
-    if ok == 0 {
+    if ctx == null {
         return 0, "digest update failed"
     }
+    w = ctx as *DigestCtx
+    if w.kind == 0 {
+        ok = cryptography_digest_update_raw(w.inner, data, length)
+        if ok == 0 {
+            return 0, "digest update failed"
+        }
+        return 1, ""
+    }
+    if w.kind == 1 { sha1.update(w.inner, data, length) }
+    if w.kind == 2 { sha2.update(w.inner, data, length) }
+    if w.kind == 3 { md5.update(w.inner, data, length) }
+    if w.kind == 4 { md4.update(w.inner, data, length) }
     return 1, ""
 }
 
@@ -558,8 +673,30 @@ digest_update(ctx: ptr, data: string, length: int) -> {
 // call — do not reuse or free it again. Returns (hex, "") on success,
 // ("", error) on failure.
 digest_final_hex(ctx: ptr) -> {
-    out = cryptography_digest_final_hex_raw(ctx)
-    if out == 0 {
+    if ctx == null {
+        return "", "digest finalize failed"
+    }
+    w = ctx as *DigestCtx
+    kind = w.kind
+    inner = w.inner
+    if kind == 0 {
+        out = cryptography_digest_final_hex_raw(inner)
+        free(ctx)
+        if out == 0 {
+            return "", "digest finalize failed"
+        }
+        return out, ""
+    }
+    // The pure final_hex frees the inner context, matching the OpenSSL
+    // contract that a successful final_* consumes the handle; the wrapper is
+    // this layer's to release.
+    out = ""
+    if kind == 1 { out = sha1.final_hex(inner) }
+    if kind == 2 { out = sha2.final_hex(inner) }
+    if kind == 3 { out = md5.final_hex(inner) }
+    if kind == 4 { out = md4.final_hex(inner) }
+    free(ctx)
+    if string.length(out) == 0 {
         return "", "digest finalize failed"
     }
     return out, ""
@@ -571,15 +708,38 @@ digest_final_hex(ctx: ptr) -> {
 // subsequent step (SigV4 payload hashing). Returns (bytes, length, "")
 // on success, ("", 0, error) on failure.
 digest_final_bytes(ctx: ptr) -> {
-    ok = cryptography_digest_final_bytes_raw(ctx)
-    if ok == 0 {
+    if ctx == null {
         return "", 0, "digest finalize failed"
     }
-    raw = cryptography_get_binary_digest()
-    n = cryptography_get_binary_digest_length()
-    owned = string_new_with_length(raw, n)
-    cryptography_release_binary_digest()
-    return owned, n, ""
+    w = ctx as *DigestCtx
+    kind = w.kind
+    inner = w.inner
+    dlen = w.dlen
+    if kind == 0 {
+        ok = cryptography_digest_final_bytes_raw(inner)
+        free(ctx)
+        if ok == 0 {
+            return "", 0, "digest finalize failed"
+        }
+        raw = cryptography_get_binary_digest()
+        n = cryptography_get_binary_digest_length()
+        owned = string_new_with_length(raw, n)
+        cryptography_release_binary_digest()
+        return owned, n, ""
+    }
+    // The pure final_bytes hands back a std.bytes buffer of dlen bytes and
+    // frees the inner context; bytes.finish turns it into the owned string
+    // this API returns.
+    buf = null
+    if kind == 1 { buf = sha1.final_bytes(inner) }
+    if kind == 2 { buf = sha2.final_bytes(inner) }
+    if kind == 3 { buf = md5.final_bytes(inner) }
+    if kind == 4 { buf = md4.final_bytes(inner) }
+    free(ctx)
+    if buf == null {
+        return "", 0, "digest finalize failed"
+    }
+    return bytes.finish(buf, dlen), dlen, ""
 }
 
 // Abandon a context without finalizing — the cleanup path for an
@@ -587,5 +747,14 @@ digest_final_bytes(ctx: ptr) -> {
 // successful digest_final_* the context is already freed, so this is
 // only for the bail-out-before-final case.
 digest_free(ctx: ptr) {
-    cryptography_digest_free_raw(ctx)
+    if ctx == null {
+        return
+    }
+    w = ctx as *DigestCtx
+    if w.kind == 0 {
+        cryptography_digest_free_raw(w.inner)
+    } else {
+        pure_digest_free(w.kind, w.inner)
+    }
+    free(ctx)
 }

--- a/tests/integration/cryptography_digest_stream/probe.ae
+++ b/tests/integration/cryptography_digest_stream/probe.ae
@@ -20,22 +20,14 @@ extern exit(code: int)
 main() {
     print("=== std.cryptography streaming digest context ===\n\n")
 
-    // Skip probe. This asks the STREAMING api whether it works, rather than
-    // asking sha256_hex — which it used to, as a proxy for "is OpenSSL here".
-    // That proxy broke the moment sha256_hex grew a pure-Aether fallback: the
-    // one-shot hash started succeeding without OpenSSL while digest_new(),
-    // which is still libcrypto-only, did not, so the skip stopped firing and
-    // the test failed at the first context it opened.
-    //
-    // Probe the capability under test, not a neighbour that happens to share
-    // a backend today.
-    probe_ctx, probe_err = cryptography.digest_new("sha256")
-    if probe_err != "" {
-        println("SKIP cryptography_digest_stream: ${probe_err} (streaming digests need OpenSSL)")
-        print("\n=== streaming digest tests skipped (no backend) ===\n")
-        return
-    }
-    cryptography.digest_free(probe_ctx)
+    // No skip. There used to be one, because the streaming API was
+    // OpenSSL-only and a build without it could not answer at all. It now
+    // falls back to the pure-Aether streaming contexts over the same
+    // algorithm set as the one-shot digests, so there is no build left where
+    // digest_new("sha256") legitimately fails -- and a skip that can no
+    // longer fire is a test that stops running the day the fallback breaks.
+    // Every case below is expected to pass on every platform, with or
+    // without libcrypto.
 
     // ---- Test 1: md5("abc") in two chunks == one-shot == vector ----
     print("Test 1: md5 streamed in two chunks\n")
@@ -107,6 +99,22 @@ main() {
         println("  FAIL: md5 raw length = ${n3}, want 16")
         exit(1)
     }
+    // The BYTES, not just how many of them. Sixteen zero bytes have the right
+    // length and the wrong value, and a length-only check cannot tell the two
+    // apart -- which is exactly the failure a second backend could introduce.
+    // md5("abc") = 90 01 50 98 3c d2 4f b0 d6 96 3f 7d 28 e1 7f 72.
+    if string.char_at_n(raw, n3, 0) != 144 {
+        println("  FAIL: md5 raw byte 0 = ${string.char_at_n(raw, n3, 0)}, want 144")
+        exit(1)
+    }
+    if string.char_at_n(raw, n3, 1) != 1 {
+        println("  FAIL: md5 raw byte 1 = ${string.char_at_n(raw, n3, 1)}, want 1")
+        exit(1)
+    }
+    if string.char_at_n(raw, n3, 15) != 114 {
+        println("  FAIL: md5 raw byte 15 = ${string.char_at_n(raw, n3, 15)}, want 114")
+        exit(1)
+    }
     print("  PASS\n")
 
     // ---- Test 4: empty input (no update) == md5("") ----
@@ -132,6 +140,13 @@ main() {
     ctx5, e5 = cryptography.digest_new("not-a-real-algo")
     if string.equals(e5, "unknown algorithm") != 1 {
         println("  FAIL: expected 'unknown algorithm', got '${e5}'")
+        exit(1)
+    }
+    // And the handle is null on that path. A rejected algorithm that still
+    // handed back a context would leak it, and every caller checks the error
+    // slot rather than the pointer.
+    if ctx5 != null {
+        println("  FAIL: unknown algorithm returned a non-null context")
         exit(1)
     }
     print("  PASS\n")

--- a/tests/integration/cryptography_digest_stream/test_cryptography_digest_stream.sh
+++ b/tests/integration/cryptography_digest_stream/test_cryptography_digest_stream.sh
@@ -22,13 +22,15 @@ if ! "$TMPDIR/probe" >"$TMPDIR/run.log" 2>&1; then
     exit 1
 fi
 
+# No skip branch. The streaming API used to be OpenSSL-only, so a build
+# without libcrypto could only report "skipped" and this test passed by not
+# running. It now falls back to the pure-Aether streaming contexts, so every
+# case is expected to pass on every platform -- and a skip that is still
+# accepted is a green tick for a fallback nobody exercised.
 if grep -q "All streaming digest tests passed" "$TMPDIR/run.log"; then
     echo "  [PASS] cryptography_digest_stream: 6 cases"
-elif grep -q "streaming digest tests skipped" "$TMPDIR/run.log"; then
-    reason=$(grep '^SKIP cryptography_digest_stream:' "$TMPDIR/run.log" | head -1)
-    echo "  [PASS] cryptography_digest_stream: ${reason:-skipped (no OpenSSL backend)}"
 else
-    echo "  [FAIL] cryptography_digest_stream: didn't reach final PASS or SKIP line"
+    echo "  [FAIL] cryptography_digest_stream: didn't reach the final PASS line"
     sed 's/^/    /' "$TMPDIR/run.log" | head -30
     exit 1
 fi


### PR DESCRIPTION
`digest_new` / `digest_update` / `digest_final_*` were the one part of `std.cryptography` still OpenSSL-only. #1943 gave the one-shot digests a pure-Aether fallback and recorded the streaming API as out of scope; this closes that carve-out, and fixes a leak found while doing it.

The carve-out did not survive a second look. A streaming context is what you reach for when the object is too big to hold whole, so "call the one-shot form instead" is not advice that applies to the caller who needs it. On a build without libcrypto -- the default for a Windows source build -- hashing a large upload in windows simply had no answer.

## Streaming digests on the pure backend

A digest handle now carries its backend, and update / final dispatch on it. Both backends are wrapped, so the handle stays as opaque as it is documented to be rather than making the pure path a special case a caller could stumble into.

The pure path reuses the streaming contexts already living in `std.cryptography.{sha1,sha2,md5,md4}` rather than adding a second implementation of anything, over the same algorithm set as the one-shot fallback: an algorithm you can one-shot without OpenSSL is one you can stream without OpenSSL.

## A leak in every `*_hex` call

Found while measuring the above, and it predates it: confirmed by measuring the same loop with the module reverted.

The C side returns a `malloc`'d hex buffer the caller owns, but the externs were declared without `@heap`. The compiler therefore classified the result as **borrowed**, copied it into a fresh owned string at the boundary, and never freed the original:

```c
out = cryptography_sha256_hex_raw(...); _heap_out = 0;
return (_tuple_string_string){aether_uniform_heap_str((const char*)(out), _heap_out), ""};
```

One 80-byte buffer per call, on the hot path of anything that hashes: `sha1_hex`, `sha256_hex`, `hash_hex`, `md4_hex`, `md5_hex`, `hmac_sha256_hex`, `digest_final_hex`.

`@heap` is the annotation that exists for exactly this contract, so the fix is a declaration change rather than a copy-and-release dance repeated in seven wrappers. Each was checked against its C definition first: all seven reach `hex_encode`, which is a plain `malloc`, so the plain `free` that `aether_heap_str_free` performs on a headerless pointer is the correct release. **`base64_encode` is deliberately NOT annotated** -- it allocates through `aether_caps_malloc`, whose accounting a plain `free` would skip; that wants its own change.

## The test used to pass by not running

It skipped when there was no backend. After this change that would be a green tick for a fallback nobody exercised, and there is no build left where `digest_new("sha256")` can legitimately fail, so the skip is gone from both the probe and its runner.

Two assertions were also weaker than they looked. Test 3 checked only the digest's *length* -- sixteen zero bytes have the right length and the wrong value -- and now checks the bytes. The unknown-algorithm case now also checks the handle comes back null, as documented.

## A CI leg that actually covers it

Every other leg in the matrix installs OpenSSL, so **nothing exercised the pure fallback** #1943 added, and it could rot to a stub while staying green everywhere. `ci-no-openssl` builds with `OPENSSL=0` and runs the digest suites against the pure path. It asserts no libcrypto symbols are linked before running anything, so it cannot quietly prove nothing.

## Verification

| Check | Result |
| --- | --- |
| Six streaming cases on a real `OPENSSL=0` build | pass (previously skipped) |
| macOS leaks gate, full regression suite | 308 programs, 0 over budget |
| `*_hex` leak, 50-round loop | 200 allocations before, **0 after** |
| Streaming path leaks (50 rounds + `final_bytes` + abandoned ctx) | 0 |
| hmac after `@heap` | same digest, no double free |
| Unit tests | 409/409 |
| Byte assertion mutation-checked | flipping the expected byte turns it red |

The leaks gate passing across 308 programs is the load-bearing check on the `@heap` change: a mislabeled borrow would be a double free, which crashes under the gate rather than merely leaking.

Closes the streaming-digest carve-out recorded in #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)