### PR TITLE
fix(compiler): widen an inferred parameter to the widest call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A parameter inferred from call sites took the first call site's type and
+  truncated every later one** (#1972). `propagate_call_types_in_tree` wrote the
+  parameter's type once and ignored the rest, so `f(2)` followed by
+  `f(9000000000)` pinned the parameter to `int` and printed 410065409 instead
+  of 9000000001. `ae check` reported no errors, and the answer depended on the
+  order of the call sites: `f(3)` then `f(1.5)` truncated, while `f(1.5)` then
+  `f(3)` was correct, for the same program. The parameter now takes the widest
+  numeric kind any call site supplies, which is the direction that cannot lose
+  information. Widening only, and only among the ranked numeric kinds, so an
+  incompatible pair is still left for the type checker; signed and unsigned
+  64-bit share a rank and do not widen into each other, because that swap
+  changes what a value means rather than how much of it fits.
+
 ## [0.658.0]
 
 ### Fixed

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -1162,6 +1162,33 @@ void report_ambiguous_types(InferenceContext* ctx) {
 int propagate_function_call_types(ASTNode* program, SymbolTable* table);
 int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* func_def, int param_count);
 
+/* Widening rank for the call-site parameter unification below.
+ *
+ * A parameter whose type is inferred from call sites used to keep whatever
+ * the FIRST call site said and ignore every later one, so `f(2)` followed by
+ * `f(9000000000)` pinned the parameter to `int` and truncated the second
+ * argument to 410065409 -- a wrong number, order-dependent, with `ae check`
+ * reporting no errors (#1972). Ranking the numeric kinds lets a later, wider
+ * call site win, which is the direction that cannot lose information.
+ *
+ * 0 means "not a numeric kind this may widen through": those are left to the
+ * first-writer rule, so nothing silently reinterprets a pointer or a string.
+ * Signed and unsigned 64-bit share a rank deliberately -- neither widens into
+ * the other, because that swap changes what a value means rather than how
+ * much of it fits. */
+static int param_widening_rank(TypeKind k) {
+    switch (k) {
+        case TYPE_BYTE:       return 1;
+        case TYPE_INT:        return 2;
+        case TYPE_INT64:      return 3;
+        case TYPE_UINT64:     return 3;
+        case TYPE_FLOAT32:    return 4;
+        case TYPE_FLOAT:      return 5;
+        case TYPE_LONGDOUBLE: return 6;
+        default:              return 0;
+    }
+}
+
 // Helper to recursively find function calls and propagate types
 int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* func_def, int param_count) {
     if (!tree || !func_name) return 0;
@@ -1205,7 +1232,30 @@ int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* 
                     arg->node_type && arg->node_type->kind != TYPE_UNKNOWN) {
                     if (param->node_type) free_type(param->node_type);
                     param->node_type = clone_type(arg->node_type);
+                    /* Record that THIS pass supplied the type. Only a type we
+                     * inferred may be widened below; one the author wrote is
+                     * authoritative, and widening it would change documented
+                     * semantics -- `expect(got: int, ...)` relies on `int`
+                     * wrapping at 32 bits, and promoting it to int64 stops the
+                     * wrap the test exists to check. */
+                    param->type_inferred = 1;
                     changed++;
+                } else if (param->type_inferred && param->node_type && arg && arg->node_type) {
+                    /* Already pinned by an earlier call site. Take the wider
+                     * numeric kind rather than keeping whichever was seen
+                     * first: the narrow one truncates this argument, and
+                     * which call site the compiler happens to reach first is
+                     * not something the author controls (#1972). Only widens,
+                     * only among the ranked numeric kinds, and only over a
+                     * type this pass inferred, so an annotated parameter and a
+                     * genuinely incompatible pair are both left alone. */
+                    int cur = param_widening_rank(param->node_type->kind);
+                    int inc = param_widening_rank(arg->node_type->kind);
+                    if (cur > 0 && inc > cur) {
+                        free_type(param->node_type);
+                        param->node_type = clone_type(arg->node_type);
+                        changed++;
+                    }
                 }
             }
         }

--- a/compiler/ast.h
+++ b/compiler/ast.h
@@ -483,13 +483,18 @@ typedef struct ASTNode {
                                // synthetic nodes the parser/typechecker invent
                                // out of thin air; codegen falls back to the last
                                // known file in that case.
-    int type_inferred;         // AST_VARIABLE_DECLARATION only: 1 when the
+    int type_inferred;         // AST_VARIABLE_DECLARATION: 1 when the
                                // declaration had NO explicit type annotation
                                // (Python-style `x = expr`), so its type is
                                // inferred from the initializer. Survives the
                                // pre-typecheck inference that fills node_type,
                                // unlike a TYPE_UNKNOWN sentinel. Drives the
                                // #698 silent-narrowing guard.
+                               // Also set on a function PARAMETER whose type
+                               // was supplied by call-site propagation rather
+                               // than written down, which is the same
+                               // distinction: only an inferred parameter may
+                               // be widened by a later call site (#1972).
 
     /* Allocated slots in `children`. Only add_child maintains this;
      * code that replaces the array wholesale resets it to 0, which

--- a/tests/integration/param_inference_widening/probe.ae
+++ b/tests/integration/param_inference_widening/probe.ae
@@ -1,0 +1,54 @@
+// A parameter inferred from call sites takes the WIDEST numeric kind any
+// call site supplies, not whichever one the compiler reached first (#1972).
+//
+// Before this, propagate_call_types_in_tree wrote the parameter's type once
+// and ignored every later call site. `f(2)` followed by `f(9000000000)`
+// pinned the parameter to `int`, truncated the second argument, and printed
+// 410065409. `ae check` reported no errors, and moving the two calls past
+// each other changed the answer -- the float-first spelling was right and the
+// int-first spelling was wrong, for the same program.
+//
+// Widening is the direction that cannot lose information, which is why the
+// fix widens rather than picking a winner.
+
+import std.io
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("  FAIL: ${msg}")
+    exit(1)
+}
+
+// Inferred from its call sites: int at one, int64 at another.
+bump(a) { return a + 1 }
+
+// Inferred int at one call site, float at another.
+twice(a) { return a * 2 }
+
+// The issue's own repro, with two parameters.
+add(a, b) { return a + b }
+
+main() {
+    // int64 after int. The narrow spelling truncated to 32 bits.
+    small = bump(2)
+    big = bump(9000000000)
+    if small != 3 { fail("bump(2) = ${small}, want 3") }
+    if big != 9000000001 { fail("bump(9000000000) = ${big}, want 9000000001") }
+
+    // float after int. 1.5 * 2 is 3, not 2.
+    i2 = twice(3)
+    f2 = twice(1.5)
+    if i2 != 6.0 { fail("twice(3) = ${i2}, want 6") }
+    if f2 < 2.9 { fail("twice(1.5) = ${f2}, want 3 -- the argument was truncated") }
+    if f2 > 3.1 { fail("twice(1.5) = ${f2}, want 3") }
+
+    // Two parameters, both widened. This is the report's first example.
+    x = add(1, 2)
+    y = add(1.5, 2.5)
+    if x != 3.0 { fail("add(1, 2) = ${x}, want 3") }
+    if y < 3.9 { fail("add(1.5, 2.5) = ${y}, want 4 -- both arguments truncated") }
+    if y > 4.1 { fail("add(1.5, 2.5) = ${y}, want 4") }
+
+    println("All parameter-widening cases pass")
+}

--- a/tests/integration/param_inference_widening/test_param_inference_widening.sh
+++ b/tests/integration/param_inference_widening/test_param_inference_widening.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# A parameter inferred from call sites takes the widest numeric kind supplied,
+# not the first one seen (#1972).
+#
+# The values are the assertion. The old behaviour compiled cleanly, passed
+# `ae check`, and printed the wrong number, so a test that only checked for a
+# successful build would have passed against the bug.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] param_inference_widening: build/ae missing"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! AETHER_HOME="$ROOT" "$AE" build "$SCRIPT_DIR/probe.ae" -o "$TMP/probe" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] param_inference_widening: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -15
+    exit 1
+fi
+
+# The narrowing used to leak a C-level -Wliteral-conversion warning on the
+# float case, pointing at generated code. Widening removes the narrowing, so
+# the warning should be gone too.
+if grep -q "literal-conversion" "$TMP/build.log"; then
+    echo "  [FAIL] param_inference_widening: an argument is still being narrowed"
+    grep -B2 -A2 "literal-conversion" "$TMP/build.log" | sed 's/^/        /' | head -10
+    exit 1
+fi
+
+if ! "$TMP/probe" > "$TMP/run.out" 2>&1; then
+    echo "  [FAIL] param_inference_widening: probe reported a wrong value"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+fi
+
+grep -q "All parameter-widening cases pass" "$TMP/run.out" || {
+    echo "  [FAIL] param_inference_widening: probe did not reach the end"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+}
+
+echo "  [PASS] param_inference_widening: a later, wider call site wins"
+exit 0


### PR DESCRIPTION
A function whose parameter types are inferred from call sites took whichever call site the compiler reached first and truncated every later one.

```aether
f(a) { return a + 1 }

main() {
    x = f(2)
    y = f(9000000000)
    println("${x} | ${y}")
}
```

```
3 | 410065409
```

`f(9000000000)` is 9000000001. The parameter was pinned to `int` by the call above it, and `ae check` reported **no errors** -- the only signal was a C-level `-Wliteral-conversion` warning on the float variant, pointing at generated code, and the int64 case produced no warning at all.

It was also order-dependent. For `f(a) { return a * 2 }`:

| call order | before | correct |
|---|---|---|
| `f(3)` then `f(1.5)` | `6 \| 2` | `6 \| 3` |
| `f(1.5)` then `f(3)` | `3 \| 6` | `3 \| 6` |

Moving a call site changed the answer at the other one, and which site the compiler reaches first is not something the author controls.

## The cause

`propagate_call_types_in_tree` wrote the parameter's type once and then stopped looking:

```c
if ((!param->node_type || param->node_type->kind == TYPE_UNKNOWN) &&
    arg->node_type && arg->node_type->kind != TYPE_UNKNOWN) {
    param->node_type = clone_type(arg->node_type);   // first writer wins
}
```

## The fix

An inferred parameter takes the **widest** numeric kind any call site supplies. Widening cannot lose information, which is what makes it the safe direction to resolve a disagreement in.

Three things it deliberately does not do:

- **It does not widen an annotated parameter.** `expect(got: int, ...)` relies on `int` wrapping at 32 bits, and promoting it to `int64` stops the wrap. The inferred-versus-written distinction reuses `type_inferred`, which already carries exactly that meaning for a declaration.
- **It does not widen between signed and unsigned 64-bit.** They share a rank; that swap changes what a value means rather than how much of it fits.
- **It does not touch non-numeric kinds**, so a genuinely incompatible pair still reaches the type checker instead of being silently reinterpreted.

## My first version of this was wrong, and the suite caught it

The first attempt widened annotated parameters too. `tests/regression/test_int_wraps_at_runtime` failed with `INT_MIN - 1 wraps to INT_MAX: got -2147483649, want 2147483647` -- exactly the semantics the annotation exists to pin. That is why the fix is gated on `type_inferred` rather than applying to every parameter, and it is worth stating because the gating is the non-obvious half.

## Verification

| Check | Result |
| --- | --- |
| Issue repro `add(1,2)` / `add(1.5,2.5)` | `3 4` (was `3 3`) |
| `f(2)` then `f(9000000000)` | `3 \| 9000000001` (was `3 \| 410065409`) |
| `f(3)` then `f(1.5)` | `6 \| 3` (was `6 \| 2`) |
| `test_int_wraps_at_runtime` | all cases pass |
| Unit | 409/409 |
| Examples | 90/90 |
| Full `.ae` suite | 1094 passed, 1 failed |

The one failure is `repl`, and it is **not from this change**: it is a fixed 16 KB C-command buffer overflowing under my 112-character worktree path. I confirmed by building the same tree with and without the change -- byte-identical failures, 21545 vs 21547 bytes, the difference being my edited file paths. Filed separately as #1974.

The regression test asserts **values**, not just a successful build. The old behaviour compiled cleanly and passed `ae check` while printing the wrong number, so a build-only test would have passed against the bug.

Closes #1972

🤖 Generated with [Claude Code](https://claude.com/claude-code)