### PR TITLE
fix: six correctness bugs across the lexer, DER and X.509 parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,62 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **Float literals in scientific notation were lexed as a number followed by
+  an identifier** (#1954). `1.0e30` became the float `1.0` and the identifier
+  `e30`. In expression position that surfaced as "undefined variable 'e30'";
+  in statement position it silently swallowed the FOLLOWING line into the
+  expression, so a program lost a statement, reported only an unused-variable
+  warning for the swallowed call, and produced no binary. Two halves had to
+  agree: the lexer now consumes `e`/`E` with an optional sign and at least one
+  digit, and the literal classifier treats an exponent as making the number a
+  float, without which `1e30` was not classified as a number at all. The full
+  shape is required before anything is consumed, so a bare `e`, hex (`0x1E`),
+  durations (`500ms`) and ranges (`1..4`) lex exactly as before.
+
+- **`asn1.encode_oid` encoded strings that are not OIDs** (#1947). `""`, `"1"`,
+  `"1..2"`, `"1.2."`, `".1.2"` and `"1.2.x"` all produced well-formed DER that
+  decodes as a *different* identifier than the caller named, which is worse
+  than refusing them, and this is a function reached with strings from
+  configuration. The `have` flag that catches the empty-arc cases was already
+  there, set and cleared and never read. It now rejects a non-digit, an empty
+  arc, a first arc outside 0..2, a second arc over 39 under arcs 0 and 1, and
+  input with fewer than two arcs. The folded first subidentifier is also
+  emitted base128 rather than as a single byte: under arc 2 it exceeds 127
+  (`2.999` folds to 1079) and a one-byte store truncated it into another OID.
+
+- **The X.509 parser accepted certificates it could not read** (#1942).
+  `parse_tbs_fields` dropped the error from six TBSCertificate reads --
+  version, signature algorithm, issuer, validity, subject and
+  subjectPublicKeyInfo -- and stored whatever the failed read returned. A
+  truncated or malformed certificate therefore parsed "successfully" into a
+  `LeafCert` whose issuer, subject, validity or SPKI came from a read that did
+  not succeed, while the neighbouring serialNumber and notBefore/notAfter
+  reads in the same function did check. All six now return the error.
+
+- **Three digest wrappers used a context whose constructor had failed**
+  (#1947, #1942). `ed25519.sha512`, `ed448.shake` and `rsa.sha256b` dropped the
+  error from `sha2.new` / `sha3.new`, which answer `(null, "allocation
+  failed")`, and passed the null context to `update_bytes`. The rest of the
+  family checked; these three did not.
+
+- **A trust-store failure reported no reason** (#1942).
+  `tls13_client` discarded the error from `trust_store_load` and reported a
+  bare "cannot load trust store" for a missing file, an unreadable one, and one
+  nothing parsed out of. The reason is now included.
+
+- **56 unused-variable warnings across the stdlib are gone** (#1942), 48
+  distinct sites in `tls13_cert`, `tls13_client`, `pem` and `tls13_server`.
+  They were invisible until warnings gained a location, because a warning
+  raised inside an imported module was reported against the importing file.
+  `ae check` over every stdlib module now reports zero.
+
+- **The `ae cflags` build emitted a `-Wstring-plus-int` warning.** The
+  intentional `AETHER_WRAP_CFLAGS + 1` that skips the macro's leading space is
+  written `&AETHER_WRAP_CFLAGS[1]`, which states the same intent in a spelling
+  clang does not read as the string-plus-integer mistake.
+
 ## [0.654.0]
 
 ### Fixed

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -160,6 +160,13 @@ Type* infer_from_literal(const char* value) {
     for (const char* p = value; *p; p++) {
         if (*p == '.') {
             is_float = 1;
+        } else if (*p == 'e' || *p == 'E') {
+            /* An exponent makes it a float, and it has to be recognised here
+             * or `1e30` is not classified as a number at all: the letter fell
+             * to the `else` below, which clears is_number and breaks (#1954).
+             * Prefixed 0x / 0o / 0b literals return before this loop, so the
+             * `E` in `0x1E` never reaches it. */
+            is_float = 1;
         } else if (isdigit((unsigned char)*p)) {
             is_number = 1;
         } else if (*p != '-' && *p != '+') {

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -332,10 +332,53 @@ Token* read_number() {
         buffer[i++] = advance();
     }
 
+    /* Scientific notation: `e` or `E`, an optional sign, then at least one
+     * digit. Without this the exponent was left behind as a separate
+     * identifier: `1.0e30` lexed as the float `1.0` followed by `e30`. In
+     * expression position that surfaced as "undefined variable 'e30'"; in
+     * statement position it silently swallowed the FOLLOWING line into the
+     * expression, so a program lost a statement and still compiled clean
+     * (#1954).
+     *
+     * The full shape is required before anything is consumed, so a bare `e`
+     * or a trailing `1e` is left exactly as it lexed before and the letter
+     * stays available to whatever follows. Hex, octal and binary literals
+     * return earlier and never reach here, so the `E` in `0x1E` is safe. */
+    int has_exponent = 0;
+    if (current_pos < source_length && (peek() == 'e' || peek() == 'E')) {
+        int look = current_pos + 1;
+        if (look < source_length && (source[look] == '+' || source[look] == '-')) look++;
+        if (look < source_length && isdigit((unsigned char)source[look])) {
+            int take = (look - current_pos) + 1;   /* e[, sign], first digit */
+            for (int k = 0; k < take; k++) {
+                if (i >= capacity - 1) {
+                    capacity *= 2;
+                    char* new_buf = realloc(buffer, capacity);
+                    if (!new_buf) { free(buffer); return create_token(TOKEN_ERROR, "out of memory", token_start_line, token_start_column); }
+                    buffer = new_buf;
+                }
+                buffer[i++] = advance();
+            }
+            while (current_pos < source_length && isdigit((unsigned char)peek())) {
+                if (i >= capacity - 1) {
+                    capacity *= 2;
+                    char* new_buf = realloc(buffer, capacity);
+                    if (!new_buf) { free(buffer); return create_token(TOKEN_ERROR, "out of memory", token_start_line, token_start_column); }
+                    buffer = new_buf;
+                }
+                buffer[i++] = advance();
+            }
+            has_exponent = 1;
+        }
+    }
+
     // Duration suffixes: ns, us, ms, s, m, h, d. Compound forms
     // (`2m30s`, `1h15m`) stay a single numeric token so parser
     // precedence remains ordinary literal precedence.
-    while (current_pos < source_length) {
+    //
+    // Not after an exponent: `1e3` is a float, and `s`/`m`/`h`/`d` after one
+    // would read a unit off a number that is not a duration.
+    while (!has_exponent && current_pos < source_length) {
         int unit_len = 0;
         if (current_pos + 1 < source_length &&
             ((source[current_pos] == 'n' && source[current_pos + 1] == 's') ||

--- a/std/cryptography/asn1/module.ae
+++ b/std/cryptography/asn1/module.ae
@@ -632,7 +632,7 @@ encode_oid(dotted: string) -> ptr {
         }
         if ch == 46 {
             if have == 0 {
-                return null            // empty arc: "", "1..2", "1.2.", ".1.2"
+                return null // empty arc: "", "1..2", "1.2.", ".1.2"
             }
             if arccount == 0 {
                 arc1 = cur
@@ -664,7 +664,7 @@ encode_oid(dotted: string) -> ptr {
             have = 0
         } else {
             if ch < 48 || ch > 57 {
-                return null            // not a digit: "1.2.x", "1.2-3"
+                return null // not a digit: "1.2.x", "1.2-3"
             }
             cur = (cur * 10) + (ch - 48)
             have = 1

--- a/std/cryptography/asn1/module.ae
+++ b/std/cryptography/asn1/module.ae
@@ -602,11 +602,22 @@ encode_boolean(v: int) -> ptr {
 
 // OBJECT IDENTIFIER from a dotted-decimal string.
 encode_oid(dotted: string) -> ptr {
-    // parse arcs
+    // A dotted OID, or null. The validation is the point: every rejected
+    // form below used to encode successfully as a DIFFERENT identifier than
+    // the caller named, which is worse than refusing it, and this is a
+    // function callers reach with strings from configuration (#1947).
+    //
+    //   ""      -> a single empty arc, nothing to fold, empty OID
+    //   "1"     -> one arc, nothing to fold with, empty OID
+    //   "1..2"  -> the empty middle arc contributed a zero
+    //   "1.2."  -> trailing empty arc, same
+    //   "1.2.x" -> `cur*10 + (ch - 48)` ran on a letter and kept the result
+    //
+    // The `have` flag that catches the empty-arc cases was already here,
+    // set and cleared and never read.
     content = bytes.new(0)
     clen = 0
     n = string.length(dotted)
-    // collect arcs into a small list via repeated parse
     arc1 = -1
     arc2 = -1
     cur = 0
@@ -620,14 +631,30 @@ encode_oid(dotted: string) -> ptr {
             ch = 46 // force flush of last arc
         }
         if ch == 46 {
+            if have == 0 {
+                return null            // empty arc: "", "1..2", "1.2.", ".1.2"
+            }
             if arccount == 0 {
                 arc1 = cur
+                // X.660: the first arc is 0, 1 or 2. Anything else has no
+                // encoding -- 40*arc1 + arc2 would land in another arc's
+                // range and decode as a different OID.
+                if arc1 < 0 || arc1 > 2 {
+                    return null
+                }
             } else {
                 if arccount == 1 {
                     arc2 = cur
-                    // emit first byte = 40*arc1 + arc2
-                    bytes.set(content, clen, (40 * arc1) + arc2)
-                    clen = clen + 1
+                    // Under arcs 0 and 1 the second arc is limited to 0..39,
+                    // which is what makes the 40*arc1 + arc2 folding
+                    // reversible. Only arc 2 is open-ended.
+                    if arc1 < 2 && arc2 > 39 {
+                        return null
+                    }
+                    // base128, not a single byte: under arc 2 the folded
+                    // value exceeds 127 (2.999 folds to 1079) and a
+                    // one-byte store silently truncated it to another OID.
+                    clen = emit_base128(content, clen, (40 * arc1) + arc2)
                 } else {
                     clen = emit_base128(content, clen, cur)
                 }
@@ -636,10 +663,18 @@ encode_oid(dotted: string) -> ptr {
             cur = 0
             have = 0
         } else {
+            if ch < 48 || ch > 57 {
+                return null            // not a digit: "1.2.x", "1.2-3"
+            }
             cur = (cur * 10) + (ch - 48)
             have = 1
         }
         i = i + 1
+    }
+    // Two arcs minimum: the first two fold into one subidentifier, so a
+    // single-arc input has nothing to fold and encoded as an empty OID.
+    if arccount < 2 {
+        return null
     }
     return wrap_tlv(0x06, content)
 }

--- a/std/cryptography/ed25519/module.ae
+++ b/std/cryptography/ed25519/module.ae
@@ -350,6 +350,12 @@ pt_decode(b: ptr, p: ptr, d: ptr) -> *EdPt {
 // SHA-512 of a bytes buffer -> 64-byte bytes.
 sha512(b: ptr, len: int) -> ptr {
     ctx, err = sha2.new("sha512")
+    // sha2.new returns (null, "allocation failed"). Dropping the error here
+    // fed a null context to update_bytes, which is the one input it cannot
+    // take; the rest of the digest wrappers in this family check (#1947).
+    if err != "" {
+        return null
+    }
     sha2.update_bytes(ctx, b, len)
     return sha2.final_bytes(ctx)
 }

--- a/std/cryptography/ed448/module.ae
+++ b/std/cryptography/ed448/module.ae
@@ -338,6 +338,11 @@ pt_decode(b: ptr, p: ptr, d: ptr) -> *Pt {
 // also call free_ctx (that would double-free and segfault).
 shake(b: ptr, len: int, out_len: int) -> ptr {
     ctx, err = sha3.new("shake256")
+    // Same as ed25519.sha512: sha3.new answers (null, "allocation failed"),
+    // and update_bytes cannot take a null context (#1947).
+    if err != "" {
+        return null
+    }
     sha3.update_bytes(ctx, b, len)
     out = sha3.final_bytes(ctx, out_len)
     return out

--- a/std/cryptography/pem/module.ae
+++ b/std/cryptography/pem/module.ae
@@ -139,7 +139,7 @@ emit_b64_char(sb: ptr, alpha: string, v: int) {
 // Parse the first PEM block in `text`. Returns (der_bytes, label, "") on
 // success, (null, "", err) otherwise. Whitespace before/after is tolerated.
 parse(text: string) -> (ptr, string, string) {
-    n = string.length(text)
+    _n = string.length(text)
     begin = "-----BEGIN "
     bidx = string.index_of(text, begin)
     if bidx < 0 {

--- a/std/cryptography/rsa/module.ae
+++ b/std/cryptography/rsa/module.ae
@@ -325,6 +325,12 @@ build_emsa(di: ptr, klen: int) -> ptr {
 oaep_hlen() -> int { return 32 }
 sha256b(data: ptr, len: int) -> ptr {
     ctx, err = sha2.new("sha256")
+    // Same shape as ed25519.sha512 was: sha2.new answers
+    // (null, "allocation failed") and update_bytes cannot take a null
+    // context (#1942).
+    if err != "" {
+        return null
+    }
     sha2.update_bytes(ctx, data, len)
     return sha2.final_bytes(ctx)
 }

--- a/std/cryptography/tls13_cert/module.ae
+++ b/std/cryptography/tls13_cert/module.ae
@@ -499,7 +499,7 @@ parse_certificate(der: ptr, len: int, out: *LeafCert) -> string {
         asn1.reader_free(salg_body)
         bytes.free(salg_full)
     }
-    sigbits, snbits, sberr = asn1.read_bit_string(cert)
+    sigbits, _snbits, sberr = asn1.read_bit_string(cert)
     if string.equals(sberr, "") == 1 {
         out.signature = sigbits
         out.signature_len = bytes.length(sigbits)
@@ -528,6 +528,12 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
     v, verr = asn1.read_tlv(tbsr)
     vtag = asn1.last_tag(tbsr)
     bytes.free(v)
+    // Every read below used to drop its error, so a truncated or malformed
+    // certificate parsed "successfully" into a LeafCert whose fields came
+    // from reads that failed -- an issuer, subject, validity or SPKI the
+    // certificate does not actually carry. The neighbouring serialNumber /
+    // notBefore / notAfter reads already checked; these six did not (#1942).
+    if string.equals(verr, "") != 1 { return verr }
     if vtag != 0xA0 {
         // `v` was actually serialNumber; the field after version is
         // serialNumber, so if there was no version we've now consumed
@@ -545,14 +551,17 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
     // signature AlgorithmIdentifier (SEQUENCE) — skip.
     sa, saerr = asn1.read_tlv(tbsr)
     bytes.free(sa)
+    if string.equals(saerr, "") != 1 { return saerr }
 
     // issuer Name (SEQUENCE) — capture raw DER (tag+len+content).
     iss, ierr = read_tlv_full(tbsr)
+    if string.equals(ierr, "") != 1 { bytes.free(iss); return ierr }
     out.issuer = iss
     out.issuer_len = bytes.length(iss)
 
     // validity SEQUENCE { notBefore, notAfter }.
     val_content, valerr = asn1.read_tlv(tbsr)
+    if string.equals(valerr, "") != 1 { bytes.free(val_content); return valerr }
     vr = asn1.reader_new(val_content)
     nb, nberr = asn1.read_tlv(vr)
     if string.equals(nberr, "") == 1 { out.not_before = nb; out.not_before_len = bytes.length(nb) }
@@ -563,11 +572,13 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
 
     // subject Name (SEQUENCE) — capture raw DER.
     subj, suberr = read_tlv_full(tbsr)
+    if string.equals(suberr, "") != 1 { bytes.free(subj); return suberr }
     out.subject = subj
     out.subject_len = bytes.length(subj)
 
     // subjectPublicKeyInfo SEQUENCE { algorithm AlgId, subjectPublicKey BIT }.
     spki_content, spkierr = asn1.read_tlv(tbsr)
+    if string.equals(spkierr, "") != 1 { bytes.free(spki_content); return spkierr }
     sr = asn1.reader_new(spki_content)
     algo_body, algo_full, ae = asn1.read_sequence(sr)
     if string.equals(ae, "") == 1 {
@@ -576,7 +587,7 @@ fn parse_tbs_fields(tbsr: ptr, out: *LeafCert) -> string {
         asn1.reader_free(algo_body)
         bytes.free(algo_full)
     }
-    bitkey, nbits, berr = asn1.read_bit_string(sr)
+    bitkey, _nbits, berr = asn1.read_bit_string(sr)
     if string.equals(berr, "") == 1 {
         out.spki_key = bitkey
         out.spki_key_len = bytes.length(bitkey)
@@ -1074,7 +1085,7 @@ fn der_tlv(buf: ptr, p: int, end: int) -> (int, int, int, int) {
 // malformed / unsuccessful response.
 parse_ocsp_status(der: ptr, len: int) -> int {
     // OCSPResponse ::= SEQUENCE { responseStatus ENUMERATED, responseBytes [0] }
-    t0, c0, l0, n0 = der_tlv(der, 0, len)
+    t0, c0, l0, _n0 = der_tlv(der, 0, len)
     if t0 != 0x30 { return OCSP_ERROR }
     end0 = c0 + l0
     // responseStatus ENUMERATED — must be 0 (successful).
@@ -1083,15 +1094,15 @@ parse_ocsp_status(der: ptr, len: int) -> int {
     if ls < 1 { return OCSP_ERROR }
     if (bytes.get(der, cs) & 0xFF) != 0 { return OCSP_ERROR }
     // responseBytes [0] EXPLICIT SEQUENCE { responseType OID, response OCTET STRING }
-    tb, cb, lb2, nb = der_tlv(der, ns, end0)
+    tb, cb, lb2, _nb = der_tlv(der, ns, end0)
     if tb != 0xA0 { return OCSP_ERROR }
     endb = cb + lb2
-    trb, crb, lrb, nrb = der_tlv(der, cb, endb) // inner SEQUENCE
+    trb, crb, lrb, _nrb = der_tlv(der, cb, endb) // inner SEQUENCE
     if trb != 0x30 { return OCSP_ERROR }
     endrb = crb + lrb
-    toid, coid, loid, noid = der_tlv(der, crb, endrb) // responseType OID (skip)
+    toid, _coid, _loid, noid = der_tlv(der, crb, endrb) // responseType OID (skip)
     if toid != 0x06 { return OCSP_ERROR }
-    toct, coct, loct, noct = der_tlv(der, noid, endrb) // response OCTET STRING
+    toct, coct, loct, _noct = der_tlv(der, noid, endrb) // response OCTET STRING
     if toct != 0x04 { return OCSP_ERROR }
     // The OCTET STRING content is the DER of BasicOCSPResponse.
     return parse_basic_ocsp(der, coct, coct + loct)
@@ -1101,12 +1112,12 @@ parse_ocsp_status(der: ptr, len: int) -> int {
 //                                  signature, certs [0] }
 // We only need tbsResponseData -> responses -> [0].certStatus.
 fn parse_basic_ocsp(buf: ptr, start: int, end: int) -> int {
-    tb, cb, lb, nb = der_tlv(buf, start, end)
+    tb, cb, lb, _nb = der_tlv(buf, start, end)
     if tb != 0x30 { return OCSP_ERROR }
     endb = cb + lb
     // tbsResponseData ::= SEQUENCE { version? [0], responderID, producedAt,
     //                                responses SEQUENCE OF SingleResponse, ... }
-    tt, ct, lt, nt = der_tlv(buf, cb, endb)
+    tt, ct, lt, _nt = der_tlv(buf, cb, endb)
     if tt != 0x30 { return OCSP_ERROR }
     endt = ct + lt
     // Walk tbsResponseData's fields to the first SEQUENCE OF (the `responses`).
@@ -1124,13 +1135,13 @@ fn parse_basic_ocsp(buf: ptr, start: int, end: int) -> int {
     }
     if resp_seq < 0 { return OCSP_ERROR }
     // First SingleResponse ::= SEQUENCE { certID, certStatus, thisUpdate, ... }
-    ts1, cs1, ls1, ns1 = der_tlv(buf, resp_seq, resp_end)
+    ts1, cs1, ls1, _ns1 = der_tlv(buf, resp_seq, resp_end)
     if ts1 != 0x30 { return OCSP_ERROR }
     end_sr = cs1 + ls1
     // certID ::= SEQUENCE (skip it); certStatus is the NEXT element.
-    tcid, ccid, lcid, ncid = der_tlv(buf, cs1, end_sr)
+    tcid, _ccid, _lcid, ncid = der_tlv(buf, cs1, end_sr)
     if tcid != 0x30 { return OCSP_ERROR }
-    tcs, ccs, lcs, ncs = der_tlv(buf, ncid, end_sr)
+    tcs, _ccs, _lcs, _ncs = der_tlv(buf, ncid, end_sr)
     if tcs < 0 { return OCSP_ERROR }
     // certStatus CHOICE: good [0] IMPLICIT NULL (0x80), revoked [1] (0xA1),
     // unknown [2] IMPLICIT NULL (0x82).
@@ -1144,25 +1155,25 @@ fn parse_basic_ocsp(buf: ptr, start: int, end: int) -> int {
 // (content_start, content_end) of that SEQUENCE's body or (-1,-1) on a
 // malformed / non-successful response. Mirrors parse_ocsp_status's descent.
 fn ocsp_basic_bounds(der: ptr, len: int) -> (int, int) {
-    t0, c0, l0, n0 = der_tlv(der, 0, len)
+    t0, c0, l0, _n0 = der_tlv(der, 0, len)
     if t0 != 0x30 { return -1, -1 }
     end0 = c0 + l0
     ts, cs, ls, ns = der_tlv(der, c0, end0)
     if ts != 0x0A { return -1, -1 }
     if ls < 1 { return -1, -1 }
     if (bytes.get(der, cs) & 0xFF) != 0 { return -1, -1 }
-    tb, cb, lb2, nb = der_tlv(der, ns, end0)
+    tb, cb, lb2, _nb = der_tlv(der, ns, end0)
     if tb != 0xA0 { return -1, -1 }
     endb = cb + lb2
-    trb, crb, lrb, nrb = der_tlv(der, cb, endb)
+    trb, crb, lrb, _nrb = der_tlv(der, cb, endb)
     if trb != 0x30 { return -1, -1 }
     endrb = crb + lrb
-    toid, coid, loid, noid = der_tlv(der, crb, endrb)
+    toid, _coid, _loid, noid = der_tlv(der, crb, endrb)
     if toid != 0x06 { return -1, -1 }
-    toct, coct, loct, noct = der_tlv(der, noid, endrb)
+    toct, coct, loct, _noct = der_tlv(der, noid, endrb)
     if toct != 0x04 { return -1, -1 }
     // OCTET STRING content == DER of BasicOCSPResponse SEQUENCE.
-    tbr, cbr, lbr, nbr = der_tlv(der, coct, coct + loct)
+    tbr, cbr, lbr, _nbr = der_tlv(der, coct, coct + loct)
     if tbr != 0x30 { return -1, -1 }
     return cbr, cbr + lbr
 }
@@ -1200,7 +1211,7 @@ verify_ocsp_signature(der: ptr, len: int, issuer: *LeafCert) -> int {
     //                                  signature BIT STRING, [0] certs OPTIONAL }
     // tbsResponseData: capture the FULL DER (tag+len+content) — that is the
     // signed message.
-    tt, ct, lt, nt = der_tlv(der, bstart, bend)
+    tt, _ct, _lt, nt = der_tlv(der, bstart, bend)
     if tt != 0x30 { return 0 }
     tbs_full_len = nt - bstart
     tbs = bytes.new(tbs_full_len)
@@ -1210,7 +1221,7 @@ verify_ocsp_signature(der: ptr, len: int, issuer: *LeafCert) -> int {
     // signatureAlgorithm ::= SEQUENCE { algorithm OID, ... }
     ta, ca, la, na = der_tlv(der, nt, bend)
     if ta != 0x30 { bytes.free(tbs); return 0 }
-    toi, coi, loi, noi = der_tlv(der, ca, ca + la)
+    toi, coi, loi, _noi = der_tlv(der, ca, ca + la)
     if toi != 0x06 { bytes.free(tbs); return 0 }
     sig_alg_oid = oid_der_to_dotted_bytes(der, coi, loi)
 
@@ -1228,17 +1239,17 @@ verify_ocsp_signature(der: ptr, len: int, issuer: *LeafCert) -> int {
     delegated = null as *LeafCert
     have_delegated = 0
     if nsg < bend {
-        tc, cc, lc, nc = der_tlv(der, nsg, bend)
+        tc, cc, lc, _nc = der_tlv(der, nsg, bend)
         if tc == 0xA0 {
             // certs [0] EXPLICIT wraps a SEQUENCE OF Certificate; step INTO that
             // SEQUENCE OF, then read the first Certificate SEQUENCE inside it.
-            tso, cso, lso, nso = der_tlv(der, cc, cc + lc)
+            tso, cso, lso, _nso = der_tlv(der, cc, cc + lc)
             tcs2 = 0
-            ccs2 = 0
-            lcs2 = 0
+            _ccs2 = 0
+            _lcs2 = 0
             ncs2 = 0
             if tso == 0x30 {
-                tcs2, ccs2, lcs2, ncs2 = der_tlv(der, cso, cso + lso)
+                tcs2, _ccs2, _lcs2, ncs2 = der_tlv(der, cso, cso + lso)
             }
             if tcs2 == 0x30 {
                 cert_der_len = ncs2 - cso
@@ -1320,7 +1331,7 @@ fn cert_has_ocsp_signing_eku(c: *LeafCert) -> int {
     buf = c.tbs
     end = c.tbs_len
     // tbsCertificate ::= SEQUENCE { ... extensions [3] EXPLICIT SEQUENCE OF Extension }
-    tt, ct, lt, nt = der_tlv(buf, 0, end)
+    tt, ct, lt, _nt = der_tlv(buf, 0, end)
     if tt != 0x30 { return 0 }
     endt = ct + lt
     // Find the [3] context tag (0xA3) holding the extensions.
@@ -1332,7 +1343,7 @@ fn cert_has_ocsp_signing_eku(c: *LeafCert) -> int {
         if ti < 0 { p = endt } else {
             if ti == 0xA3 {
                 // [3] EXPLICIT wraps a SEQUENCE OF Extension.
-                ts, cs, ls, ns = der_tlv(buf, ci, ci + li)
+                ts, cs, ls, _ns = der_tlv(buf, ci, ci + li)
                 if ts == 0x30 { ext_seq = cs; ext_end = cs + ls }
                 p = endt
             } else { p = ni }
@@ -1373,7 +1384,7 @@ fn cert_has_ocsp_signing_eku(c: *LeafCert) -> int {
 // Scan a DER ExtKeyUsageSyntax (SEQUENCE OF KeyPurposeId OID) in
 // buf[start..end) for id-kp-OCSPSigning (1.3.6.1.5.5.7.3.9). Returns 1 if found.
 fn eku_octets_have_ocsp_signing(buf: ptr, start: int, end: int) -> int {
-    ts, cs, ls, ns = der_tlv(buf, start, end)
+    ts, cs, ls, _ns = der_tlv(buf, start, end)
     if ts != 0x30 { return 0 }
     p = cs
     seq_end = cs + ls
@@ -1774,7 +1785,7 @@ trust_store_load(path: string) -> (ptr, string) {
         if e < 0 { break }
         block_end = e + mlen
         block = string.substring_n(text, tlen, pos, block_end)
-        der, label, perr = pem.parse(block)
+        der, _label, perr = pem.parse(block)
         if string.equals(perr, "") == 1 {
             if der != null {
                 // sizeof(LeafCert) = 136 on LP64 (9 ptr @8 + 8 int @4, C-packed;

--- a/std/cryptography/tls13_client/module.ae
+++ b/std/cryptography/tls13_client/module.ae
@@ -536,7 +536,7 @@ fn send_plaintext_handshake(sock: ptr, msg: ptr, msg_len: int) -> string {
 
 // Fill a std.bytes buffer of length n with CSPRNG bytes.
 fn rand_into(n: int) -> ptr {
-    s, sn, err = cryptography.random_bytes(n)
+    s, _sn, err = cryptography.random_bytes(n)
     b = bytes.new(n)
     if n > 0 { bytes.set(b, n - 1, 0) }
     if string.equals(err, "") == 1 {
@@ -687,7 +687,7 @@ fn connect_full(host: string, port: int, x25519_priv: ptr, client_cert: ptr, cli
     x_pub, x_pub_len = keyshare_for_group(tls13_hs.GROUP_X25519, x25519_priv)
     p_pub, p_pub_len = keyshare_for_group(tls13_hs.GROUP_SECP256R1, p256_priv)
     pub = x_pub // primary keyshare (x25519); cleanup frees this
-    pub_len = x_pub_len
+    _pub_len = x_pub_len
     rnd = rand_into(32)
     sid = rand_into(32)
     ch = tls13_hs.client_hello_full(rnd, sid, 32, tls13_hs.GROUP_X25519, x_pub, x_pub_len, tls13_hs.GROUP_SECP256R1, p_pub, p_pub_len, host)
@@ -808,7 +808,7 @@ fn connect_full(host: string, port: int, x25519_priv: ptr, client_cert: ptr, cli
         return null, agerr
     }
     // Negotiate the record AEAD + key-schedule hash from the chosen suite.
-    rec_aead, rec_key_len, hash_algo, hash_len, suite_err = suite_params(parsed.cipher_suite)
+    _rec_aead, _rec_key_len, _hash_algo, _hash_len, suite_err = suite_params(parsed.cipher_suite)
     if string.equals(suite_err, "") != 1 {
         if parsed.key_share != null { bytes.free(parsed.key_share) }
         bytes.free(shared); bytes.free(sh); bytes.free(shrec)
@@ -975,7 +975,7 @@ fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
     th_before_finished = null
     th_through_cert = null
     server_verify_data = null
-    svd_len = 0
+    _svd_len = 0
     done = 0
     ferr = ""
     guard = 0
@@ -1004,7 +1004,7 @@ fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
 
     if string.equals(ferr, "") == 1 {
         th_before_finished, th_through_cert = add_flight_capture_prefinished(tr, fl, fllen, hash_algo)
-        server_verify_data, svd_len = extract_server_finished(fl, fllen)
+        server_verify_data, _svd_len = extract_server_finished(fl, fllen)
     }
 
     result = null
@@ -1022,7 +1022,14 @@ fn run_handshake_tail(sock: ptr, rio: ptr, tr: ptr, host: string,
             if string.equals(cafile, "") != 1 { store = cafile }
             anchors, tsErr = tls13_cert.trust_store_load(store)
             if anchors == null {
+                // Say WHY. trust_store_load reports the reason (missing file,
+                // unreadable, nothing parsed out of it) and that was dropped,
+                // leaving an operator with a bare "cannot load trust store"
+                // for every one of those causes (#1942).
                 auth_err = "cannot load trust store"
+                if string.equals(tsErr, "") != 1 {
+                    auth_err = "cannot load trust store: ${tsErr}"
+                }
             } else {
                 auth_err = authenticate_server(fl, fllen, th_through_cert, hash_len, host, anchors)
                 tls13_cert.free_anchors(anchors)
@@ -2010,7 +2017,7 @@ fn extract_stapled_ocsp(body: ptr, body_len: int) -> (ptr, int) {
     ctx_len = bytes.get(body, 0) & 0xFF
     p = 1 + ctx_len
     if p + 3 > body_len { return null, 0 }
-    list_len = ((bytes.get(body, p) & 0xFF) << 16) | ((bytes.get(body, p + 1) & 0xFF) << 8) | (bytes.get(body, p + 2) & 0xFF)
+    _list_len = ((bytes.get(body, p) & 0xFF) << 16) | ((bytes.get(body, p + 1) & 0xFF) << 8) | (bytes.get(body, p + 2) & 0xFF)
     p = p + 3
     // First CertificateEntry: cert_data<3>, then extensions<2>.
     if p + 3 > body_len { return null, 0 }
@@ -2166,7 +2173,7 @@ fn authenticate_server(fl: ptr, flen: int, th_thru_cert: ptr, th_len: int, host:
                             // Extract the EC point only if the SPKI is one; a
                             // non-EC (RSA) leaf leaves leaf_px null, which the
                             // RSA-PSS dispatch handles. Not an error here.
-                            px, py, coordw, sperr = split_ec_point(leaf.spki_key, leaf.spki_key_len)
+                            px, py, _coordw, sperr = split_ec_point(leaf.spki_key, leaf.spki_key_len)
                             if string.equals(sperr, "") == 1 {
                                 leaf_px = px
                                 leaf_py = py

--- a/std/cryptography/tls13_server/module.ae
+++ b/std/cryptography/tls13_server/module.ae
@@ -513,7 +513,7 @@ parse_cert_chain_pem(pem_text: string) -> (ptr, ptr) {
         if e < 0 { break }
         block_end = e + mlen
         block = string.substring_n(pem_text, tlen, pos, block_end)
-        der, label, perr = pem.parse(block)
+        der, _label, perr = pem.parse(block)
         if string.equals(perr, "") == 1 && der != null {
             list_add_raw(chain, der)
             list_add_raw(lens, null)

--- a/tests/integration/asn1_oid_and_cert_validation/probe.ae
+++ b/tests/integration/asn1_oid_and_cert_validation/probe.ae
@@ -1,0 +1,121 @@
+// asn1.encode_oid refuses input that is not an OID (#1947), and the X.509
+// TBSCertificate parse refuses a certificate whose fields it could not read
+// (#1942).
+//
+// Both had the same shape: an error was available and not consulted, so the
+// caller got a confident answer built from a failed read. encode_oid returned
+// DER that decodes as a DIFFERENT identifier than the caller named -- a
+// function reached with strings from configuration. parse_certificate filled
+// a LeafCert's issuer, subject, validity or SPKI from reads that failed.
+
+import std.cryptography.asn1
+import std.cryptography.tls13_cert
+import std.bytes
+import std.string
+import std.io
+
+extern exit(code: int)
+
+// Returns 1 on failure so main can total them.
+oid_case(label: string, dotted: string, want_ok: int) -> int {
+    r = asn1.encode_oid(dotted)
+    ok = 0
+    if r != null { ok = 1 }
+    if ok != want_ok {
+        println("  FAIL encode_oid(\"${dotted}\") [${label}]: accepted=${ok}, want ${want_ok}")
+        return 1
+    }
+    return 0
+}
+
+main() {
+    fails = 0
+    // --- #1947: encode_oid rejects non-OIDs --------------------------------
+    // Each of these used to encode successfully, as a different identifier.
+    fails = fails + oid_case("empty string", "", 0)
+    fails = fails + oid_case("single arc has nothing to fold", "1", 0)
+    fails = fails + oid_case("empty middle arc", "1..2", 0)
+    fails = fails + oid_case("trailing dot", "1.2.", 0)
+    fails = fails + oid_case("leading dot", ".1.2", 0)
+    fails = fails + oid_case("non-digit arc", "1.2.x", 0)
+    fails = fails + oid_case("letter alone", "x", 0)
+    // X.660: the first arc is 0, 1 or 2, and under 0/1 the second is < 40.
+    // Outside that, 40*arc1 + arc2 lands in another arc's range.
+    fails = fails + oid_case("first arc out of range", "3.2.1", 0)
+    fails = fails + oid_case("second arc over 39 under arc 1", "1.40.1", 0)
+
+    // Real OIDs keep working.
+    fails = fails + oid_case("rsaEncryption", "1.2.840.113549.1.1.1", 1)
+    fails = fails + oid_case("subjectAltName", "2.5.29.17", 1)
+    fails = fails + oid_case("two arcs is the minimum", "1.2", 1)
+    // Under arc 2 the folded first subidentifier exceeds 127 and needs
+    // base128; a one-byte store used to truncate it into another OID.
+    fails = fails + oid_case("large second arc under arc 2", "2.999.3", 1)
+
+    // The folding is the encoding's, so check the bytes, not just non-null.
+    // 2.999.3 -> first subidentifier 40*2+999 = 1079 -> 0x88 0x37, then 0x03.
+    big = asn1.encode_oid("2.999.3")
+    if big == null {
+        println("  FAIL 2.999.3 was refused")
+        fails = fails + 1
+    } else {
+        n = bytes.length(big)
+        // TLV: tag 0x06, length 3, then the three content bytes.
+        if n != 5 {
+            println("  FAIL 2.999.3 encoded to ${n} bytes, want 5")
+            fails = fails + 1
+        } else {
+            if bytes.get(big, 0) != 0x06 { println("  FAIL 2.999.3 tag"); fails = fails + 1 }
+            if bytes.get(big, 2) != 0x88 { println("  FAIL 2.999.3 byte0 = ${bytes.get(big, 2)}, want 136"); fails = fails + 1 }
+            if bytes.get(big, 3) != 0x37 { println("  FAIL 2.999.3 byte1 = ${bytes.get(big, 3)}, want 55"); fails = fails + 1 }
+            if bytes.get(big, 4) != 0x03 { println("  FAIL 2.999.3 byte2 = ${bytes.get(big, 4)}, want 3"); fails = fails + 1 }
+        }
+    }
+
+    // --- #1942: a malformed certificate is refused ------------------------
+    // A TBSCertificate whose fields run off the end of the buffer. Every
+    // dropped error meant this parsed "successfully" with fields taken from
+    // reads that failed.
+    leaf = tls13_cert.LeafCert { tbs: null, tbs_len: 0, sig_alg_oid: null, signature: null, signature_len: 0, spki_algo_oid: null, spki_key: null, spki_key_len: 0, issuer: null, issuer_len: 0, subject: null, subject_len: 0, not_before: null, not_before_len: 0, not_after: null, not_after_len: 0, dns_names: null }
+
+    // A WELL-FORMED outer Certificate and TBSCertificate whose TBS content
+    // simply ends after serialNumber. Every length is honest, so the outer
+    // parse succeeds and the failure lands exactly where it must: on the
+    // `signature AlgorithmIdentifier` read and the issuer / validity /
+    // subject / SPKI reads after it, which are the six that dropped their
+    // error. A cert malformed at the OUTER layer would be refused before
+    // reaching them and would prove nothing about this fix.
+    //
+    //   30 0A                Certificate SEQUENCE, 10 bytes
+    //      30 08             TBSCertificate SEQUENCE, 8 bytes
+    //         A0 03 02 01 02    [0] version = 2
+    //         02 01 05          serialNumber = 5
+    //      <TBS content ends here: no signature, issuer, validity, ...>
+    der = bytes.new(0)
+    bytes.set(der, 0, 0x30)
+    bytes.set(der, 1, 0x0A)
+    bytes.set(der, 2, 0x30)
+    bytes.set(der, 3, 0x08)
+    bytes.set(der, 4, 0xA0)
+    bytes.set(der, 5, 0x03)
+    bytes.set(der, 6, 0x02)
+    bytes.set(der, 7, 0x01)
+    bytes.set(der, 8, 0x02)
+    bytes.set(der, 9, 0x02)
+    bytes.set(der, 10, 0x01)
+    bytes.set(der, 11, 0x05)
+
+    perr = tls13_cert.parse_certificate(der, 12, &leaf)
+    if string.equals(perr, "") == 1 {
+        println("  FAIL a certificate whose TBS ends after serialNumber parsed successfully")
+        fails = fails + 1
+    }
+    tls13_cert.free_leaf(&leaf)
+
+    if fails == 0 {
+        println("All OID and certificate validation cases pass")
+    } else {
+        println("${fails} failure(s)")
+        exit(1)
+    }
+}

--- a/tests/integration/asn1_oid_and_cert_validation/test_asn1_oid_and_cert_validation.sh
+++ b/tests/integration/asn1_oid_and_cert_validation/test_asn1_oid_and_cert_validation.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# asn1.encode_oid refuses non-OIDs (#1947) and the X.509 TBSCertificate parse
+# refuses a certificate whose fields it could not read (#1942).
+#
+# Both bugs were an available error going unread, so the caller received a
+# confident answer assembled from a failed read: DER that decodes as a
+# different identifier than the caller named, and a LeafCert whose issuer,
+# subject, validity or SPKI came from reads that did not succeed.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] asn1_oid_and_cert_validation: build/ae missing"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! AETHER_HOME="$ROOT" "$AE" build "$SCRIPT_DIR/probe.ae" -o "$TMP/probe" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] asn1_oid_and_cert_validation: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -15
+    exit 1
+fi
+
+if ! "$TMP/probe" > "$TMP/run.out" 2>&1; then
+    echo "  [FAIL] asn1_oid_and_cert_validation: probe reported failures"
+    sed 's/^/        /' "$TMP/run.out" | head -20
+    exit 1
+fi
+
+grep -q "All OID and certificate validation cases pass" "$TMP/run.out" || {
+    echo "  [FAIL] asn1_oid_and_cert_validation: probe did not reach the end"
+    sed 's/^/        /' "$TMP/run.out" | head -20
+    exit 1
+}
+
+echo "  [PASS] asn1_oid_and_cert_validation: non-OIDs and unreadable certificates are refused"
+exit 0

--- a/tests/integration/float_scientific_notation/probe.ae
+++ b/tests/integration/float_scientific_notation/probe.ae
@@ -44,7 +44,7 @@ main() {
 
     // Comparison position: the report's original repro.
     v = 2.0
-    if v < 1.0e30 { } else { fail("2.0 < 1.0e30 was false") }
+    if v >= 1.0e30 { fail("2.0 < 1.0e30 was false") }
 
     // The statement AFTER a scientific literal must survive. When the
     // exponent lexed as an identifier this line was swallowed into the

--- a/tests/integration/float_scientific_notation/probe.ae
+++ b/tests/integration/float_scientific_notation/probe.ae
@@ -1,0 +1,78 @@
+// Float literals in scientific notation are one token (#1954).
+//
+// `1.0e30` used to lex as the float `1.0` followed by the identifier `e30`.
+// In expression position that surfaced as "undefined variable 'e30'"; in
+// statement position it silently swallowed the FOLLOWING line into the
+// expression, so a program lost a statement and still compiled clean. That
+// second shape is why this is a correctness bug and not an ergonomics one.
+//
+// Two halves had to agree: the lexer consumes the exponent, and the literal
+// classifier in type inference treats `e`/`E` as making the number a float.
+// Without the second, `1e30` is not classified as a number at all.
+//
+// The negative half matters as much: hex (`0x1E` contains an E), durations
+// (`500ms`), and ranges (`1..4`) must lex exactly as they did.
+
+import std.io
+import std.string
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("  FAIL: ${msg}")
+    exit(1)
+}
+
+main() {
+    // Every spelling from the report.
+    a = 1.0e30
+    b = 1e30
+    c = 1.5E-3
+    d = 2.0e+8
+
+    if a != b { fail("1.0e30 != 1e30") }
+    if a < 9.9e29 { fail("1.0e30 came out too small") }
+    if a > 1.1e30 { fail("1.0e30 came out too large") }
+
+    // 1.5E-3 is 0.0015: uppercase E and a negative exponent.
+    if c > 0.0016 { fail("1.5E-3 too large") }
+    if c < 0.0014 { fail("1.5E-3 too small") }
+
+    // 2.0e+8 is 200000000: an explicit + sign.
+    if d > 200000001.0 { fail("2.0e+8 too large") }
+    if d < 199999999.0 { fail("2.0e+8 too small") }
+
+    // Comparison position: the report's original repro.
+    v = 2.0
+    if v < 1.0e30 { } else { fail("2.0 < 1.0e30 was false") }
+
+    // The statement AFTER a scientific literal must survive. When the
+    // exponent lexed as an identifier this line was swallowed into the
+    // expression above and never ran.
+    reached = 0
+    _x = 1.0e30
+    reached = 1
+    if reached != 1 { fail("the statement after a scientific literal was lost") }
+
+    // --- the forms that must NOT have changed ---
+
+    // Hex: the E in 0x1E is a hex digit, not an exponent.
+    h = 0x1E
+    if h != 30 { fail("0x1E is ${h}, want 30") }
+
+    // A duration keeps its unit suffix.
+    dur = 500ms
+    if dur.ms != 500 { fail("500ms is ${dur.ms}ms, want 500") }
+
+    // A range's dots are not part of the number.
+    sum = 0
+    for i in 1..4 { sum = sum + i }
+    if sum != 6 { fail("1..4 summed to ${sum}, want 6") }
+
+    // An `e` that is not an exponent is still an identifier.
+    e = 7
+    one = 1
+    if e + one != 8 { fail("bare identifier 'e' broke") }
+
+    println("All scientific-notation cases pass")
+}

--- a/tests/integration/float_scientific_notation/test_float_scientific_notation.sh
+++ b/tests/integration/float_scientific_notation/test_float_scientific_notation.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Float literals in scientific notation are one token (#1954).
+#
+# The probe asserts the values, and this asserts the two shapes that made the
+# bug hard to see: the compile is CLEAN (the misparse used to leave a
+# spurious "unused variable 'println'" behind, because the call on the next
+# line was swallowed into the expression), and a binary is actually produced
+# (the misparse ended compilation without one).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] float_scientific_notation: build/ae missing"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! AETHER_HOME="$ROOT" "$AE" build "$SCRIPT_DIR/probe.ae" -o "$TMP/probe" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] float_scientific_notation: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -15
+    exit 1
+fi
+
+# A binary, not just a clean exit. The misparse ended compilation with no
+# artifact while reporting only a warning.
+[ -x "$TMP/probe" ] || { echo "  [FAIL] float_scientific_notation: no binary produced"; exit 1; }
+
+# No warnings. `println` reported as an unused VARIABLE is the fingerprint of
+# the statement being swallowed into the line above.
+if grep -q "^warning" "$TMP/build.log"; then
+    echo "  [FAIL] float_scientific_notation: the build warned"
+    grep -A2 "^warning" "$TMP/build.log" | sed 's/^/        /' | head -8
+    exit 1
+fi
+
+if ! "$TMP/probe" > "$TMP/run.out" 2>&1; then
+    echo "  [FAIL] float_scientific_notation: probe reported a failure"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+fi
+grep -q "All scientific-notation cases pass" "$TMP/run.out" || {
+    echo "  [FAIL] float_scientific_notation: probe did not reach the end"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+}
+
+echo "  [PASS] float_scientific_notation: every exponent spelling lexes as one number"
+exit 0

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -8060,9 +8060,12 @@ static int cmd_cflags(int argc, char** argv) {
          * `gcc your.c $(ae cflags)` recipe is right even on an install whose
          * include list came back empty.
          *
-         * +1 skips the macro's leading space: it is written to be appended to
-         * an existing flag string, and here it starts the line. */
-        fputs(AETHER_WRAP_CFLAGS + 1, stdout);
+         * &[1] skips the macro's leading space: it is written to be appended
+         * to an existing flag string, and here it starts the line. Indexed
+         * rather than `+ 1`, which clang reads as the string-plus-integer
+         * mistake and warns about (-Wstring-plus-int); the intent is the same
+         * and this spelling states it. */
+        fputs(&AETHER_WRAP_CFLAGS[1], stdout);
         wrote_anything = 1;
         if (tc.include_flags[0]) {
             fputc(' ', stdout);


### PR DESCRIPTION
Six correctness bugs, from the three open issues that are defects rather than proposals. Each one is a case where an answer was produced from information the code already knew was wrong.

## `1.0e30` was two tokens (#1954)

A float literal in scientific notation lexed as the float `1.0` followed by the identifier `e30`. In expression position that surfaced as `undefined variable 'e30'`, which is the good case. In statement position it misparsed **silently**:

```aether
x = 1.0e30
println("${x}")     // swallowed into the line above
```

reported only `warning[W1001]: unused variable 'println'` and produced no binary. A program that loses a statement and still compiles is the reason this is filed as a correctness bug.

Two halves had to agree, and fixing either alone leaves it broken:

1. **The lexer** consumes `e`/`E`, an optional sign, and at least one digit.
2. **The literal classifier** treats an exponent as making the number a float. Without this, `1e30` is not classified as a number *at all* -- the letter fell to the branch that clears `is_number` and breaks.

The full shape is required before anything is consumed, so a bare `e`, `0x1E` (hex, where `E` is a digit), `500ms` (durations) and `1..4` (ranges) lex exactly as before. All four are asserted.

## `asn1.encode_oid` encoded things that are not OIDs (#1947)

`""`, `"1"`, `"1..2"`, `"1.2."`, `".1.2"` and `"1.2.x"` each produced well-formed DER that decodes as a **different identifier than the caller named**. That is worse than refusing the input, and this is a function callers reach with strings from configuration.

The `have` flag that catches the empty-arc cases was already in the function -- set, cleared, and never read. It now rejects a non-digit, an empty arc, a first arc outside 0..2, a second arc over 39 under arcs 0 and 1, and fewer than two arcs.

One more, found while writing the test: the folded first subidentifier was stored as a **single byte**. Under arc 2 it exceeds 127 (`2.999` folds to 1079), so a legitimate OID was silently truncated into a different one. It is emitted base128 now, and the test asserts the bytes (`88 37 03`), not just that the call succeeded.

## The X.509 parser accepted certificates it could not read (#1942)

`parse_tbs_fields` dropped the error from six TBSCertificate reads -- version, signature algorithm, issuer, validity, subject, subjectPublicKeyInfo -- and stored whatever the failed read returned:

```aether
iss, ierr = read_tlv_full(tbsr)   // ierr never read
out.issuer = iss
out.issuer_len = bytes.length(iss)
```

A truncated or malformed certificate therefore parsed **successfully** into a `LeafCert` whose issuer, subject, validity or SPKI came from a read that did not succeed. The serialNumber and notBefore/notAfter reads in the same function already checked; these six now do too, freeing the buffer on the paths where `out` does not take ownership.

## Three digest wrappers used a context they were told not to (#1947, #1942)

`ed25519.sha512`, `ed448.shake` and `rsa.sha256b` ignored the error from `sha2.new` / `sha3.new`, which answer `(null, "allocation failed")`, and handed the null context to `update_bytes`. The rest of the family checked.

## Smaller, same shape

- `tls13_client` discarded the reason `trust_store_load` gave and reported a bare "cannot load trust store" for a missing file, an unreadable one, and one nothing parsed out of.
- **56 unused-variable warnings across the stdlib are gone** (48 distinct sites in `tls13_cert`, `tls13_client`, `pem`, `tls13_server`). `ae check` over all 140 stdlib modules now reports **zero**, down from 56.
- A pre-existing `-Wstring-plus-int` warning in the `ae cflags` path, fixed at the spelling rather than suppressed: `&AETHER_WRAP_CFLAGS[1]` says what `AETHER_WRAP_CFLAGS + 1` meant.

## Verification

Both new tests were mutation-checked by reintroducing the defect:

| Mutation | Result |
| --- | --- |
| Revert `encode_oid` validation | 10 cases fail |
| Revert the six TBS error checks | a certificate whose TBS ends after serialNumber parses successfully |
| Revert the lexer half | `1.0e30` misparses again |

The malformed certificate is deliberately **well-formed at the outer layer**. My first attempt was malformed at the Certificate SEQUENCE, so it was refused before ever reaching the six reads -- the mutation check passed against it and proved nothing. The one used now has honest lengths and a TBS that simply ends after serialNumber, which is what puts the failure on the reads under test.

| Suite | Result |
| --- | --- |
| Unit | 409/409 |
| Examples | 90/90 |
| TLS/crypto suites (cert, cert_p384, client, hs, server_hs, rsa_oaep_pss, ed25519, curves2) | all pass |
| `ae check` across 140 stdlib modules | 0 warnings (was 56) |
| Build | 0 warnings |

Closes #1954
Closes #1947
Closes #1942

🤖 Generated with [Claude Code](https://claude.com/claude-code)