### PR TITLE
fix(compiler): let a float operand beat long in mixed arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`long` was not promoted in mixed arithmetic with a float, and the wrong
+  result was silent** (#1965). The pre-typecheck pass checked "either side is
+  int64 -> int64" *before* it checked for a floating operand, so `long * 1.0`
+  inferred int64 and discarded the float; the division that followed became
+  integer division. `(elapsed * 1.0) / (n * 1.0)` printed 0 rather than 0.51,
+  and in the benchmark it was found in, that zero read as "too fast to
+  measure". The same ordering also let int64 beat `longdouble`. The int
+  spelling of the identical arithmetic was always correct, so the two
+  disagreed depending only on whether the operand came from a `long`.
+  `typechecker.c` already ordered these correctly -- longdouble, then float,
+  then the integer kinds, which is what C's usual arithmetic conversions say --
+  and the two passes now agree.
+
 ## [0.658.0]
 
 ### Fixed

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -238,6 +238,21 @@ Type* infer_from_binary_op(Type* left, Type* right, const char* operator) {
             left->kind == TYPE_DURATION && right->kind == TYPE_DURATION) {
             return create_type(TYPE_FLOAT);
         }
+        /* Floating wins over every integer kind, which is both what C's usual
+         * arithmetic conversions say and what typechecker.c already did. This
+         * pass had the int64 rule FIRST, so `long * 1.0` inferred int64 and
+         * the float was discarded: the following division became integer
+         * division and `(t * 1.0) / (n * 1.0)` printed 0 instead of 0.51,
+         * with nothing warning. The same ordering also let int64 beat
+         * longdouble. `int * 1.0` was unaffected and correct, so the two
+         * spellings of the same arithmetic disagreed depending only on
+         * whether the left operand came from a `long` (#1965). */
+        if (left->kind == TYPE_LONGDOUBLE || right->kind == TYPE_LONGDOUBLE) {
+            return create_type(TYPE_LONGDOUBLE);
+        }
+        if (left->kind == TYPE_FLOAT || right->kind == TYPE_FLOAT) {
+            return create_type(TYPE_FLOAT);
+        }
         // If either is int64 (long), promote to int64
         if (left->kind == TYPE_INT64 || right->kind == TYPE_INT64) {
             return create_type(TYPE_INT64);
@@ -274,14 +289,6 @@ Type* infer_from_binary_op(Type* left, Type* right, const char* operator) {
         // If both are int, result is int
         if (left->kind == TYPE_INT && right->kind == TYPE_INT) {
             return create_type(TYPE_INT);
-        }
-        // #749: longdouble is the widest numeric — wins over float/int.
-        if (left->kind == TYPE_LONGDOUBLE || right->kind == TYPE_LONGDOUBLE) {
-            return create_type(TYPE_LONGDOUBLE);
-        }
-        // If either is float, result is float
-        if (left->kind == TYPE_FLOAT || right->kind == TYPE_FLOAT) {
-            return create_type(TYPE_FLOAT);
         }
         // String concatenation for +
         if (strcmp(operator, "+") == 0 && 

--- a/tests/integration/long_float_promotion/probe.ae
+++ b/tests/integration/long_float_promotion/probe.ae
@@ -1,0 +1,60 @@
+// `long` participates in float promotion the same way `int` does (#1965).
+//
+// infer_binary_type checked "either side is int64 -> int64" BEFORE it checked
+// for a floating operand, so `long * 1.0` inferred int64 and discarded the
+// float. The division that followed became integer division: a per-call
+// timing computed as `(elapsed * 1.0) / (n * 1.0)` printed 0, and the zero
+// read as "too fast to measure" rather than "the arithmetic is wrong".
+//
+// The two spellings below differ only in whether the left operand came from a
+// function returning `long` or from an `int`. They have to agree.
+//
+// typechecker.c already had the correct order (longdouble, then float, then
+// the integer kinds, which is what C's usual arithmetic conversions say). The
+// pre-typecheck pass disagreed with it; this pins them together.
+
+import std.io
+
+extern exit(code: int)
+
+fail(msg: string) {
+    println("  FAIL: ${msg}")
+    exit(1)
+}
+
+as_long() -> long { return 102000 }
+odd_long() -> long { return 102001 }
+
+main() {
+    t = as_long()
+    n = 200000
+
+    // The report's own case: 0.51, not 0.
+    per = (t * 1.0) / (n * 1.0)
+    if per < 0.509 { fail("long path = ${per}, want 0.51 -- integer division truncated it") }
+    if per > 0.511 { fail("long path = ${per}, want 0.51") }
+
+    // The int spelling was always right; it must stay right.
+    i = 102000
+    per2 = (i * 1.0) / (n * 1.0)
+    if per2 < 0.509 { fail("int path = ${per2}, want 0.51") }
+    if per2 > 0.511 { fail("int path = ${per2}, want 0.51") }
+
+    // A fraction that cannot survive an integer result, so this cannot pass
+    // by accident the way a whole-numbered one could.
+    o = odd_long()
+    half = o * 0.5
+    if half < 51000.4 { fail("long * 0.5 = ${half}, want 51000.5") }
+    if half > 51000.6 { fail("long * 0.5 = ${half}, want 51000.5") }
+
+    quarter = (o * 1.0) / 4.0
+    if quarter < 25500.2 { fail("long / 4 = ${quarter}, want 25500.25") }
+    if quarter > 25500.3 { fail("long / 4 = ${quarter}, want 25500.25") }
+
+    // Integer-only arithmetic must NOT have been promoted: `long` still wins
+    // over `int`, and the result stays integral.
+    sum = t + 1
+    if sum != 102001 { fail("long + 1 = ${sum}, want 102001") }
+
+    println("All long/float promotion cases pass")
+}

--- a/tests/integration/long_float_promotion/test_long_float_promotion.sh
+++ b/tests/integration/long_float_promotion/test_long_float_promotion.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# `long` participates in float promotion the same way `int` does (#1965).
+#
+# The values are the assertion. The old behaviour compiled cleanly and printed
+# 0 for a quotient of 0.51, so a test that only checked the build would have
+# passed against the bug.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AE="$ROOT/build/ae"
+[ -x "$AE" ] || { echo "  [SKIP] long_float_promotion: build/ae missing"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! AETHER_HOME="$ROOT" "$AE" build "$SCRIPT_DIR/probe.ae" -o "$TMP/probe" > "$TMP/build.log" 2>&1; then
+    echo "  [FAIL] long_float_promotion: build failed"
+    sed 's/^/        /' "$TMP/build.log" | head -15
+    exit 1
+fi
+
+if ! "$TMP/probe" > "$TMP/run.out" 2>&1; then
+    echo "  [FAIL] long_float_promotion: probe reported a wrong value"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+fi
+
+grep -q "All long/float promotion cases pass" "$TMP/run.out" || {
+    echo "  [FAIL] long_float_promotion: probe did not reach the end"
+    sed 's/^/        /' "$TMP/run.out" | head -10
+    exit 1
+}
+
+echo "  [PASS] long_float_promotion: long and int agree in mixed float arithmetic"
+exit 0


### PR DESCRIPTION
`int * 1.0` promotes and gives a float. `long * 1.0` did not: the expression stayed integral and the division that followed truncated, silently.

```aether
as_long() -> long { return 102000 }

main() {
    t = as_long()
    n = 200000
    println("long path = ${(t * 1.0) / (n * 1.0)}")
    i = 102000
    println("int path  = ${(i * 1.0) / (n * 1.0)}")
}
```

```
long path = 0        <- want 0.51
int path  = 0.51
```

The two lines differ only in whether the left operand came from a function returning `long`, and they disagreed.

## The cause

`infer_binary_type` checked the integer rule **before** the floating one:

```c
// If either is int64 (long), promote to int64
if (left->kind == TYPE_INT64 || right->kind == TYPE_INT64) {
    return create_type(TYPE_INT64);          // <- `long * 1.0` stops here
}
...
// #749: longdouble is the widest numeric — wins over float/int.
if (left->kind == TYPE_LONGDOUBLE || ...)    // <- never reached
if (left->kind == TYPE_FLOAT || ...)         // <- never reached
```

So the float operand was discarded and the following `/` became integer division. The same ordering also let int64 beat `longdouble`, directly contradicting the `#749` comment sitting above it.

## The fix

Move the floating checks ahead of the integer ones, which is both what C's usual arithmetic conversions specify and **what `typechecker.c` already did**:

```c
if (left_type->kind == TYPE_LONGDOUBLE || ...) return create_type(TYPE_LONGDOUBLE);
if (left_type->kind == TYPE_FLOAT || ...)      return create_type(TYPE_FLOAT);
// then the integer kinds
```

The two passes disagreed, and whichever stamped the node first decided the answer. They now agree, which is the real content of this change -- one of them was already right.

## Why it matters beyond the repro

Anything timing off a nanosecond clock is on the `long` path by construction:

```aether
elapsed = clock_ns() - start             // long
per_call = (elapsed * 1.0) / (n * 1.0)   // 0, silently
```

The issue reports it was found exactly that way, and the `0` read as "too fast to measure" rather than "the arithmetic is wrong".

## Verification

| Check | Before | After |
| --- | --- | --- |
| `(long * 1.0) / (n * 1.0)` | `0` | `0.51` |
| `(int * 1.0) / (n * 1.0)` | `0.51` | `0.51` |
| `long * 0.5` (102001) | `51000` | `51000.5` |
| `long + 1` (integer-only, must NOT promote) | `102001` | `102001` |

| Suite | Result |
| --- | --- |
| Unit | 409/409 |
| Examples | 90/90 |
| Full `.ae` suite | 1094 passed, 1 failed |

The one failure is `repl`, unrelated to this change: a fixed 16 KB C-command buffer overflowing under my 112-character worktree path, filed as #1974 and confirmed byte-identical with and without this change.

The regression test asserts a **fractional** result (`long * 0.5` is 51000.5), because a whole-numbered one can pass by accident under integer arithmetic, and asserts that integer-only arithmetic was not promoted so `long + 1` still comes back integral. Reverting the ordering fails it with `long * 0.5 = 51000, want 51000.5`.

Closes #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)