### PR TITLE
fix(codegen): a function may be named after a libc symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **A function named after a libc symbol emitted C that did not compile**
+  (#1993). `remove()`, `div()`, `index()`, `abs()` and two dozen more reached C
+  unmangled, and the only diagnostic came from the C compiler, naming a system
+  header and a type the source never wrote. `is_c_reserved_word` already
+  mangled `read`, `write` and `bind` for exactly this reason; its curated list
+  was missing the rest of `<stdio.h>`, `<stdlib.h>` and `<string.h>`. These are
+  ordinary domain verbs, which is what makes them worth listing: an undo pair
+  is naturally `add`/`remove`, a list editor has `remove` and `index`.
+
+  A name absent from that list was not safe, it was lucky: it survived only
+  while its signature happened to match libc's, so `rand() -> int` compiled and
+  `rand(seed: int) -> int` did not. The names are listed regardless.
+
+- **`atoi` is a builtin, and it did not yield to a program's own function.**
+  With the reserved-name entry alone, the definition was mangled while every
+  call still went to the builtin, so the program's function became dead code
+  and the call carried libc's signature. The builtin now steps aside when the
+  program defines a function of that name, which is the rule #1967 settled for
+  types. `atoi("41")` still reaches the builtin in a program that defines none.
+
 ## [0.662.0]
 
 ### Fixed

--- a/compiler/codegen/codegen.c
+++ b/compiler/codegen/codegen.c
@@ -1958,8 +1958,29 @@ int is_c_reserved_word(const char* name) {
         // ── libc time + env + misc ─────────────────────────────
         "time", "clock", "gettimeofday", "clock_gettime", "clock_settime",
         "gmtime", "localtime", "mktime", "asctime", "ctime", "strftime",
+        "difftime",
         "getenv", "setenv", "unsetenv", "putenv", "clearenv",
         "getcwd", "chdir", "fchdir", "system",
+        /* #1993: the rest of <stdio.h>/<stdlib.h>/<string.h>, which the
+           prelude includes. These are ORDINARY DOMAIN VERBS, which is what
+           makes them worth listing: an undo pair is naturally written
+           add/remove, a list editor has remove and index, a numeric helper
+           has abs or div. Found by an aether-ui README snippet whose undo
+           example was `|| { remove() }`, the obvious thing to write, which
+           did not compile.
+
+           A name absent from this list is not safe, it is LUCKY: it survives
+           only while its signature happens to match libc's. `rand() -> int`
+           compiles because that is libc's exact signature, and `rand(seed:
+           int) -> int` does not. So these are listed regardless of whether
+           any one probe collided. */
+        "remove", "rename", "tmpfile", "tmpnam", "setbuf", "setvbuf",
+        "getline", "getdelim", "fgetpos", "fsetpos", "clearerr",
+        "abs", "labs", "llabs", "div", "ldiv", "lldiv",
+        "rand", "srand", "random", "srandom",
+        "qsort", "bsearch",
+        "atoi", "atol", "atoll", "atof",
+        "index", "rindex",
         NULL
     };
     for (int i = 0; reserved[i]; i++) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -3885,7 +3885,16 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                     generate_expression(gen, expr->children[0]);
                     fprintf(gen->output, ")");
                 }
-                else if (strcmp(func_name, "atoi") == 0 && expr->child_count == 1) {
+                /* #1993: the builtin only claims this name while the program
+                   has not defined one of its own. `atoi` is an ordinary
+                   identifier, and a program that defines it had the definition
+                   emitted (mangled, since atoi is a reserved libc name) while
+                   every CALL still went to the builtin, so the function was
+                   dead code and the call carried libc's signature. A program's
+                   own function wins, which is the same rule #1967 settled for
+                   types. */
+                else if (strcmp(func_name, "atoi") == 0 && expr->child_count == 1 &&
+                         !find_function_definition_by_name(gen->program, "atoi")) {
                     fprintf(gen->output, "atoi(");
                     generate_expression(gen, expr->children[0]);
                     fprintf(gen->output, ")");

--- a/compiler/codegen/codegen_internal.h
+++ b/compiler/codegen/codegen_internal.h
@@ -227,6 +227,10 @@ void mark_escaped_heap_string_vars(CodeGenerator* gen, ASTNode* body);
 void mark_escaped_capture_boxes(CodeGenerator* gen, ASTNode* body);
 /* The closure argument a call provably drops on return, or NULL. */
 ASTNode* transient_closure_arg(CodeGenerator* gen, ASTNode* call);
+/* The program's own definition of `name`, or NULL. Shared rather than
+   duplicated: the builtin fast-paths need it to know when a program has
+   defined a function of its own with a builtin's name. */
+ASTNode* find_function_definition_by_name(ASTNode* program, const char* name);
 
 /* Push function-exit defer-free statements for every hoisted
  * heap-string var that's NOT escaped. Closes the single-call

--- a/compiler/codegen/codegen_stmt.c
+++ b/compiler/codegen/codegen_stmt.c
@@ -697,8 +697,8 @@ static int function_def_returns_heap_string(CodeGenerator* gen, ASTNode* fn_def)
 // (K < 200) this is well under a millisecond. If the count grows,
 // promote to a hash via gen->fn_def_lookup; the static here is the
 // O(1)-amortised refactor seam.
-static ASTNode* find_function_definition_by_name(ASTNode* program,
-                                                 const char* name) {
+ASTNode* find_function_definition_by_name(ASTNode* program,
+                                          const char* name) {
     if (!program || !name) return NULL;
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* c = program->children[i];

--- a/tests/regression/test_libc_named_functions.ae
+++ b/tests/regression/test_libc_named_functions.ae
@@ -1,0 +1,57 @@
+// Regression: a function named after a libc symbol the prelude includes
+// emitted C that did not compile, and aetherc reported nothing.
+//
+// The generated file includes <stdio.h>, <stdlib.h> and <string.h>, so a
+// program-level `remove()` reached C unmangled and clang rejected the
+// redeclaration, naming a system header and a type the source never wrote.
+// A curated reserved-name list already mangled `read`, `write` and `bind`
+// for exactly this reason; it was missing the rest of those three headers.
+//
+// These are ordinary domain verbs, which is what makes them worth listing: an
+// undo pair is naturally add/remove, a list editor has remove and index, a
+// numeric helper has abs or div.
+//
+// An absent name was not safe, it was LUCKY: it survived only while its
+// signature happened to match libc's. So every name here takes an argument
+// and returns a value, which libc's counterpart does not, and pre-fix each
+// one failed to compile.
+//
+// `atoi` additionally needed the builtin fast-path to yield: the definition
+// was mangled while every call still went to the builtin, so the function was
+// dead code. A program's own function wins.
+
+extern exit(code: int)
+
+remove(x: int) -> int { return x + 1 }
+index(x: int) -> int { return x + 2 }
+div(x: int) -> int { return x + 3 }
+abs(x: int) -> int { return x + 4 }
+rand(x: int) -> int { return x + 5 }
+qsort(x: int) -> int { return x + 6 }
+atoi(x: int) -> int { return x + 7 }
+getline(x: int) -> int { return x + 8 }
+difftime(x: int) -> int { return x + 9 }
+setbuf(x: int) -> int { return x + 10 }
+
+check(label: string, got: int, want: int) {
+    if got != want {
+        println("  FAIL: ${label} got=${got} want=${want}")
+        exit(1)
+    }
+}
+
+main() {
+    println("=== test_libc_named_functions ===")
+    check("remove", remove(0), 1)
+    check("index", index(0), 2)
+    check("div", div(0), 3)
+    check("abs", abs(0), 4)
+    check("rand", rand(0), 5)
+    check("qsort", qsort(0), 6)
+    check("atoi", atoi(0), 7)
+    check("getline", getline(0), 8)
+    check("difftime", difftime(0), 9)
+    check("setbuf", setbuf(0), 10)
+    println("  PASS: a libc-named function is the program's own")
+    println("=== test_libc_named_functions passed ===")
+}


### PR DESCRIPTION
Closes #1993

```
remove() -> int { return 1 }

error: conflicting types for 'remove'
note: 'remove' declared here     (SDK _stdio.h:268)
```

The generated file includes `<stdio.h>`, `<stdlib.h>` and `<string.h>`, so a program-level function whose name matches one of their declarations reached C unmangled. `aetherc` reported nothing: the only diagnostic came from the C compiler, naming a system header and a type the source never wrote.

## The mechanism already existed

`is_c_reserved_word` is there for exactly this, and its own comment cites the original trigger, an Aether function named `bind` colliding with `bind(2)`. It has curated sections for sockets, POSIX I/O, process control, memory, string/stdio and time/env.

So this is not a new mechanism, it is the missing rest of those three headers: `remove`, `div`/`ldiv`/`lldiv`, `index`/`rindex`, `abs`/`labs`/`llabs`, `rand`/`srand`/`random`/`srandom`, `qsort`, `bsearch`, `atoi`/`atol`/`atoll`/`atof`, `getline`, `getdelim`, `difftime`, `tmpfile`, `tmpnam`, `setbuf`, `setvbuf`, `clearerr`, `fgetpos`, `fsetpos`.

**I got the diagnosis wrong first time** and corrected it on the issue: I had said `write`/`read`/`link` pass because `unistd.h` is not included, when in fact they pass because they are already in this list. I explained a mechanism before reading it.

## An absent name was not safe, it was lucky

It survived only while its signature happened to match libc's:

| | result |
|---|---|
| `rand() -> int` | compiles, because that is libc's exact signature |
| `rand(seed: int) -> int` | **fails** |

So the names are listed regardless of whether any one probe collided, and the regression test gives **every** name an argument and a return value so none can pass by that coincidence.

## atoi needed a second fix

`atoi` is also a language **builtin**, registered in the typechecker and emitted verbatim by codegen. With the list entry alone, the definition was mangled to `ae_atoi` while every **call** still went to the builtin: the program's function became dead code and the call carried libc's signature, so it failed differently rather than working.

The builtin now yields when the program defines a function of that name, the same rule #1967 settled for types: the program's own definition wins. Verified both ways, a program defining `atoi` gets its own, and one that does not still reaches the builtin (`atoi("41")` → 41).

`find_function_definition_by_name` was static in `codegen_stmt.c` and is now shared through `codegen_internal.h` rather than copied, since the builtin path needs the same lookup.

## Verification

25 probe names checked with non-libc signatures, all failing before and all working after. `tests/regression/test_libc_named_functions.ae` locks in ten of them plus the `atoi` case.

409 C tests, **1100** `.ae` tests, 90 examples and the docs gate pass.

## How it was found

Writing an undo example for aether-ui's README, where `undoable("Add", || { add() }, || { remove() })` is the obvious thing to write and does not build. The snippet test added in aether-ui#135 is what caught it; without that, the README would have shipped an example nobody could compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)