### PR TITLE
test(regression): #1991 local shadowing a suffixed import (already fixed by #1967)

### DIFF
--- a/tests/regression/test_local_shadows_suffixed_import.ae
+++ b/tests/regression/test_local_shadows_suffixed_import.ae
@@ -1,0 +1,54 @@
+// Regression (#1991): a LOCAL variable whose name is the tail of a name
+// exported by an imported module retyped an unrelated symbol, and the error
+// surfaced on a line in a different function.
+//
+// std.os exports `run_full`, declared with no return type (`-> {`). A local
+// named `full` in one function reached that declaration through the resolver
+// and — via the same shared-symbol-table mutation as #1967, but triggered by a
+// local binding rather than a parameter — mistyped the program elsewhere. The
+// user saw `error[E0200]: Type mismatch in variable initialization` on the
+// `g_out = env(null)` line, two functions away from the `full` that caused it.
+//
+// Fixed by #1967 (a name that shadows another must get its own symbol entry
+// that the inference unwind removes, instead of overwriting the outer one).
+// This test pins the local-variable-across-an-import manifestation: it fails
+// to compile pre-fix (E0200 on a line that has nothing to do with the local)
+// and compiles + runs correctly after.
+
+import std.os
+import std.string
+
+var g_out: string = ""
+
+// Binds a local named `full` — the tail of std.os.run_full. Need not be
+// reachable for the pre-fix error to appear; called here so the run also
+// checks the value is right.
+held(s: string) -> string {
+    full = string.concat(s, "!")
+    return full
+}
+
+// The line `g_out = env(null)` is what pre-fix reported the E0200 against,
+// though neither this function nor that line has anything to do with `full`.
+env(v: ptr) -> string {
+    return v as string
+}
+
+main() {
+    println("=== test_local_shadows_suffixed_import ===")
+
+    // The bug was a COMPILE error (E0200) on this line; reaching runtime at
+    // all is the pass. env(null) casts a null ptr to string, so the value
+    // itself is not the point — that this function type-checks is.
+    g_out = env(null)
+    println("ok   env(null) line type-checks and runs")
+
+    h = held("a")
+    if string.equals(h, "a!") == 1 {
+        println("ok   held(\"a\") == \"a!\" (local `full` resolved correctly)")
+    } else {
+        println("FAIL held: ${h}")
+    }
+
+    println("test_local_shadows_suffixed_import passed")
+}


### PR DESCRIPTION
Closes #1991.

## TL;DR — already fixed, adding the regression guard

#1991 (aetherc 0.658.0) reported that a local named `full` together with `import std.os` failed an **unrelated** line — `g_out = env(null)`, two functions away — with `error[E0200]: Type mismatch in variable initialization`, and that renaming the local to `joined` compiled. The reporter's bisection was exactly right, including the suspicion that `std.os`'s `run_full` (declared `-> {`, no return type) was involved.

**This is the local-variable manifestation of #1967:** a name that shadows another retyped it through the shared symbol table, because the inference unwind removes an *added* entry but cannot undo a *mutation*. #1967 fixed the parameter case (`bbdd66a4`, shipped 0.660.0) by giving a shadowing name its own entry that the unwind removes — which resolves the local case too.

## Verification (both directions)

- **v0.658.0** (the reporter's version, built in a worktree): the repro fails with the exact `E0200 Type mismatch in variable initialization`, and renaming `full` → `joined` compiles — matching the reporter's decision table.
- **Current main (0.665.0):** the repro compiles and runs correctly (`(null)` then `a!`), including harder variants — a local named *exactly* `run_full`, and the case where the binding function is never called.

So no code fix is needed; #1967 already covers it. This PR adds a dedicated regression test (`tests/regression/test_local_shadows_suffixed_import.ae`) pinning the **local-across-an-import** shape, distinct from the existing #1967 test (which covers a *parameter* shadowing a *function*). It guards against a future symbol-table change that leaves parameters correct but breaks locals.

Test-only — no shipped-code paths touched, so the CHANGELOG gate is not triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)