### PR TITLE
ci: drop an apt source we never use, so its outages stop breaking builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: Aether CI
 
+# Every `apt-get update` below first drops the runner's Google Chrome apt
+# source. Nothing in this repository installs from it, and no workflow here
+# uses a browser at all, but the GitHub images ship the source and when its
+# index is briefly inconsistent EVERY apt-get update in the matrix fails:
+#
+#   E: Failed to fetch .../google-chrome/.../Packages.gz  Hash Sum mismatch
+#   ##[error]Process completed with exit code 100
+#
+# and each Linux leg goes red in setup, before compiling a line. That took
+# main and every open PR down on 2026-09-09: 15 legs on main, 10 on a PR that
+# had touched only the type checker. Removing a third party we never asked
+# for from the critical path costs nothing and cannot regress a build that
+# never installed from it.
+
 # A change that touches only VERSION and CHANGELOG.md is a release bump, and
 # that tree was already built and tested on main before the release was cut.
 # Running the full matrix on it again gains nothing and costs twice over: the
@@ -57,13 +71,13 @@ jobs:
             os: ubuntu-22.04
             cc: gcc
             harden: "0"
-            install: sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           - name: Linux / Clang
             os: ubuntu-22.04
             cc: clang
             harden: "0"
-            install: sudo apt-get update && sudo apt-get install -y clang make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y clang make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           # Hardened gcc build (issue #396). Same OS + compiler as
           # Linux / GCC but with HARDEN=1 set in the environment, which
@@ -77,7 +91,7 @@ jobs:
             os: ubuntu-22.04
             cc: gcc
             harden: "1"
-            install: sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
+            install: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc pkg-config libgtk-4-dev; pip install --break-system-packages websockets 2>/dev/null || pip install websockets
 
           - name: macOS / Clang (ARM64)
             os: macos-latest
@@ -350,7 +364,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
 
     # zig cc bundles no FreeBSD libc, so the base sysroot is what makes the
     # FreeBSD headers visible. Same source as the release leg.
@@ -450,7 +464,7 @@ jobs:
 
     - name: Install host language dev libraries
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y \
           gcc make bc pkg-config \
           liblua5.3-dev \
@@ -490,7 +504,7 @@ jobs:
 
     - name: Install build deps
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y gcc make valgrind
         pip install --break-system-packages websockets 2>/dev/null || pip install websockets
         # contrib/vulkan needs the headers to build and a driver to run.
@@ -669,7 +683,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc
 
     - name: Run cooperative scheduler CI
       run: make ci-coop
@@ -689,7 +703,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc
 
     - name: Build without OpenSSL
       run: make -j"$(nproc)" OPENSSL=0
@@ -729,7 +743,7 @@ jobs:
         version: 3.1.51
 
     - name: Install native GCC
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Still needed after #1648 wired wasm32-wasi into `ae build`, and worth
     # saying why: `ae build --target=wasm32-wasi --emit=obj` compiles the
@@ -806,7 +820,7 @@ jobs:
 
     - name: Install ARM cross-compiler
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y gcc make gcc-arm-none-eabi libnewlib-arm-none-eabi
 
     - name: Run embedded CI
@@ -829,7 +843,7 @@ jobs:
 
     - name: Install RISC-V cross-toolchain + qemu
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y \
           gcc-riscv64-linux-gnu \
           libc6-dev-riscv64-cross \
@@ -853,7 +867,7 @@ jobs:
 
     - name: Install tools
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y valgrind gcc-multilib
 
     - name: Valgrind — runtime test suite

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y gcc make valgrind
 
     - name: Build with debug symbols
@@ -108,7 +108,7 @@ jobs:
     - name: Setup GCC
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y gcc make
 
     - name: Setup Clang
@@ -173,7 +173,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo apt-get install -y gcc make valgrind
 
     - name: Build with memory tracking
@@ -227,7 +227,7 @@ jobs:
 
     - name: Setup GCC
       run: |
-        sudo apt-get update || brew update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update || brew update
         sudo apt-get install -y gcc make || brew install gcc make
 
     - name: Verify 64-bit compilation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,7 +413,7 @@ jobs:
     - name: Setup (Linux)
       if: matrix.os == 'ubuntu-22.04'
       run: |
-        sudo apt-get update && sudo apt-get install -y gcc make bc python3-pip
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc python3-pip
         # The websocket suites check our RFC 6455 implementation against an
         # independent one, and they fail rather than skip on a Linux CI runner
         # because a silent skip would hide the only thing they exist for.
@@ -647,7 +647,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Zig is checksum-pinned by this repo; the FreeBSD base sysroot (headers +
     # libc) comes from the sibling aether-crossbuild repo, which fetches

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install toolchain
-      run: sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
+      run: sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update && sudo apt-get install -y gcc make bc curl xz-utils
 
     # Restore on every run, save only on a main-merge miss. Zig bundles the
     # mingw-w64 headers + CRT sources, so there is no sysroot to fetch.
@@ -175,7 +175,7 @@ jobs:
 
     - name: Install toolchain
       run: |
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
         sudo -E apt-get install -y --no-install-recommends \
           build-essential wine file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A third-party apt source took CI down**, main and every open PR at once. The
+  GitHub runner images ship an apt source for Google Chrome. Nothing here
+  installs from it and no workflow uses a browser, but when its index went
+  briefly inconsistent every `apt-get update` in the matrix failed with
+  `Hash Sum mismatch` and each Linux leg went red during setup, before
+  compiling a line: 15 legs on main, 10 on a PR that had touched only the type
+  checker. Every `apt-get update` now drops that source first, which cannot
+  regress a build that never installed from it.
+
 ## [0.659.0]
 
 ### Fixed


### PR DESCRIPTION
## What happened

The GitHub runner images ship an apt source for **Google Chrome**. Nothing in this repository installs from it, and no workflow here uses a browser at all. But every Linux job runs `apt-get update`, and apt fails the entire command when *any* configured source has a bad index:

```
E: Failed to fetch .../google-chrome/.../Packages.gz  Hash Sum mismatch
##[error]Process completed with exit code 100
```

So a hiccup in a third party's repository turns every Linux leg red **during setup, before a line is compiled**. Today that took down `main` (15 failing legs) and every open PR at once.

## How it was found, and why that matters

It surfaced on #1980, a type-checker change, as 10 red legs. The obvious read is "the change broke it". It did not: I pulled three of the failing job logs and they all failed on the identical apt line, then checked `main` and found a **superset** of the same failures on a commit that change is not part of.

Worth stating plainly because the failure mode is designed to mislead: a PR author sees their PR red, re-runs, sees it red again, and starts editing code that was never wrong.

## The change

Each of the 20 `apt-get update` call sites removes that source first:

```diff
-        sudo apt-get update
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list; sudo apt-get update
```

The reasoning is recorded once, at the top of `ci.yml`, rather than twenty times.

## Why this is the fix and not a workaround

The source is **not a dependency of this project**. It is not a retry loop, a `|| true`, or a pin: it removes a third party we never asked for from the critical path of a build that never installed from it. It cannot regress anything, because no job here has ever fetched a package from that repository.

If a workflow ever does need a browser, it should install one deliberately, and that step can add the source back itself.

## Verification

All four workflow files parse (`yaml.safe_load`). The change is mechanical and identical at every site; `grep` confirms 12 + 4 + 2 + 2 = 20 guarded, with none double-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)