### PR TITLE
changelog: correct 0.655.0's stdlib warning-clean overclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,11 +138,12 @@ version number before tagging the release.
   bare "cannot load trust store" for a missing file, an unreadable one, and one
   nothing parsed out of. The reason is now included.
 
-- **56 unused-variable warnings across the stdlib are gone** (#1942), 48
+- **56 unused-variable warnings across the crypto stdlib are gone** (#1942), 48
   distinct sites in `tls13_cert`, `tls13_client`, `pem` and `tls13_server`.
   They were invisible until warnings gained a location, because a warning
   raised inside an imported module was reported against the importing file.
-  `ae check` over every stdlib module now reports zero.
+  Those four modules now report zero; the sweep of the remaining non-crypto
+  modules follows in 0.656.0.
 
 - **The `ae cflags` build emitted a `-Wstring-plus-int` warning.** The
   intentional `AETHER_WRAP_CFLAGS + 1` that skips the macro's leading space is


### PR DESCRIPTION
## What

The `[0.655.0]` CHANGELOG entry for #1942 claimed:

> `ae check` over every stdlib module now reports zero.

That was an overclaim. 0.655.0's sweep (from the #1961 high-priority-correctness batch) had only visited the four **crypto** modules — `tls13_cert`, `tls13_client`, `pem`, `tls13_server`. Seven non-crypto sites (`cbor`, `sm3`, `number` ×2, `tar`, `worker`, and one more `tls13_client` site) were still live, and the **`[0.656.0]`** entry already says exactly that ("the sweep had only visited the crypto modules"). So the 0.655.0 line directly contradicted the next release.

## Fix

Scope the 0.655.0 claim to the four crypto modules it actually cleared, and forward-reference 0.656.0 for the rest — so the two entries read as the two halves of the same story instead of contradicting each other. Wording only; the "56 warnings / 48 distinct sites" facts are unchanged and correct.

Editing a released section after its tag is the CHANGELOG gate's explicitly-permitted case (it compares against `origin/main`, not the tag): only `[0.655.0]` differs, every other released section is byte-for-byte unchanged, and `[current]` stays empty.

Doc-only — the branch commit carries `[skip actions]` (no code, no release note to fold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)