### PR TITLE
fix: int must wrap at runtime, not only at constant-fold time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,29 @@ version number before tagging the release.
   or unreadable manifest → rebuild), so behaviour is unchanged on the first
   build and strictly more precise thereafter. Implements the direction ratified
   in `docs/notes/import-closure-cache-key.md`.
+
+### Fixed
+
+- **`int` did not wrap at runtime: generated C was compiled with signed
+  overflow left undefined (#1957).** Aether's `int` wraps, and the constant
+  folder already wrapped to match (W1003) precisely so that a literal and the
+  same expression over variables could not disagree. The runtime broke that
+  promise: `int` is emitted as C `int`, signed overflow is undefined in C, and
+  nothing on the compile line said otherwise. GCC 15.2 at `-O2` folded
+  `g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF` down to a three-value
+  cycle — the mask proves `g_seed >= 0`, "a signed multiply does not overflow"
+  then proves `g_seed <= 2^31 / 1103515245`, and value-range propagation
+  finishes it. Any LCG, hash or checksum written in Aether could compute
+  different values in a shipped build than under `ae run`, which compiles at
+  `-O0` and was unaffected. Every command line that compiles generated C now
+  carries `-fwrapv`: all five `opt_flags` modes and the `-pipe` mainline in
+  `ae build`, both `zig cc` cross paths, the wasm/emcc backend, and `ae cflags`
+  so external build systems compiling `aetherc` output inherit the same
+  semantics. Found as a black window in ae3d's `black_hole` example on Windows,
+  where all 200,000 particles were seeded from the collapsed generator and
+  landed on one pixel; macOS looked correct only because Apple Clang does not
+  make the same deduction for that loop.
+
 ## [0.652.0]
 
 ### Fixed

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -194,6 +194,42 @@ If you run `ae build` from a subdirectory and there's no `aether.toml` in the cu
 
 ---
 
+## Integer semantics (`-fwrapv`)
+
+Aether's `int` is 32 bits and **wraps**: `2147483647 + 1` is `-2147483648`, and
+the compiler's constant folder says so out loud
+([W1003](language-reference.md#constant-expression-overflow-w1003)). The code
+generator emits it as a C `int`, and C leaves signed overflow *undefined* — so
+the flag that makes the two agree has to be on every command line that compiles
+generated C:
+
+| flag | what it buys | where |
+|---|---|---|
+| `-fwrapv` | signed overflow wraps in two's complement, as the language reference specifies | every compile of generated C: `ae run`, `ae build`, `--profile`, `--size`, `--coverage`, `ae build --target=<triple>`, the wasm/emcc backend, and `ae cflags` |
+
+Without it the guarantee held only up to `-O1`. At `-O2` GCC 15.2 folded
+
+```c
+g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF;
+```
+
+down to a three-value cycle — the mask proves `g_seed >= 0`, "a signed multiply
+does not overflow" then proves `g_seed <= 2^31 / 1103515245`, and value-range
+propagation finishes the job. `ae run` compiles at `-O0` and was unaffected, so
+the disagreement appeared only in shipped binaries.
+
+`ae cflags` emits `-fwrapv` too, ahead of the include flags, so a build system
+that compiles `aetherc` output itself gets the same language:
+
+```bash
+aetherc app.ae app.c
+gcc app.c $(ae cflags) -o app        # -fwrapv arrives with the -I flags
+```
+
+The hand-written runtime and compiler are built by the Makefile rather than
+through `ae`, and are deliberately left out: signed overflow in that C is a bug
+to fix, not an operation with a defined result.
+
 ## Binary Hardening
 
 `ae build` asks the C toolchain for the mitigations whose cost is a rounding

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -2704,6 +2704,15 @@ long span = 250000000 - 200000000
 cv = span * 50 / 225000000          // 11, no warning
 ```
 
+The runtime is held to the same rule. Aether compiles to C, where signed
+overflow is *undefined behaviour* rather than a wrap, so every command line the
+toolchain uses to compile generated code carries `-fwrapv` — `ae run`,
+`ae build` at any optimisation level, the cross and wasm backends, and
+`ae cflags` for build systems that compile `aetherc` output themselves. Two's
+complement wrapping is the specified behaviour of `int`, not an artifact of the
+optimiser: an LCG, a hash, or a checksum written in Aether computes the same
+values on every target.
+
 Use `ae check file.ae` to see warnings without compiling. It skips codegen and linking, so iteration is much faster than `ae build`.
 
 ---

--- a/tests/integration/ae_cflags/test_ae_cflags.sh
+++ b/tests/integration/ae_cflags/test_ae_cflags.sh
@@ -50,8 +50,26 @@ if ! printf %s "$flags" | grep -q -- "-laether"; then
     fi
 fi
 
+# -fwrapv: `int` wraps in Aether and is undefined in C, so the flag that makes
+# the generated C mean what the language reference says has to travel with the
+# include paths (#1957). Without it a downstream build compiling `aetherc`
+# output at -O2 gets a different program -- which is how ae3d's black_hole
+# example came to draw a black window on Windows.
+if ! printf %s "$flags" | grep -q -- "-fwrapv"; then
+    echo "  [FAIL] ae_cflags: -fwrapv missing; generated C would be compiled with signed overflow undefined"
+    echo "  ---- output ----"
+    echo "$flags"
+    exit 1
+fi
+
 # --cflags subset: must be -I-only, no -L / -l flags.
 cflags_only="$("$AE" cflags --cflags 2>/dev/null)"
+if ! printf %s "$cflags_only" | grep -q -- "-fwrapv"; then
+    echo "  [FAIL] ae_cflags --cflags: -fwrapv missing from the compile-only subset"
+    echo "  ---- output ----"
+    echo "$cflags_only"
+    exit 1
+fi
 if printf %s "$cflags_only" | grep -qE -- "(^|[[:space:]])-(L|l)"; then
     echo "  [FAIL] ae_cflags --cflags: leaked link flags into the compile-only subset"
     echo "  ---- output ----"
@@ -129,5 +147,5 @@ if [ "$actual" != "ae_cflags ok" ]; then
     exit 1
 fi
 
-echo "  [PASS] ae_cflags: full / --cflags / --libs subsets correct, transitive deps present, gcc \$(ae cflags) builds"
+echo "  [PASS] ae_cflags: full / --cflags / --libs subsets correct, -fwrapv present, transitive deps present, gcc \$(ae cflags) builds"
 exit 0

--- a/tests/regression/test_int_wraps_at_runtime.ae
+++ b/tests/regression/test_int_wraps_at_runtime.ae
@@ -1,0 +1,117 @@
+// Regression: an `int` expression that overflows must wrap at runtime (#1957).
+//
+// The code generator emits Aether `int` as C `int`, and signed overflow is
+// undefined in C. Nothing on the compile line said otherwise, so GCC 15.2 at
+// -O2 was free to reason about this generator:
+//
+//     g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF
+//
+// From the mask it knows g_seed is non-negative; from "a signed multiply does
+// not overflow" it derives g_seed <= 2^31 / 1103515245, i.e. 0 or 1 -- and
+// folds the generator down to a three-value cycle. `ae run` was unaffected
+// (-O0), so only shipped builds were wrong.
+//
+// docs/language-reference.md (W1003) already promises the opposite: the
+// constant folder "wraps exactly as the runtime would", precisely so that the
+// literal form and the same expression over variables cannot disagree. The fix
+// is -fwrapv on every command line that compiles generated C.
+//
+// Found through ae3d's black_hole example, where every one of 200,000 particles
+// was seeded from the collapsed generator and landed on the same pixel: a black
+// window on Windows, correct on macOS, because Apple Clang happens not to make
+// the same deduction. The bug was never platform-specific -- only the
+// optimiser's choice was.
+//
+// The shape below is the one that collapsed: a helper drawing three numbers,
+// called from a long loop, each draw consumed as a double. A single call to
+// next_random() in main() is NOT enough to reproduce it.
+
+extern exit(code: int)
+
+const ROUNDS = 100000
+
+var g_seed = 987654321
+var g_x = 0.0
+var g_y = 0.0
+var g_z = 0.0
+
+fail(msg: string) {
+    println("FAIL: ${msg}")
+    exit(1)
+}
+
+expect(got: int, want: int, label: string) {
+    if got != want {
+        fail("${label}: got ${got}, want ${want}")
+    }
+}
+
+next_random() -> int {
+    g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF
+    return g_seed
+}
+
+scaled() -> float {
+    return (next_random() * 1.0) / 2147483647.0
+}
+
+draw_triple() {
+    g_x = 140.0 + scaled() * 620.0
+    g_y = scaled() * 6.283185307179586
+    g_z = (scaled() - 0.5) * 90.0
+}
+
+main() {
+    // The first eight draws, as two's-complement wrapping produces them. Every
+    // one of these overflows the 32-bit multiply.
+    expect(next_random(), 1048490390, "draw 1")
+    expect(next_random(), 638681367, "draw 2")
+    expect(next_random(), 965945604, "draw 3")
+    expect(next_random(), 390061805, "draw 4")
+    expect(next_random(), 1953255714, "draw 5")
+    expect(next_random(), 1965234099, "draw 6")
+    expect(next_random(), 1486606704, "draw 7")
+    expect(next_random(), 550010089, "draw 8")
+    println("PASS 1: the first eight draws wrap as documented")
+
+    // The same generator driven the way the miscompile needed: 300,000 draws
+    // through a three-call helper in a loop. Under the collapsed generator the
+    // third component of every triple was the bare `+ 12345` term, so g_z was
+    // (12345 / 2^31 - 0.5) * 90 = -44.9995 on the first iteration and on the
+    // last. Pinning the seed after the loop catches any drift, not just that
+    // one shape.
+    g_seed = 987654321
+    first_z = 0.0
+    i = 0
+    while i < ROUNDS {
+        draw_triple()
+        if i == 0 { first_z = g_z }
+        i = i + 1
+    }
+    expect(g_seed, 1758132689, "seed after ${ROUNDS} triples")
+    println("PASS 2: 300,000 draws through a helper leave the documented seed")
+
+    if g_z == first_z {
+        fail("the last triple repeats the first: the generator has collapsed")
+    }
+    if first_z < 0.0 - 5.0 {
+        fail("first triple's third draw is ${first_z}, the collapsed value")
+    }
+    println("PASS 3: the triples differ, so the generator did not cycle")
+
+    // A wrap that is not a multiply, and one that is negative.
+    a = 2147483647
+    a = a + 1
+    expect(a, 0 - 2147483648, "INT_MAX + 1 wraps to INT_MIN")
+
+    b = 0 - 2147483648
+    b = b - 1
+    expect(b, 2147483647, "INT_MIN - 1 wraps to INT_MAX")
+
+    c = 65536
+    c = c * 65536
+    expect(c, 0, "65536 * 65536 wraps to 0")
+    println("PASS 4: add, subtract and multiply all wrap")
+
+    println("=== All cases passed ===")
+}

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -2718,12 +2718,12 @@ static const char* opt_flags(bool optimize) {
      * extern calls; #line directives map its warning to the user's .ae
      * source. User cflags from aether.toml append after these flags, so
      * -Wno-format remains available to opt out. */
-    if (g_coverage) return "-O0 -g --coverage -Wformat";
+    if (g_coverage) return "-O0 -g --coverage -Wformat" AETHER_WRAP_CFLAGS;
     /* --profile keeps -O2 so the profile describes the code that ships,
      * and adds what a sampling profiler needs to attribute it. Checked
      * after coverage because --coverage's -O0 is a correctness
      * requirement for gcov, not a preference. */
-    if (g_profile) return "-O2 -g -fno-omit-frame-pointer -Wformat";
+    if (g_profile) return "-O2 -g -fno-omit-frame-pointer -Wformat" AETHER_WRAP_CFLAGS;
     /* --size optimises for bytes: -Os over -O2, and -g0 to suppress debug
      * info the compiler would otherwise emit. Checked after --profile
      * because asking for both is contradictory and the debug-oriented mode
@@ -2734,8 +2734,9 @@ static const char* opt_flags(bool optimize) {
      * -Os is supported by every gcc and clang we target and gives nearly the
      * same result. The CROSS path can and does use -Oz, because zig bundles
      * its own clang and the version is not the host's to vary. */
-    if (g_size) return "-Os -g0 -Wformat";
-    return optimize ? "-O2 -Wformat" : "-O0 -g -Wformat";
+    if (g_size) return "-Os -g0 -Wformat" AETHER_WRAP_CFLAGS;
+    return optimize ? "-O2 -Wformat" AETHER_WRAP_CFLAGS
+                    : "-O0 -g -Wformat" AETHER_WRAP_CFLAGS;
 }
 
 void build_gcc_cmd(char* cmd, size_t size,
@@ -2981,7 +2982,8 @@ void build_gcc_cmd(char* cmd, size_t size,
     // remains an opt-out.
     const char* base_opt = (g_coverage || g_profile || g_size)
                           ? opt_flags(optimize)
-                          : (optimize ? "-O2 -pipe -Wformat" : "-O0 -g -pipe -Wformat");
+                          : (optimize ? "-O2 -pipe -Wformat" AETHER_WRAP_CFLAGS
+                                      : "-O0 -g -pipe -Wformat" AETHER_WRAP_CFLAGS);
     const char* trace_def = g_trace ? " -DAETHER_TRACE" : "";
     /* The link-side flags ride in the same blob: gcc accepts -Wl,... anywhere
      * on the line, and threading them through four separate link-command
@@ -3291,8 +3293,12 @@ static int build_wasm_cmd(char* cmd, size_t size,
         }
     }
 
+    /* AETHER_WRAP_CFLAGS: emcc is clang, and the wasm build compiles the same
+     * generated C as every other target, so it owes the same `int` semantics
+     * (#1957). */
     snprintf(cmd, size,
-        "emcc -O2 -DAETHER_NO_THREADING -DAETHER_NO_FILESYSTEM -DAETHER_NO_NETWORKING "
+        "emcc -O2" AETHER_WRAP_CFLAGS
+        " -DAETHER_NO_THREADING -DAETHER_NO_FILESYSTEM -DAETHER_NO_NETWORKING "
         "%s %s \"%s\" %s -o \"%s\" -lm "
         "-Wall -Wextra -Wno-unused-parameter -Wno-unused-function "
         "-Wno-unused-variable -Wno-missing-field-initializers -Wno-unused-label",
@@ -8045,9 +8051,23 @@ static int cmd_cflags(int argc, char** argv) {
 
     int wrote_anything = 0;
 
-    if (want_cflags && tc.include_flags[0]) {
-        fputs(tc.include_flags, stdout);
+    if (want_cflags) {
+        /* Semantics before paths. -fwrapv is what makes the generated C
+         * implement Aether's wrapping `int` (#1957); a build system that
+         * compiles `aetherc` output without it gets a different program from
+         * -O2 upward, which is how ae3d's black_hole example came to draw a
+         * black window on Windows. Emitted unconditionally, so the documented
+         * `gcc your.c $(ae cflags)` recipe is right even on an install whose
+         * include list came back empty.
+         *
+         * +1 skips the macro's leading space: it is written to be appended to
+         * an existing flag string, and here it starts the line. */
+        fputs(AETHER_WRAP_CFLAGS + 1, stdout);
         wrote_anything = 1;
+        if (tc.include_flags[0]) {
+            fputc(' ', stdout);
+            fputs(tc.include_flags, stdout);
+        }
     }
 
     if (want_libs) {

--- a/tools/ae_cross.c
+++ b/tools/ae_cross.c
@@ -580,8 +580,12 @@ int run_cross_compile_obj(const char* c_file, const char* obj_file,
      * smallest artifact, so it takes -Oz and suppresses that debug info. */
     /* -Oz is safe here where it is not on the native path: zig bundles its
      * own clang, so the version is not the host compiler's to vary. */
-    const char* opt = ae_build_size_mode() ? "-Oz -g0"
-                    : (optimize ? "-O2" : "-O0 -g");
+    /* AETHER_WRAP_CFLAGS on all three: a cross build has to compute what the
+     * native build computes, and `int` wrapping is part of the language rather
+     * than of the host (#1957). */
+    const char* opt = ae_build_size_mode() ? "-Oz -g0" AETHER_WRAP_CFLAGS
+                    : (optimize ? "-O2" AETHER_WRAP_CFLAGS
+                                : "-O0 -g" AETHER_WRAP_CFLAGS);
 
     /* Same macos workaround as the link path: zig's bundled macOS SDK stubs
      * do not ship the Apple-licensed CoreAudio framework headers, so
@@ -734,8 +738,12 @@ int run_cross_build(const char* c_file, const char* out_file,
      * smallest artifact, so it takes -Oz and suppresses that debug info. */
     /* -Oz is safe here where it is not on the native path: zig bundles its
      * own clang, so the version is not the host compiler's to vary. */
-    const char* opt = ae_build_size_mode() ? "-Oz -g0"
-                    : (optimize ? "-O2" : "-O0 -g");
+    /* AETHER_WRAP_CFLAGS on all three: a cross build has to compute what the
+     * native build computes, and `int` wrapping is part of the language rather
+     * than of the host (#1957). */
+    const char* opt = ae_build_size_mode() ? "-Oz -g0" AETHER_WRAP_CFLAGS
+                    : (optimize ? "-O2" AETHER_WRAP_CFLAGS
+                                : "-O0 -g" AETHER_WRAP_CFLAGS);
     const char* ex = extra ? extra : "";
     /* std.audio's vendored miniaudio auto-selects a backend by platform macro:
      * on a macos target it #includes <CoreAudio/CoreAudio.h>, an APPLE FRAMEWORK

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -14,6 +14,32 @@
 
 #include "../compiler/aether_lib_path.h"
 
+/* Aether `int` wraps; C `int` overflow is undefined. -fwrapv is what closes
+ * that gap, and it belongs on every command line that compiles generated C.
+ *
+ * docs/language-reference.md (W1003) already states the contract: a constant
+ * fold "wraps exactly as the runtime would", specifically so that the literal
+ * form and the same expression written over `int` variables cannot disagree.
+ * Without this flag they did, from -O2 upward. GCC 15.2 folded
+ *
+ *     g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF
+ *
+ * down to a three-value cycle: the mask proves g_seed >= 0, "a signed multiply
+ * does not overflow" then proves g_seed <= 2^31 / 1103515245, and value-range
+ * propagation takes it from there. `ae run` was unaffected (-O0), so the
+ * miscompile reached shipped binaries only -- #1957, found as a black window in
+ * ae3d's black_hole example, whose 200,000 particles were all seeded from the
+ * collapsed generator.
+ *
+ * Every GCC and Clang the project targets accepts it, zig cc included. What it
+ * costs is a narrow class of loop optimisations that rely on a signed
+ * induction variable not wrapping; the shape most exposed to that -- a 200M
+ * iteration `int` loop doing multiply, divide and modulo -- measured 199 ms
+ * either way on GCC 15.2 x86_64. The hand-written runtime is compiled by the
+ * Makefile, not through here, and is unaffected: signed overflow there is a
+ * bug rather than a defined operation. */
+#define AETHER_WRAP_CFLAGS " -fwrapv"
+
 typedef struct {
     char root[1024];           // Aether root directory (dev: repo root;
                                // installed: the PREFIX, e.g. ~/.local)


### PR DESCRIPTION
Fixes #1957.

## Description

Aether's `int` wraps. `docs/language-reference.md` says so under W1003, and the constant folder wraps to match — with the reason spelled out there: otherwise a literal and the same expression written over `int` variables would disagree, and the literal form would look correct while shipped code silently overflowed.

The runtime broke that promise. `int` is emitted as C `int`, signed overflow is undefined in C, and nothing on the compile line said otherwise. GCC 15.2 at `-O2` folded

```c
g_seed = (g_seed * 1103515245 + 12345) & 0x7FFFFFFF;
```

down to a three-value cycle: the mask proves `g_seed >= 0`, "a signed multiply does not overflow" then proves `g_seed <= 2^31 / 1103515245`, and value-range propagation finishes it. `ae run` compiles at `-O0` and was unaffected, so the disagreement appeared only in shipped binaries. Any LCG, hash or checksum written in Aether was exposed.

`-fwrapv` closes it, and is now on every command line that compiles generated C:

| where | what changed |
|---|---|
| `opt_flags()` | all five modes: `--coverage`, `--profile`, `--size`, `-O2`, `-O0` |
| `build_gcc_cmd` | the `-pipe` mainline, which carries its own copy of the opt string |
| `ae_cross.c` | both `zig cc` paths (object and link) |
| wasm/emcc backend | the same generated C, so the same semantics |
| `ae cflags` | so external build systems compiling `aetherc` output inherit the language instead of having to know about this |

The macro lives in `tools/ae_internal.h` rather than in `ae.c`: a native build and a cross build disagreeing about what `int` means would be worse than either of them being wrong.

The hand-written runtime and compiler are built by the Makefile rather than through `ae`, and are deliberately untouched — signed overflow in that C is a bug to fix, not an operation with a defined result.

## How it was found

ae3d's `black_hole` example draws a black window on Windows and the correct 200,000-particle accretion disc on macOS. Everything on the graphics side is healthy — `OpenGL 4.1.0 NVIDIA 616.56`, both instanced draws issued with 100000 instances, post framebuffers complete, 144 fps. The particles are simply all seeded to the same point, so the swarm is one 1.3-pixel dot. Apple Clang does not make the same deduction for that loop, which is the only reason macOS looks fine; the program had undefined behaviour on every platform, and a GCC upgrade would have surfaced it on Linux too.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Documentation update

## Testing

- [x] Added tests for new functionality

  `tests/regression/test_int_wraps_at_runtime.ae` pins the sequence through the shape that collapsed — a helper drawing three numbers, called from a long loop, each draw consumed as a double. A single call in `main()` does not reproduce it. On 0.652.0 it fails immediately:

  ```
  FAIL: draw 2: got 12344, want 638681367
  ```

  With this change:

  ```
  PASS 1: the first eight draws wrap as documented
  PASS 2: 300,000 draws through a helper leave the documented seed
  PASS 3: the triples differ, so the generator did not cycle
  PASS 4: add, subtract and multiply all wrap
  === All cases passed ===
  ```

  `tests/integration/ae_cflags/test_ae_cflags.sh` now requires `-fwrapv` in both the full output and the `--cflags` subset.

- [x] Tested on Windows (Windows 11, MSYS2 UCRT64 GCC 15.2.0, `make build/ae.exe` clean, `ae cflags`, both new tests)
- [ ] Valgrind reports no leaks — unchanged; this touches command-line construction only

## Performance Impact

- [x] No performance impact

`-fwrapv` blocks a narrow class of loop optimisations that rely on a signed induction variable not wrapping. The shape most exposed to it — a 200M-iteration `int` loop doing multiply, divide and modulo — measured **199 ms either way** on GCC 15.2 x86_64, on the same generated C compiled with and without the flag.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] CHANGELOG.md updated under `[current]`
- [x] `docs/language-reference.md` states the runtime guarantee beside the W1003 fold
- [x] `docs/build-system.md` gains an "Integer semantics (`-fwrapv`)" section next to Binary Hardening
