### PR TITLE
ci: stop an unused third-party apt repo from failing every Linux job

### DIFF
--- a/.github/scripts/ci-apt-update.sh
+++ b/.github/scripts/ci-apt-update.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# `apt-get update` for CI, minus the repositories we do not use.
+#
+# apt refreshes EVERY repository configured on the runner, and GitHub's Ubuntu
+# images ship third-party ones we never install from. When one of those serves
+# an index whose hash does not match its own Release file, `apt-get update`
+# exits 100, the `&&` in the caller short-circuits, and the job fails before
+# running a line of our code:
+#
+#   E: Failed to fetch https://dl.google.com/linux/chrome-stable/.../Packages.gz
+#      Hash Sum mismatch
+#   ##[error]Process completed with exit code 100
+#
+# That took down ten CI jobs across four workflows and a release build on
+# 2026-09-09, none of which touch a browser (#1981). Everything our jobs
+# install -- gcc, clang, make, bc, pkg-config, libgtk-4-dev, curl, xz-utils,
+# valgrind, qemu, the arm-none-eabi toolchain -- comes from Ubuntu's own
+# archives, so dropping these costs nothing and removes an upstream that can
+# veto our builds.
+#
+# Deliberately NOT `apt-get update || true`: a genuine failure to reach the
+# Ubuntu archives must still fail the job, or the install that follows fails
+# later with a worse message.
+#
+# Non-Debian hosts: `apt-get` is absent, the script exits non-zero, and callers
+# that support both (memory-check.yml's `|| brew ...`) fall through as before.
+set -e
+
+sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+           /etc/apt/sources.list.d/microsoft-prod.list \
+           /etc/apt/sources.list.d/microsoft.list 2>/dev/null || true
+
+sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
             os: ubuntu-22.04
             cc: gcc
             harden: "0"
-            install: sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           - name: Linux / Clang
             os: ubuntu-22.04
             cc: clang
             harden: "0"
-            install: sudo apt-get update && sudo apt-get install -y clang make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: .github/scripts/ci-apt-update.sh && sudo apt-get install -y clang make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           # Hardened gcc build (issue #396). Same OS + compiler as
           # Linux / GCC but with HARDEN=1 set in the environment, which
@@ -77,7 +77,7 @@ jobs:
             os: ubuntu-22.04
             cc: gcc
             harden: "1"
-            install: sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           - name: macOS / Clang (ARM64)
             os: macos-latest
@@ -350,7 +350,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc curl xz-utils
 
     # zig cc bundles no FreeBSD libc, so the base sysroot is what makes the
     # FreeBSD headers visible. Same source as the release leg.
@@ -450,7 +450,7 @@ jobs:
 
     - name: Install host language dev libraries
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y \
           gcc make bc pkg-config \
           liblua5.3-dev \
@@ -490,7 +490,7 @@ jobs:
 
     - name: Install build deps
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y gcc make valgrind
         pip install --break-system-packages websockets 2>/dev/null || pip install websockets
         # contrib/vulkan needs the headers to build and a driver to run.
@@ -669,7 +669,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc
 
     - name: Run cooperative scheduler CI
       run: make ci-coop
@@ -689,7 +689,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc
 
     - name: Build without OpenSSL
       run: make -j"$(nproc)" OPENSSL=0
@@ -729,7 +729,7 @@ jobs:
         version: 3.1.51
 
     - name: Install native GCC
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Still needed after #1648 wired wasm32-wasi into `ae build`, and worth
     # saying why: `ae build --target=wasm32-wasi --emit=obj` compiles the
@@ -806,7 +806,7 @@ jobs:
 
     - name: Install ARM cross-compiler
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y gcc make gcc-arm-none-eabi libnewlib-arm-none-eabi
 
     - name: Run embedded CI
@@ -829,7 +829,7 @@ jobs:
 
     - name: Install RISC-V cross-toolchain + qemu
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y \
           gcc-riscv64-linux-gnu \
           libc6-dev-riscv64-cross \
@@ -853,7 +853,7 @@ jobs:
 
     - name: Install tools
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y valgrind gcc-multilib
 
     - name: Valgrind — runtime test suite

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y gcc make valgrind
 
     - name: Build with debug symbols
@@ -108,7 +108,7 @@ jobs:
     - name: Setup GCC
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y gcc make
 
     - name: Setup Clang
@@ -173,7 +173,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo apt-get install -y gcc make valgrind
 
     - name: Build with memory tracking
@@ -227,7 +227,7 @@ jobs:
 
     - name: Setup GCC
       run: |
-        sudo apt-get update || brew update
+        .github/scripts/ci-apt-update.sh || brew update
         sudo apt-get install -y gcc make || brew install gcc make
 
     - name: Verify 64-bit compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,7 +413,7 @@ jobs:
     - name: Setup (Linux)
       if: matrix.os == 'ubuntu-22.04'
       run: |
-        sudo apt-get update && sudo apt-get install -y gcc make bc python3-pip
+        .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc python3-pip
         # The websocket suites check our RFC 6455 implementation against an
         # independent one, and they fail rather than skip on a Linux CI runner
         # because a silent skip would hide the only thing they exist for.
@@ -647,7 +647,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Zig is checksum-pinned by this repo; the FreeBSD base sysroot (headers +
     # libc) comes from the sibling aether-crossbuild repo, which fetches

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: .github/scripts/ci-apt-update.sh && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Restore on every run, save only on a main-merge miss. Zig bundles the
     # mingw-w64 headers + CRT sources, so there is no sysroot to fetch.
@@ -175,7 +175,7 @@ jobs:
 
     - name: Install toolchain
       run: |
-        sudo apt-get update
+        .github/scripts/ci-apt-update.sh
         sudo -E apt-get install -y --no-install-recommends \
           build-essential wine file
 


### PR DESCRIPTION
A fifteen-minute hiccup in an apt repository **we do not use** turned ten CI jobs red across four workflows and failed a release build.

## What broke

Every Linux job starts with `sudo apt-get update`. That refreshes *every* repository on the runner, including the Google Chrome one GitHub's Ubuntu images ship preinstalled. It served an index whose hash did not match its own `Release` file:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   Hash Sum mismatch
##[error]Process completed with exit code 100
```

apt exits 100, the `&&` short-circuits, the packages never install, and the job fails before running any of our code.

**Ten jobs on #1980**, all byte-identical: AddressSanitizer & LeakSanitizer, Memory Usage Profiling, Memory Safety (Valgrind + ASan), Source build without OpenSSL, Linux / RISC-V 64, Embedded ARM (Cortex-M4), contrib runtime tests, contrib/host bridges, Cooperative Scheduler, WebAssembly. And the **freebsd-x86_64 cross build of a release run**, same cause.

Nothing was wrong with either branch. Ten red checks on a PR that changed one compiler file reads as "this branch broke everything", and the actual cause is nineteen lines into an apt log.

**It is not a one-off.** I re-ran the failed jobs three hours later and they failed the same way, which is what moved this from "wait it out" to "fix it".

## The fix

We use no browser anywhere in CI:

```
$ grep -rniE "chrome|chromium|puppeteer|playwright|selenium" .github/workflows/
(nothing)
```

Everything these jobs install -- gcc, clang, make, bc, pkg-config, libgtk-4-dev, curl, xz-utils, valgrind, qemu, arm-none-eabi -- comes from Ubuntu's own archives. So the third-party sources are dropped before updating, and only repositories we actually install from can affect us.

All **20** `sudo apt-get update` sites call one script instead of repeating the removal twenty times, which is also the only way it stays consistent when the next preinstalled repository misbehaves. Each site keeps its own package list.

## What it deliberately does not do

- **Not `apt-get update || true`.** A genuine failure to reach the Ubuntu archives must still fail the job, rather than surfacing later as a confusing install error.
- **Not a retry loop.** The index was consistently wrong for hours; retrying would have burned runner time and still failed.

## Checked

| | |
|---|---|
| YAML parses, all four workflows | ok |
| `apt-get update` sites left unguarded | 0 of 20 |
| Script shell syntax (`sh -n`) | ok |
| Non-Debian host exit code | 1, so `memory-check.yml`'s `\|\| brew update` still falls through (verified on macOS) |
| `actions/checkout` precedes every apt step | yes, including the three matrix `install:` values, which are *defined* near the top of ci.yml but *consumed* at the step after checkout |

Closes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)