### PR TITLE
fix(ae): forward `--` args on a cache hit, not just on a cold build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`ae run prog.ae -- args` dropped the arguments on every run after the
+  first.** `ae run` runs the cached exe when it has one, and that path ran it
+  bare: the arguments reached the program on the cold build and silently
+  vanished from then on, which is exactly the shape a config-is-code entry
+  point (`ae run supervisor.ae -- make -j8`) runs in. The cache-hit path now
+  builds the same command as the cold path, through one shared helper, so it
+  also regains the signal forwarding and the `AE_TEST_RUNNER` prefix it was
+  missing. The integration test now covers the cached run, not just the cold
+  one.
+
+- **A test that timed out under load reported a startup that had succeeded.**
+  The script-gateway integration test waited 5s for its host to print `READY`
+  while the rest of the suite waits 15s, so the parallel sweep could load the
+  box past its deadline. Raised to the suite's deadline.
+
+- One pre-existing `-Wstring-plus-int` warning in `ae cflags`, where a leading
+  space is skipped with pointer arithmetic on a string literal. Written as an
+  array index instead, which says the same thing unambiguously.
+
 ## [0.654.0]
 
 ### Fixed

--- a/tests/integration/http_script_gateway/test_http_script_gateway.sh
+++ b/tests/integration/http_script_gateway/test_http_script_gateway.sh
@@ -116,8 +116,11 @@ fi
 "$TMPDIR/host" "$PORT" "$SO_PATH" >"$TMPDIR/host.log" 2>&1 &
 HOST_PID=$!
 
-# Poll the listener — expect READY in the host's log within 5s.
-deadline=$(($(date +%s) + 5))
+# Poll the listener — expect READY in the host's log. 15s, the deadline the
+# rest of the integration suite uses: this ran with 5s and timed out whenever
+# the parallel sweep loaded the box, reporting a startup that had in fact
+# succeeded. A deadline costs nothing when the host starts promptly.
+deadline=$(($(date +%s) + 15))
 ready=0
 while [ "$(date +%s)" -lt "$deadline" ]; do
     if grep -q '^READY$' "$TMPDIR/host.log" 2>/dev/null; then
@@ -138,7 +141,7 @@ if [ "$ready" != "1" ]; then
 fi
 
 # Need a few more ms for the listen socket to actually accept.
-deadline=$(($(date +%s) + 5))
+deadline=$(($(date +%s) + 15))
 while [ "$(date +%s)" -lt "$deadline" ]; do
     if curl -s -o /dev/null --max-time 1 --connect-timeout 0.3 "$URL/static" 2>/dev/null; then
         break

--- a/tests/integration/run_arg_forwarding/test_run_arg_forwarding.sh
+++ b/tests/integration/run_arg_forwarding/test_run_arg_forwarding.sh
@@ -9,6 +9,10 @@
 #   2. A single arg containing spaces stays ONE token (double-quoted
 #      through run_cmd's tokenizer), not split.
 #   3. No `--` → no forwarded args (argc == 1).
+#   4. A CACHE HIT forwards them too. `ae run` runs the cached exe on the
+#      second invocation, and that path used to run it bare: the args
+#      reached the program the first time and silently vanished every time
+#      after, which is the shape a supervisor entry point actually runs in.
 
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -17,6 +21,12 @@ AE="$ROOT/build/ae"
 MAIN="$SCRIPT_DIR/main.ae"
 
 fail() { echo "  FAIL: $1"; exit 1; }
+
+# A private cache, so this test controls cold vs warm without touching the
+# shared one the rest of the parallel sweep is using.
+TMPDIR_T=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_T"' EXIT
+export AETHER_CACHE_DIR="$TMPDIR_T/cache"
 
 # --- Case 1 + 2: forward three args, the middle one with a space -------
 out=$("$AE" run "$MAIN" -- alpha "beta gamma" delta 2>&1)
@@ -30,4 +40,10 @@ echo "$out" | grep -qx "ARG:delta"      || fail "missing ARG:delta"
 out2=$("$AE" run "$MAIN" 2>&1)
 echo "$out2" | grep -q "argc=1" || fail "expected argc=1 with no '--', got: $(echo "$out2" | grep argc)"
 
-echo "  PASS: ae run forwards post-'--' args (spaces preserved); none without '--'"
+# --- Case 4: same command again, now a cache hit ----------------------
+out3=$("$AE" run "$MAIN" -- alpha "beta gamma" delta 2>&1)
+
+echo "$out3" | grep -q "argc=4" || fail "cache hit dropped the forwarded args, got: $(echo "$out3" | grep argc)"
+echo "$out3" | grep -qx "ARG:beta gamma" || fail "cache hit split or lost the spaces-arg"
+
+echo "  PASS: ae run forwards post-'--' args cold and cached (spaces preserved); none without '--'"

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -3809,6 +3809,34 @@ static void prepare_host_bridge_imports(const char* main_file) {
 // Commands
 // --------------------------------------------------------------------------
 
+/* Build the command that runs a program `ae run` just produced or found in
+ * the cache: the exe, then every post-`--` argument, each double-quoted so an
+ * argument containing spaces stays one token through run_cmd's tokenizer
+ * (posix_run / win_run). Arguments containing a literal double-quote are not
+ * representable through this path, rare for a build command line; build the
+ * binary and invoke it directly if you need that.
+ *
+ * AE_TEST_RUNNER, when set, is spliced in ahead of the exe so the program runs
+ * under a wrapper (wine, qemu-user, ...). Empty by default, see
+ * test_runner_prefix().
+ *
+ * CRITICAL: the cache-hit and cache-miss paths must both go through this. A
+ * cache hit that ran the exe bare dropped every forwarded argument, so
+ * `ae run supervisor.ae -- make -j8` worked once and then silently ran with an
+ * empty argv on every later invocation. */
+static void build_run_cmd(char* cmd, size_t cap, const char* exe,
+                          int argc, char** argv, int prog_args_start) {
+    const char* runner = test_runner_prefix();
+    snprintf(cmd, cap, "%s%s\"%s\"", runner, *runner ? " " : "", exe);
+    if (prog_args_start < 0) return;
+    size_t off = strlen(cmd);
+    for (int i = prog_args_start; i < argc && off < cap - 1; i++) {
+        int w = snprintf(cmd + off, cap - off, " \"%s\"", argv[i]);
+        if (w < 0 || (size_t)w >= cap - off) break;  /* truncated, stop cleanly */
+        off += (size_t)w;
+    }
+}
+
 static int cmd_run(int argc, char** argv) {
     const char* file = NULL;
     /* 8 KiB matches toml_extra below + the fgets line buffer in
@@ -3926,8 +3954,8 @@ static int cmd_run(int argc, char** argv) {
         snprintf(cached_exe, sizeof(cached_exe), "%s/%016llx" EXE_EXT, s_cache_dir, cache_key);
         if (path_exists(cached_exe)) {
             if (tc.verbose) fprintf(stderr, "[cache] hit: %016llx\n", cache_key);
-            snprintf(cmd, sizeof(cmd), "%s", cached_exe);
-            int rc = run_cmd(cmd);
+            build_run_cmd(cmd, sizeof(cmd), cached_exe, argc, argv, prog_args_start);
+            int rc = run_cmd_forwarding(cmd);
             if (rc < 0) {
                 fprintf(stderr, "Program crashed (signal %d", -rc);
                 if (-rc == 11) fprintf(stderr, ": segmentation fault");
@@ -4053,29 +4081,8 @@ static int cmd_run(int argc, char** argv) {
         }
     }
 
-    // Step 3: Run, forwarding any post-`--` args to the program. Each is
-    // wrapped in double quotes so a single arg with spaces stays one
-    // token through run_cmd's tokenizer (posix_run / win_run). Args
-    // containing a literal double-quote aren't representable through this
-    // path — rare for a build command line; build the binary and invoke
-    // it directly if you need that.
-    //
-    // AE_TEST_RUNNER, when set, is spliced in ahead of the exe so the
-    // program runs under a wrapper (wine, qemu-user, ...). Empty by
-    // default — see test_runner_prefix().
-    {
-        const char* runner = test_runner_prefix();
-        snprintf(cmd, sizeof(cmd), "%s%s\"%s\"",
-                 runner, *runner ? " " : "", exe_file);
-    }
-    if (prog_args_start >= 0) {
-        size_t off = strlen(cmd);
-        for (int i = prog_args_start; i < argc && off < sizeof(cmd) - 1; i++) {
-            int w = snprintf(cmd + off, sizeof(cmd) - off, " \"%s\"", argv[i]);
-            if (w < 0 || (size_t)w >= sizeof(cmd) - off) break;  /* truncated — stop cleanly */
-            off += (size_t)w;
-        }
-    }
+    // Step 3: run it, forwarding any post-`--` args (see build_run_cmd).
+    build_run_cmd(cmd, sizeof(cmd), exe_file, argc, argv, prog_args_start);
     int rc = run_cmd_forwarding(cmd);
 
     if (rc < 0) {
@@ -8062,7 +8069,7 @@ static int cmd_cflags(int argc, char** argv) {
          *
          * +1 skips the macro's leading space: it is written to be appended to
          * an existing flag string, and here it starts the line. */
-        fputs(AETHER_WRAP_CFLAGS + 1, stdout);
+        fputs(&AETHER_WRAP_CFLAGS[1], stdout);
         wrote_anything = 1;
         if (tc.include_flags[0]) {
             fputc(' ', stdout);


### PR DESCRIPTION
## The bug

`ae run prog.ae -- alpha beta` passed the arguments through the first time and dropped them on every run after that:

```
$ ae run main.ae -- alpha "beta gamma" delta   # cold cache
argc=4
$ ae run main.ae -- alpha "beta gamma" delta   # cached
argc=1
```

`ae run` executes the cached exe when it has one, and that path ran it bare. The failure therefore only appears on the second invocation, so a config-is-code entry point (`ae run supervisor.ae -- make -j8`), the use case the forwarding was added for, ran with an empty argv in every real session after the first.

## Fix

Both paths now build the command through one `build_run_cmd` helper. The cache hit regains, alongside the arguments, two other things it was quietly missing by not sharing the cold path's code:

- the signal forwarding that lets Ctrl-C and SIGTERM reach the child (`run_cmd_forwarding`, not `run_cmd`),
- the `AE_TEST_RUNNER` prefix that runs the program under wine or qemu-user.

## Why the test did not catch it

The integration test asserted only the cold run, so it went green whenever the sweep happened to reach it with a cold cache, and red when it did not. That order dependence is what surfaced the bug. It now runs the same command twice against a private `AETHER_CACHE_DIR`, so it exercises cold and warm deterministically without touching the shared cache the parallel sweep uses.

Confirmed the extended test fails against unpatched `ae` (`FAIL: cache hit dropped the forwarded args, got: argc=1`) and passes with the fix.

## Two more reliability fixes found in the same sweep

- **A test that timed out under load reported a startup that had succeeded.** The script-gateway test waited 5s for its host to print `READY` while 33 other integration tests wait 15s. Under the parallel sweep the box could pass that deadline, and the failure dump then printed a log that already contained `READY`. Raised to the suite's deadline.
- **One pre-existing `-Wstring-plus-int` warning** in `ae cflags`, where a leading space is skipped with pointer arithmetic on a string literal. Written as an array index, which says the same thing unambiguously. `make ae` is now warning-free.

## Verification

409 C tests, 1088 `.ae` tests, 90 examples: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)