### PR TITLE
build: declare no-arg functions foo(void) + add -Wstrict-prototypes (#1996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ version number before tagging the release.
 
 ## [current]
 
+### Changed
+
+- **The build now checks that no-argument functions are declared `foo(void)`,
+  not `foo()`** (#1996). In C before C23, `foo()` means "unspecified arguments",
+  not "no arguments", so the compiler cannot check a call against it — a call
+  passing arguments to a `foo()`-declared function is accepted silently. Every
+  such declaration across the compiler, runtime, stdlib and LSP now uses
+  `(void)`, and `-Wstrict-prototypes` is added to `CFLAGS` so the gap cannot
+  reopen. Mechanical, no behaviour change; it closes a real argument-checking
+  hole on the C11 toolchains the project builds with (GCC, Clang, MSYS2).
+
 ## [0.665.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 # silently delete the other.
 AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) $(ZSTD_CFLAGS)
 
-CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
+CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wstrict-prototypes $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
 # passwd / sysctl past Capsicum capability mode. libcasper + the
 # per-service libs ship in the FreeBSD base system. We resolve them by

--- a/compiler/aether_error.c
+++ b/compiler/aether_error.c
@@ -425,15 +425,15 @@ void aether_error_with_code(const char* message, int line, int column, AetherErr
 }
 
 // Error statistics
-int aether_error_count() {
+int aether_error_count(void) {
     return error_count_global;
 }
 
-int aether_warning_count() {
+int aether_warning_count(void) {
     return warning_count_global;
 }
 
-void aether_error_reset_counts() {
+void aether_error_reset_counts(void) {
     error_count_global = 0;
     warning_count_global = 0;
 }

--- a/compiler/aether_error.h
+++ b/compiler/aether_error.h
@@ -71,9 +71,9 @@ const char* aether_color_bold(void);
 #define AETHER_COLOR_BOLD aether_color_bold()
 
 // Error statistics
-int aether_error_count();
-int aether_warning_count();
-void aether_error_reset_counts();
+int aether_error_count(void);
+int aether_warning_count(void);
+void aether_error_reset_counts(void);
 
 #endif // AETHER_ERROR_H
 

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -196,7 +196,7 @@ void module_set_lib_dir(const char* lib_dir) {
 }
 
 // Module management
-void module_registry_init() {
+void module_registry_init(void) {
     if (!global_module_registry) {
         global_module_registry = (ModuleRegistry*)malloc(sizeof(ModuleRegistry));
         global_module_registry->modules = NULL;
@@ -216,7 +216,7 @@ void module_registry_init() {
     }
 }
 
-void module_registry_shutdown() {
+void module_registry_shutdown(void) {
     if (global_module_registry) {
         for (int i = 0; i < global_module_registry->module_count; i++) {
             module_free(global_module_registry->modules[i]);
@@ -476,7 +476,7 @@ void package_manifest_free(PackageManifest* manifest) {
 
 // Dependency Graph Implementation
 
-DependencyGraph* dependency_graph_create() {
+DependencyGraph* dependency_graph_create(void) {
     DependencyGraph* graph = malloc(sizeof(DependencyGraph));
     graph->nodes = NULL;
     graph->node_count = 0;

--- a/compiler/aether_module.h
+++ b/compiler/aether_module.h
@@ -37,8 +37,8 @@ typedef struct {
 extern ModuleRegistry* global_module_registry;
 
 // Module management
-void module_registry_init();
-void module_registry_shutdown();
+void module_registry_init(void);
+void module_registry_shutdown(void);
 
 AetherModule* module_create(const char* name, const char* file_path);
 void module_free(AetherModule* module);
@@ -70,7 +70,7 @@ typedef struct {
     int node_count;
 } DependencyGraph;
 
-DependencyGraph* dependency_graph_create();
+DependencyGraph* dependency_graph_create(void);
 void dependency_graph_free(DependencyGraph* graph);
 DependencyNode* dependency_graph_add_node(DependencyGraph* graph, const char* module_name);
 void dependency_graph_add_edge(DependencyGraph* graph, const char* from, const char* to);

--- a/compiler/codegen/optimizer.c
+++ b/compiler/codegen/optimizer.c
@@ -8,7 +8,7 @@
 
 OptimizationStats global_opt_stats = {0, 0, 0, 0, 0};
 
-void reset_optimization_stats() {
+void reset_optimization_stats(void) {
     global_opt_stats.constants_folded = 0;
     global_opt_stats.dead_code_removed = 0;
     global_opt_stats.tail_calls_detected = 0;
@@ -16,7 +16,7 @@ void reset_optimization_stats() {
     global_opt_stats.linear_loops_collapsed = 0;
 }
 
-void print_optimization_stats() {
+void print_optimization_stats(void) {
     printf("Optimization Statistics:\n");
     printf("  Constants folded: %d\n", global_opt_stats.constants_folded);
     printf("  Dead code removed: %d\n", global_opt_stats.dead_code_removed);

--- a/compiler/codegen/optimizer.h
+++ b/compiler/codegen/optimizer.h
@@ -40,8 +40,8 @@ typedef struct {
 
 extern OptimizationStats global_opt_stats;
 
-void reset_optimization_stats();
-void print_optimization_stats();
+void reset_optimization_stats(void);
+void print_optimization_stats(void);
 
 #endif // OPTIMIZER_H
 

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -50,12 +50,12 @@ void lexer_restore(const LexerState* in) {
     current_column = in->current_column;
 }
 
-char peek() {
+char peek(void) {
     if (current_pos >= source_length) return '\0';
     return source[current_pos];
 }
 
-char advance() {
+char advance(void) {
     if (current_pos >= source_length) return '\0';
     char c = source[current_pos++];
     if (c == '\n') {
@@ -73,7 +73,7 @@ char advance() {
     return c;
 }
 
-void skip_whitespace() {
+void skip_whitespace(void) {
     while (current_pos < source_length) {
         char c = peek();
         if (c == ' ' || c == '\t' || c == '\r') {
@@ -86,7 +86,7 @@ void skip_whitespace() {
     }
 }
 
-int skip_comment() {
+int skip_comment(void) {
     if (peek() == '/' && current_pos + 1 < source_length && source[current_pos + 1] == '/') {
         // Single line comment
         while (current_pos < source_length && peek() != '\n') {
@@ -115,7 +115,7 @@ int skip_comment() {
     return 0;
 }
 
-Token* read_string() {
+Token* read_string(void) {
     advance(); // skip opening quote
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
@@ -270,7 +270,7 @@ Token* read_string() {
     return token;
 }
 
-Token* read_number() {
+Token* read_number(void) {
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
     int i = 0;
@@ -423,7 +423,7 @@ Token* read_number() {
     return token;
 }
 
-Token* read_identifier() {
+Token* read_identifier(void) {
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
     int i = 0;
@@ -555,7 +555,7 @@ Token* read_raw_identifier(void) {
     return token;
 }
 
-Token* next_token() {
+Token* next_token(void) {
     skip_whitespace();
 
     token_start_line = current_line;

--- a/lsp/aether_lsp.c
+++ b/lsp/aether_lsp.c
@@ -46,7 +46,7 @@ static char* json_extract_string(const char* json, const char* key) {
 }
 
 // LSP Server lifecycle
-LSPServer* lsp_server_create() {
+LSPServer* lsp_server_create(void) {
     LSPServer* server = (LSPServer*)malloc(sizeof(LSPServer));
     if (!server) return NULL;
     server->input = stdin;

--- a/lsp/aether_lsp.h
+++ b/lsp/aether_lsp.h
@@ -19,7 +19,7 @@ typedef struct {
 } LSPServer;
 
 // LSP Server lifecycle
-LSPServer* lsp_server_create();
+LSPServer* lsp_server_create(void);
 void lsp_server_free(LSPServer* server);
 void lsp_server_run(LSPServer* server);
 

--- a/runtime/aether_runtime.c
+++ b/runtime/aether_runtime.c
@@ -104,7 +104,7 @@ void aether_runtime_init(int num_cores, int flags) {
 }
 
 // Get current runtime configuration
-const AetherRuntimeInitConfig* aether_runtime_get_config() {
+const AetherRuntimeInitConfig* aether_runtime_get_config(void) {
     if (!g_runtime_initialized) {
         // Initialize with defaults on first access
         aether_runtime_init(0, AETHER_FLAG_AUTO_DETECT);
@@ -119,7 +119,7 @@ int aether_runtime_has_feature(int feature_flag) {
 }
 
 // Print current runtime configuration
-void aether_runtime_print_config() {
+void aether_runtime_print_config(void) {
     const AetherRuntimeInitConfig* config = aether_runtime_get_config();
     const CPUInfo* cpu = cpu_get_info();
     
@@ -162,7 +162,7 @@ void aether_runtime_print_config() {
 }
 
 // Shutdown runtime
-void aether_runtime_shutdown() {
+void aether_runtime_shutdown(void) {
     g_runtime_initialized = 0;
 }
 

--- a/runtime/aether_runtime.h
+++ b/runtime/aether_runtime.h
@@ -30,7 +30,7 @@ typedef struct {
 
 // Runtime initialization
 void aether_runtime_init(int num_cores, int flags);
-void aether_runtime_shutdown();
+void aether_runtime_shutdown(void);
 
 // Command-line arguments (set by main, accessible from anywhere)
 extern int aether_argc;
@@ -79,9 +79,9 @@ void aether_args_seal(void);
 int  aether_args_sealed(void);
 
 // Configuration queries
-const AetherRuntimeInitConfig* aether_runtime_get_config();
+const AetherRuntimeInitConfig* aether_runtime_get_config(void);
 int aether_runtime_has_feature(int feature_flag);
-void aether_runtime_print_config();
+void aether_runtime_print_config(void);
 
 // Aether built-in `sleep(ms)` lowers to a call to this — a stable,
 // prefixed symbol that won't collide with libc's `sleep` if user code
@@ -89,11 +89,11 @@ void aether_runtime_print_config();
 void aether_sleep_ms(int ms);
 
 // Legacy compatibility
-static inline void aether_init() {
+static inline void aether_init(void) {
     aether_runtime_init(0, AETHER_FLAG_AUTO_DETECT);
 }
 
-static inline void aether_cleanup() {
+static inline void aether_cleanup(void) {
     aether_runtime_shutdown();
 }
 

--- a/runtime/examples/buffered_send_bench.c
+++ b/runtime/examples/buffered_send_bench.c
@@ -166,7 +166,7 @@ double bench_buffered(int num_actors, int messages_per_actor) {
     return throughput;
 }
 
-int main() {
+int main(void) {
     printf("Sender-Side Message Batching Benchmark\n");
     printf("======================================\n");
     

--- a/runtime/examples/high_throughput_actor.c
+++ b/runtime/examples/high_throughput_actor.c
@@ -127,7 +127,7 @@ void process_batch_zerocopy(
 }
 
 // Main example
-int main() {
+int main(void) {
     printf("High-Throughput Actor Example\n");
     printf("Optimizations: SIMD + Coalescing + Zero-Copy\n\n");
     

--- a/runtime/examples/index_bench.c
+++ b/runtime/examples/index_bench.c
@@ -105,7 +105,7 @@ double bench_index_passing(int num_actors, int msgs_per_actor) {
     return tput;
 }
 
-int main() {
+int main(void) {
     printf("Message Index Passing vs Copy Benchmark\n");
     printf("=======================================\n");
     

--- a/runtime/examples/manual_actor_test.c
+++ b/runtime/examples/manual_actor_test.c
@@ -19,7 +19,7 @@ void Counter_step(Counter* self) {
     (self->count = (self->count + 1));
 }
 
-Counter* spawn_Counter() {
+Counter* spawn_Counter(void) {
     Counter* actor = malloc(sizeof(Counter));
     actor->id = 0;
     actor->active = 1;
@@ -38,7 +38,7 @@ void send_Counter(Counter* actor, int type, int payload) {
     actor->active = 1;
 }
 
-int main() {
+int main(void) {
     Counter* c1 = spawn_Counter();
     Counter* c2 = spawn_Counter();
     

--- a/runtime/examples/multicore_bench.c
+++ b/runtime/examples/multicore_bench.c
@@ -92,7 +92,7 @@ void send_Node(Node* actor, int type) {
     }
 }
 
-int main() {
+int main(void) {
     int cores = 4;
     current_core_id = 0;  // Main thread acts as core 0
     

--- a/runtime/examples/ring_bench_buffered.c
+++ b/runtime/examples/ring_bench_buffered.c
@@ -42,7 +42,7 @@ void ring_step(void* self) {
     }
 }
 
-int main() {
+int main(void) {
     printf("Multicore Ring Benchmark with Buffered Sends\n");
     printf("============================================\n\n");
     

--- a/runtime/examples/ring_benchmark_manual.c
+++ b/runtime/examples/ring_benchmark_manual.c
@@ -33,7 +33,7 @@ void Node_step(Node* self) {
     }
 }
 
-int main() {
+int main(void) {
     Node** actors = malloc(NUM_ACTORS * sizeof(Node*));
     
     for (int i = 0; i < NUM_ACTORS; i++) {

--- a/runtime/examples/runtime_config_example.c
+++ b/runtime/examples/runtime_config_example.c
@@ -5,7 +5,7 @@
 #include "../aether_runtime.h"
 #include "../utils/aether_cpu_detect.h"
 
-void print_examples() {
+void print_examples(void) {
     printf("========================================\n");
     printf("  Aether Runtime Configuration Examples\n");
     printf("========================================\n\n");
@@ -48,7 +48,7 @@ void print_examples() {
     printf("========================================\n\n");
 }
 
-int main() {
+int main(void) {
     print_examples();
     
     // Example 1: Auto-detect (best for most users)

--- a/runtime/examples/simd_batch_processing.c
+++ b/runtime/examples/simd_batch_processing.c
@@ -13,7 +13,7 @@ typedef struct {
     int32_t payload;
 } SimpleMessage;
 
-int main() {
+int main(void) {
     printf("===========================================\n");
     printf("  SIMD Batch Processing Example\n");
     printf("===========================================\n\n");

--- a/runtime/examples/state_machine_bench.c
+++ b/runtime/examples/state_machine_bench.c
@@ -100,7 +100,7 @@ void counter_actor_step(Actor* self) {
 
 Actor* actors;
 
-int main() {
+int main(void) {
     printf("Allocating %d actors...\n", ACTOR_COUNT);
     actors = malloc(sizeof(Actor) * ACTOR_COUNT);
     

--- a/runtime/examples/workstealing_bench.c
+++ b/runtime/examples/workstealing_bench.c
@@ -69,7 +69,7 @@ void send_Node(Node* actor, int type) {
     }
 }
 
-int main() {
+int main(void) {
     int cores = 4;
     current_core_id = 0;
     

--- a/runtime/memory/aether_arena_optimized.c
+++ b/runtime/memory/aether_arena_optimized.c
@@ -100,7 +100,7 @@ static void thread_arena_destructor(void* arg) {
 }
 
 // Get or create thread-local arena
-static ThreadLocalArena* get_thread_arena() {
+static ThreadLocalArena* get_thread_arena(void) {
     if (tl_arena) return tl_arena;
     
     tl_arena = (ThreadLocalArena*)calloc(1, sizeof(ThreadLocalArena));
@@ -132,7 +132,7 @@ void arena_manager_init(int max_threads) {
     pthread_key_create(&global_manager.thread_key, thread_arena_destructor);
 }
 
-void arena_manager_shutdown() {
+void arena_manager_shutdown(void) {
     if (!global_manager.thread_arenas) return;
     
     pthread_key_delete(global_manager.thread_key);
@@ -185,7 +185,7 @@ void arena_get_thread_stats(uint64_t* allocated_bytes, uint64_t* allocation_coun
     }
 }
 
-void arena_reset_thread() {
+void arena_reset_thread(void) {
     ThreadLocalArena* arena = tl_arena;
     if (!arena) return;
     

--- a/runtime/memory/aether_arena_optimized.h
+++ b/runtime/memory/aether_arena_optimized.h
@@ -43,7 +43,7 @@ typedef struct {
 
 // Initialization
 void arena_manager_init(int max_threads);
-void arena_manager_shutdown();
+void arena_manager_shutdown(void);
 
 // Fast path allocation (thread-local, no locks)
 void* arena_alloc_fast(size_t bytes);
@@ -53,7 +53,7 @@ void* arena_alloc_fast_aligned(size_t bytes, size_t alignment);
 void arena_get_thread_stats(uint64_t* allocated_bytes, uint64_t* allocation_count);
 
 // Reset thread-local arena (for per-request allocations)
-void arena_reset_thread();
+void arena_reset_thread(void);
 
 // Get total memory statistics
 typedef struct {

--- a/runtime/memory/aether_memory_stats.c
+++ b/runtime/memory/aether_memory_stats.c
@@ -4,7 +4,7 @@
 
 static MemoryStats g_stats = {0};
 
-void memory_stats_init() {
+void memory_stats_init(void) {
     memset(&g_stats, 0, sizeof(MemoryStats));
 }
 
@@ -34,15 +34,15 @@ void memory_stats_record_free(size_t bytes) {
     }
 }
 
-void memory_stats_record_failure() {
+void memory_stats_record_failure(void) {
     g_stats.allocation_failures++;
 }
 
-MemoryStats memory_stats_get() {
+MemoryStats memory_stats_get(void) {
     return g_stats;
 }
 
-void memory_stats_print() {
+void memory_stats_print(void) {
     printf("\n========== Memory Statistics ==========\n");
     printf("Allocations:\n");
     printf("  Total:   %llu\n", (unsigned long long)g_stats.total_allocations);
@@ -74,7 +74,7 @@ void memory_stats_print() {
     printf("=======================================\n\n");
 }
 
-void memory_stats_reset() {
+void memory_stats_reset(void) {
     memset(&g_stats, 0, sizeof(MemoryStats));
 }
 

--- a/runtime/memory/aether_memory_stats.h
+++ b/runtime/memory/aether_memory_stats.h
@@ -16,13 +16,13 @@ typedef struct {
     uint64_t allocation_failures;
 } MemoryStats;
 
-void memory_stats_init();
+void memory_stats_init(void);
 void memory_stats_record_alloc(size_t bytes);
 void memory_stats_record_free(size_t bytes);
-void memory_stats_record_failure();
-MemoryStats memory_stats_get();
-void memory_stats_print();
-void memory_stats_reset();
+void memory_stats_record_failure(void);
+MemoryStats memory_stats_get(void);
+void memory_stats_print(void);
+void memory_stats_reset(void);
 
 #ifdef AETHER_MEMORY_TRACKING
     #define TRACK_ALLOC(bytes) memory_stats_record_alloc(bytes)

--- a/runtime/memory/aether_pool.c
+++ b/runtime/memory/aether_pool.c
@@ -93,7 +93,7 @@ void pool_destroy(MemoryPool* pool) {
     aether_caps_free(pool, sizeof(MemoryPool));
 }
 
-StandardPools* standard_pools_create() {
+StandardPools* standard_pools_create(void) {
     StandardPools* pools = (StandardPools*)aether_caps_malloc(sizeof(StandardPools));
     if (!pools) return NULL;
     

--- a/runtime/memory/aether_pool.h
+++ b/runtime/memory/aether_pool.h
@@ -21,7 +21,7 @@ typedef struct {
     MemoryPool* pool_256;
 } StandardPools;
 
-StandardPools* standard_pools_create();
+StandardPools* standard_pools_create(void);
 void* standard_pools_alloc(StandardPools* pools, size_t size);
 void standard_pools_free(StandardPools* pools, void* ptr, size_t size);
 void standard_pools_destroy(StandardPools* pools);

--- a/runtime/scheduler/aether_atomic_asm.h
+++ b/runtime/scheduler/aether_atomic_asm.h
@@ -71,7 +71,7 @@ static inline int atomic_fetch_add_asm(atomic_int* ptr, int value) {
 }
 
 // Optimized spin-lock using PAUSE instruction
-static inline void spin_pause() {
+static inline void spin_pause(void) {
     __asm__ volatile("pause" ::: "memory");
 }
 
@@ -140,7 +140,7 @@ static inline int atomic_fetch_add_asm(atomic_int* ptr, int value) {
     return atomic_fetch_add_explicit(ptr, value, memory_order_acq_rel);
 }
 
-static inline void spin_pause() {
+static inline void spin_pause(void) {
 #if defined(__aarch64__) || defined(__arm64__)
     // ARM64: yield gives up CPU time slice to other threads
     __asm__ volatile("yield" ::: "memory");

--- a/runtime/scheduler/aether_scheduler_coop.c
+++ b/runtime/scheduler/aether_scheduler_coop.c
@@ -70,19 +70,19 @@ void scheduler_init_with_opts(int cores, AetherOptFlags opts) {
 // Lifecycle — mostly no-ops in cooperative mode
 // ============================================================================
 
-void scheduler_start() {
+void scheduler_start(void) {
     // No threads to start
 }
 
-void scheduler_ensure_threads_running() {
+void scheduler_ensure_threads_running(void) {
     // No threads in cooperative mode — this is a no-op
 }
 
-void scheduler_stop() {
+void scheduler_stop(void) {
     // No threads to stop
 }
 
-void scheduler_cleanup() {
+void scheduler_cleanup(void) {
     if (schedulers[0].actors) {
         free(schedulers[0].actors);
         schedulers[0].actors = NULL;
@@ -90,7 +90,7 @@ void scheduler_cleanup() {
     schedulers[0].actor_count = 0;
 }
 
-void scheduler_shutdown() {
+void scheduler_shutdown(void) {
     // Drain all remaining messages
     int drained;
     do {
@@ -206,7 +206,7 @@ void scheduler_send_batch_flush(void) {
 // Wait for quiescence — poll until no messages remain
 // ============================================================================
 
-void scheduler_wait() {
+void scheduler_wait(void) {
     // Drain all pending messages cooperatively
     // Also wait for active timeouts to fire
     int idle_rounds = 0;

--- a/runtime/scheduler/multicore_scheduler.c
+++ b/runtime/scheduler/multicore_scheduler.c
@@ -1140,7 +1140,7 @@ void scheduler_init_with_opts(int cores, AetherOptFlags opts) {
     scheduler_init(cores);
 }
 
-void scheduler_start() {
+void scheduler_start(void) {
     // MAIN THREAD MODE: Single-actor programs don't need scheduler threads
     // All message processing happens synchronously on the main thread
     if (aether_main_thread_mode_active()) {
@@ -1186,7 +1186,7 @@ void scheduler_ensure_threads_running(void) {
     scheduler_start();
 }
 
-void scheduler_stop() {
+void scheduler_stop(void) {
     // Set all running flags to 0 with release semantics
     for (int i = 0; i < num_cores; i++) {
         atomic_store_explicit(&schedulers[i].running, 0, memory_order_release);
@@ -1257,7 +1257,7 @@ static int has_pending_actor_timeout(void) {
     return 0;
 }
 
-void scheduler_wait() {
+void scheduler_wait(void) {
     // MAIN THREAD MODE: All messages processed synchronously, nothing to wait for
     // This is the fastest path for single-actor programs (counting benchmark)
     if (aether_main_thread_mode_active()) {
@@ -1355,7 +1355,7 @@ void scheduler_wait() {
 // Full shutdown: wait for quiescence, stop threads, join them.
 // Called once at program exit.  Safe to call even if threads were never
 // started (main-thread mode) or already shut down.
-void scheduler_shutdown() {
+void scheduler_shutdown(void) {
     // Wait for any in-flight messages first
     scheduler_wait();
 
@@ -1384,7 +1384,7 @@ void scheduler_shutdown() {
     AETHER_TRACE_FLUSH();
 }
 
-void scheduler_cleanup() {
+void scheduler_cleanup(void) {
     // Free allocated scheduler resources
     for (int i = 0; i < num_cores; i++) {
         // Clean up thread resources

--- a/runtime/scheduler/multicore_scheduler.h
+++ b/runtime/scheduler/multicore_scheduler.h
@@ -202,12 +202,12 @@ void scheduler_init(int cores);
 // Initialize with explicit optimization flags
 void scheduler_init_with_opts(int cores, AetherOptFlags opts);
 
-void scheduler_start();
-void scheduler_ensure_threads_running();  // Start threads if not already started (for main-thread mode transition)
-void scheduler_stop();
-void scheduler_wait();      // Wait for quiescence (all pending messages processed). Non-destructive.
-void scheduler_shutdown();  // Wait + stop + join threads. Call once at program exit.
-void scheduler_cleanup();
+void scheduler_start(void);
+void scheduler_ensure_threads_running(void);  // Start threads if not already started (for main-thread mode transition)
+void scheduler_stop(void);
+void scheduler_wait(void);      // Wait for quiescence (all pending messages processed). Non-destructive.
+void scheduler_shutdown(void);  // Wait + stop + join threads. Call once at program exit.
+void scheduler_cleanup(void);
 
 int scheduler_register_actor(ActorBase* actor, int preferred_core);
 void scheduler_deregister_actor(ActorBase* actor);

--- a/runtime/scheduler/scheduler_optimizations.c
+++ b/runtime/scheduler/scheduler_optimizations.c
@@ -4,7 +4,7 @@
 // Global optimization statistics
 OptimizationStats g_opt_stats;
 
-void scheduler_opts_global_init() {
+void scheduler_opts_global_init(void) {
     atomic_store(&g_opt_stats.use_direct_send, true);
     atomic_store(&g_opt_stats.use_adaptive_batching, true);
     atomic_store(&g_opt_stats.use_message_dedup, false);

--- a/runtime/scheduler/scheduler_optimizations.h
+++ b/runtime/scheduler/scheduler_optimizations.h
@@ -32,7 +32,7 @@ typedef struct {
 extern OptimizationStats g_opt_stats;
 
 // Initialize optimization subsystem
-static inline void scheduler_opts_init() {
+static inline void scheduler_opts_init(void) {
     atomic_store(&g_opt_stats.use_direct_send, true);
     atomic_store(&g_opt_stats.use_adaptive_batching, true);
     atomic_store(&g_opt_stats.use_message_dedup, false);  // Opt-in per actor
@@ -170,7 +170,7 @@ static inline void optimized_process_batch_simd(
 }
 
 // Print optimization statistics
-static inline void scheduler_opts_print_stats() {
+static inline void scheduler_opts_print_stats(void) {
     printf("\n=== Scheduler Optimization Statistics ===\n");
     printf("Direct Send:  %d hits, %d misses (%.1f%% hit rate)\n",
         atomic_load(&g_opt_stats.direct_send_hits),

--- a/runtime/utils/aether_cpu_detect.c
+++ b/runtime/utils/aether_cpu_detect.c
@@ -230,7 +230,7 @@ void cpu_detect_features(CPUInfo* info) {
 }
 
 // Initialize and cache CPU info
-const CPUInfo* cpu_get_info() {
+const CPUInfo* cpu_get_info(void) {
     if (!g_cpu_info_initialized) {
         cpu_detect_features(&g_cpu_info);
         g_cpu_info_initialized = 1;
@@ -239,27 +239,27 @@ const CPUInfo* cpu_get_info() {
 }
 
 // Check if AVX2 is available
-int cpu_has_avx2() {
+int cpu_has_avx2(void) {
     return cpu_get_info()->avx2_supported;
 }
 
 // Check if AVX-512 is available
-int cpu_has_avx512() {
+int cpu_has_avx512(void) {
     return cpu_get_info()->avx512f_supported;
 }
 
 // Check if MONITOR/MWAIT is available
-int cpu_has_mwait() {
+int cpu_has_mwait(void) {
     return cpu_get_info()->mwait_supported;
 }
 
 // Check if SSE4.2 is available
-int cpu_has_sse42() {
+int cpu_has_sse42(void) {
     return cpu_get_info()->sse42_supported;
 }
 
 // Print CPU capabilities
-void cpu_print_info() {
+void cpu_print_info(void) {
     const CPUInfo* info = cpu_get_info();
     
     printf("=== CPU Information ===\n");
@@ -304,7 +304,7 @@ void cpu_print_info() {
 }
 
 // Recommend optimal core count
-int cpu_recommend_cores() {
+int cpu_recommend_cores(void) {
     const CPUInfo* info = cpu_get_info();
 
     // Use all logical cores, but cap at 16 for diminishing returns

--- a/runtime/utils/aether_simd_vectorized.c
+++ b/runtime/utils/aether_simd_vectorized.c
@@ -16,7 +16,7 @@
 #endif
 
 // CPU feature detection (extern from aether_cpu_detect.c)
-int cpu_supports_avx2() {
+int cpu_supports_avx2(void) {
 #ifdef __AVX2__
     // Simplified check - assume available if compiled with AVX2
     return 1;
@@ -185,7 +185,7 @@ int count_active_actors_avx2(const uint8_t* active_flags, int count) {
 // Public API with runtime dispatch
 static int g_avx2_available = -1;  // -1 = not checked, 0 = no, 1 = yes
 
-void aether_simd_init() {
+void aether_simd_init(void) {
     if (g_avx2_available == -1) {
         g_avx2_available = cpu_supports_avx2();
         if (g_avx2_available) {
@@ -196,7 +196,7 @@ void aether_simd_init() {
     }
 }
 
-int aether_simd_is_available() {
+int aether_simd_is_available(void) {
     if (g_avx2_available == -1) {
         aether_simd_init();
     }

--- a/runtime/utils/aether_simd_vectorized.h
+++ b/runtime/utils/aether_simd_vectorized.h
@@ -5,10 +5,10 @@
 #include <stdint.h>
 
 // Initialize SIMD system (detects AVX2)
-void aether_simd_init();
+void aether_simd_init(void);
 
 // Check if AVX2 is available
-int aether_simd_is_available();
+int aether_simd_is_available(void);
 
 // Vectorized operations (8-wide AVX2 or scalar fallback)
 void extract_message_ids_avx2(const void** msg_data, int32_t* msg_ids, int count);

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -74,7 +74,7 @@ ArrayList* list_new_in(AetherAllocator* alloc) {
     return list;
 }
 
-ArrayList* list_new() {
+ArrayList* list_new(void) {
     return list_new_in(NULL);
 }
 
@@ -379,7 +379,7 @@ static int key_equals(const HashMapEntry* e, const char* b, unsigned int b_len) 
     return memcmp(e->key->data, b, b_len) == 0;
 }
 
-HashMap* map_new() {
+HashMap* map_new(void) {
     HashMap* map = (HashMap*)aether_caps_malloc(sizeof(HashMap));
     if (!map) return NULL;
     map->_kind_magic = AETHER_KIND_MAP_MAGIC;

--- a/std/collections/aether_collections.h
+++ b/std/collections/aether_collections.h
@@ -11,7 +11,7 @@ typedef struct IntArray IntArray;
 typedef struct FloatArray FloatArray;
 typedef struct LongArray LongArray;
 
-ArrayList* list_new();
+ArrayList* list_new(void);
 ArrayList* list_new_in(AetherAllocator* alloc);
 int list_add_raw(ArrayList* list, void* item);
 
@@ -48,7 +48,7 @@ void list_remove(ArrayList* list, int index);
 void list_clear(ArrayList* list);
 void list_free(ArrayList* list);
 
-HashMap* map_new();
+HashMap* map_new(void);
 int map_put_raw(HashMap* map, const char* key, void* value);
 
 /* Heap-string-aware put (#467). Retains the value and tags the

--- a/std/log/aether_log.c
+++ b/std/log/aether_log.c
@@ -118,7 +118,7 @@ void log_init_with_config(LogConfig* config) {
     g_log.initialized = 1;
 }
 
-void log_shutdown() {
+void log_shutdown(void) {
     if (g_log.initialized && g_log.config.output_file &&
         g_log.config.output_file != stderr && g_log.config.output_file != stdout) {
         fclose(g_log.config.output_file);
@@ -244,11 +244,11 @@ void log_set_format(const char* format) {
 }
 
 // Statistics
-LogStats* log_get_stats() {
+LogStats* log_get_stats(void) {
     return &g_log.stats;
 }
 
-void log_print_stats() {
+void log_print_stats(void) {
     fprintf(stderr, "\n========== Logging Statistics ==========\n");
     fprintf(stderr, "DEBUG: %zu\n", g_log.stats.debug_count);
     fprintf(stderr, "INFO:  %zu\n", g_log.stats.info_count);

--- a/std/log/aether_log.h
+++ b/std/log/aether_log.h
@@ -27,7 +27,7 @@ typedef struct {
 // log file could not be opened (logging still works via stderr).
 int log_init_raw(const char* filename, LogLevel min_level);
 void log_init_with_config(LogConfig* config);
-void log_shutdown();
+void log_shutdown(void);
 
 // Core logging functions
 void log_write(LogLevel level, const char* fmt, ...);
@@ -62,8 +62,8 @@ typedef struct {
     size_t fatal_count;
 } LogStats;
 
-LogStats* log_get_stats();
-void log_print_stats();
+LogStats* log_get_stats(void);
+void log_print_stats(void);
 
 #endif // AETHER_LOG_H
 

--- a/std/log/demo_log.c
+++ b/std/log/demo_log.c
@@ -18,7 +18,7 @@ void perform_task(int task_id) {
     LOG_INFO("Task %d completed successfully", task_id);
 }
 
-int main() {
+int main(void) {
     printf("Aether Logging System Demo\n");
     printf("===========================\n\n");
     

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -799,7 +799,7 @@ static const char* http_strcasestr(const char* haystack, const char* needle) {
 
 static int http_server_initialized = 0;
 
-static void http_server_init() {
+static void http_server_init(void) {
     if (http_server_initialized) return;
     #ifdef _WIN32
     WSADATA wsa_data;
@@ -1986,7 +1986,7 @@ void http_request_free(HttpRequest* req) {
 }
 
 // Response building
-HttpServerResponse* http_response_create() {
+HttpServerResponse* http_response_create(void) {
     HttpServerResponse* res = (HttpServerResponse*)calloc(1, sizeof(HttpServerResponse));
     if (!res) return NULL;
     res->status_code = 200;

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -112,7 +112,7 @@ const char* http_get_header(HttpRequest* r, const char* k) { (void)r; (void)k; r
 const char* http_get_query_param(HttpRequest* r, const char* k) { (void)r; (void)k; return NULL; }
 const char* http_get_path_param(HttpRequest* r, const char* k) { (void)r; (void)k; return NULL; }
 void http_request_free(HttpRequest* r) { (void)r; }
-HttpServerResponse* http_response_create() { return NULL; }
+HttpServerResponse* http_response_create(void) { return NULL; }
 void http_response_set_status(HttpServerResponse* r, int c) { (void)r; (void)c; }
 void http_response_set_header(HttpServerResponse* r, const char* k, const char* v) { (void)r; (void)k; (void)v; }
 void http_response_add_header(HttpServerResponse* r, const char* k, const char* v) { (void)r; (void)k; (void)v; }

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -445,7 +445,7 @@ const char* http_get_path_param(HttpRequest* req, const char* key);
 void http_request_free(HttpRequest* req);
 
 // Response building
-HttpServerResponse* http_response_create();
+HttpServerResponse* http_response_create(void);
 void http_response_set_status(HttpServerResponse* res, int code);
 void http_response_set_header(HttpServerResponse* res, const char* key, const char* value);
 /* Append a header verbatim, even if a header with the same name

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -76,7 +76,7 @@ struct TcpServer {
 
 static int net_initialized = 0;
 
-static void net_init() {
+static void net_init(void) {
     if (net_initialized) return;
     #ifdef _WIN32
     WSADATA wsa_data;

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -78,7 +78,7 @@ AetherString* string_new_with_length(const char* data, size_t length) {
     return str;
 }
 
-AetherString* string_empty() {
+AetherString* string_empty(void) {
     return string_new_with_length("", 0);
 }
 

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -52,7 +52,7 @@ AetherString* string_new(const char* cstr);
 AetherString* string_from_cstr(const char* cstr);  // Alias for new
 AetherString* string_from_literal(const char* cstr);  // Alias for new
 AetherString* string_new_with_length(const char* data, size_t length);
-AetherString* string_empty();
+AetherString* string_empty(void);
 
 // Reference counting — safe to call with plain char* (no-op)
 void string_retain(const void* str);

--- a/tests/compiler/test_arrays.c
+++ b/tests/compiler/test_arrays.c
@@ -36,7 +36,7 @@ static Parser* create_test_parser(Token** tokens, int token_count) {
 } while(0)
 
 // Test array literal parsing
-int test_array_literal_parsing() {
+int test_array_literal_parsing(void) {
     const char* code = "main() { let arr = [1, 2, 3]; }";
     
     lexer_init(code);
@@ -78,7 +78,7 @@ int test_array_literal_parsing() {
 }
 
 // Test array indexing parsing
-int test_array_indexing_parsing() {
+int test_array_indexing_parsing(void) {
     const char* code = "main() { let x = arr[0]; }";
     
     lexer_init(code);
@@ -112,7 +112,7 @@ int test_array_indexing_parsing() {
 }
 
 // Test fixed array type parsing
-int test_fixed_array_type() {
+int test_fixed_array_type(void) {
     const char* code = "main() { let nums = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; }";
     
     lexer_init(code);
@@ -148,7 +148,7 @@ int test_fixed_array_type() {
 }
 
 // Test make() for dynamic arrays
-int test_make_dynamic_array() {
+int test_make_dynamic_array(void) {
     const char* code = "main() { let buf = make([]int, 100); }";
     
     lexer_init(code);
@@ -185,7 +185,7 @@ int test_make_dynamic_array() {
 }
 
 // Test multi-dimensional arrays
-int test_multidimensional_arrays() {
+int test_multidimensional_arrays(void) {
     const char* code = "main() { let matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]; }";
     
     lexer_init(code);
@@ -225,7 +225,7 @@ int test_multidimensional_arrays() {
     return 1;
 }
 
-int main() {
+int main(void) {
     int passed = 0;
     int total = 0;
     

--- a/tests/compiler/test_lexer.c
+++ b/tests/compiler/test_lexer.c
@@ -57,6 +57,6 @@ TEST_CATEGORY(lexer_strings, TEST_CATEGORY_COMPILER) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_lexer_tests() {
+void register_lexer_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/memory/test_memory_arena.c
+++ b/tests/memory/test_memory_arena.c
@@ -160,6 +160,6 @@ TEST_CATEGORY(arena_nested_scopes, TEST_CATEGORY_MEMORY) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_memory_arena_tests() {
+void register_memory_arena_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/memory/test_memory_pool.c
+++ b/tests/memory/test_memory_pool.c
@@ -196,6 +196,6 @@ TEST_CATEGORY(pool_alignment_odd_object_size, TEST_CATEGORY_MEMORY) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_memory_pool_tests() {
+void register_memory_pool_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/runtime/bench_atomic_overhead.c
+++ b/tests/runtime/bench_atomic_overhead.c
@@ -15,7 +15,7 @@
 // Test: Counter Increment Overhead
 // ============================================================================
 
-void bench_counter_overhead() {
+void bench_counter_overhead(void) {
     printf("\n=== Counter Increment Overhead ===\n");
     
     const int ITERATIONS = 10000000;  // 10M iterations
@@ -46,7 +46,7 @@ void bench_counter_overhead() {
 // Test: Mailbox Operation Overhead
 // ============================================================================
 
-void bench_mailbox_operations() {
+void bench_mailbox_operations(void) {
     printf("\n=== Mailbox Operation Overhead ===\n");
     
     const int ITERATIONS = 1000000;  // 1M iterations
@@ -88,7 +88,7 @@ void bench_mailbox_operations() {
 // Test: Message Copy Overhead
 // ============================================================================
 
-void bench_message_copy() {
+void bench_message_copy(void) {
     printf("\n=== Message Copy Overhead ===\n");
     
     const int ITERATIONS = 10000000;
@@ -128,7 +128,7 @@ typedef struct {
     _Atomic int message_count;  // Atomic int
 } AtomicActor;
 
-void bench_actor_loop() {
+void bench_actor_loop(void) {
     printf("\n=== Actor Message Processing Loop ===\n");
     
     const int MESSAGES = 1000000;
@@ -189,7 +189,7 @@ void bench_actor_loop() {
 // Main
 // ============================================================================
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("     Aether Micro-Benchmarks: Atomic Operation Overhead\n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_batched_atomic.c
+++ b/tests/runtime/bench_batched_atomic.c
@@ -67,7 +67,7 @@ void* new_actor_thread(void* arg) {
     return NULL;
 }
 
-int main() {
+int main(void) {
     printf("=== Batched Atomic Optimization Benchmark ===\n");
     printf("Messages: %d\n\n", MESSAGES);
     

--- a/tests/runtime/bench_plain_vs_atomic.c
+++ b/tests/runtime/bench_plain_vs_atomic.c
@@ -14,7 +14,7 @@
 
 #define ITERATIONS 10000000
 
-int main() {
+int main(void) {
     printf("=== Atomic Overhead Benchmark ===\n");
     printf("Iterations: %d\n\n", ITERATIONS);
     

--- a/tests/runtime/bench_profiled.c
+++ b/tests/runtime/bench_profiled.c
@@ -8,7 +8,7 @@
 #include "../../runtime/actors/actor_state_machine.h"
 #include "../../runtime/utils/aether_runtime_profile.h"
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("     Aether Profiled Benchmark - Continuous Monitoring\n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_scheduler.c
+++ b/tests/runtime/bench_scheduler.c
@@ -77,7 +77,7 @@ void bench_actor_step(BenchActor* self) {
 // Benchmark Functions
 // ============================================================================
 
-void bench_single_core_throughput() {
+void bench_single_core_throughput(void) {
     printf("\n=== Single Core Throughput ===\n");
 
     scheduler_init(1);
@@ -192,7 +192,7 @@ void bench_multi_core_throughput(int cores) {
     free(actors);
 }
 
-void bench_cross_core_overhead() {
+void bench_cross_core_overhead(void) {
     printf("\n=== Cross-Core Messaging Overhead ===\n");
     
     scheduler_init(4);
@@ -252,7 +252,7 @@ actor1->count_local = 0;
     }
 }
 
-void bench_scalability() {
+void bench_scalability(void) {
     printf("\n=== Scalability Analysis ===\n");
     printf("Cores | Throughput (msg/sec) | Efficiency\n");
     printf("------|----------------------|-----------\n");
@@ -327,7 +327,7 @@ void bench_scalability() {
         free(actors);
     }
 }
-void bench_latency() {
+void bench_latency(void) {
     printf("\n=== Latency Test ===");
     
     scheduler_init(2);
@@ -383,7 +383,7 @@ void bench_latency() {
     free(schedulers[1].actors);
 }
 
-void bench_contention() {
+void bench_contention(void) {
     printf("\n=== Contention Test (Many-to-One) ===");
     
     scheduler_init(4);
@@ -439,7 +439,7 @@ void bench_contention() {
     }
 }
 
-void bench_burst_patterns() {
+void bench_burst_patterns(void) {
     printf("\n=== Burst Pattern Test ===");
     
     scheduler_init(2);
@@ -496,7 +496,7 @@ void bench_burst_patterns() {
     free(schedulers[0].actors);
     free(schedulers[1].actors);
 }
-void bench_mailbox_saturation() {
+void bench_mailbox_saturation(void) {
     printf("\n=== Mailbox Saturation Test ===\n");
     
     scheduler_init(2);
@@ -551,7 +551,7 @@ void bench_mailbox_saturation() {
 // Main
 // ============================================================================
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("        Aether Scheduler Performance Benchmarks               \n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_zerocopy.c
+++ b/tests/runtime/bench_zerocopy.c
@@ -45,7 +45,7 @@ void bench_actor_step(BenchActor* self) {
     atomic_store_explicit(&self->active, (self->mailbox.count > 0), memory_order_relaxed);
 }
 
-void benchmark_small_messages() {
+void benchmark_small_messages(void) {
     printf("\n=== Benchmark: Small Messages (64 bytes, inline) ===\n");
 
     scheduler_init(1);
@@ -88,7 +88,7 @@ void benchmark_small_messages() {
     free(actor);
 }
 
-void benchmark_large_messages() {
+void benchmark_large_messages(void) {
     printf("\n=== Benchmark: Large Messages (1KB, zero-copy) ===\n");
     
     scheduler_init(1);
@@ -139,7 +139,7 @@ void benchmark_large_messages() {
     free(actor);
 }
 
-void benchmark_mixed_messages() {
+void benchmark_mixed_messages(void) {
     printf("\n=== Benchmark: Mixed Messages (33%% large) ===\n");
     
     scheduler_init(1);
@@ -192,7 +192,7 @@ void benchmark_mixed_messages() {
     free(actor);
 }
 
-int main() {
+int main(void) {
     printf("Zero-Copy Message Passing Performance Benchmark\n");
     printf("================================================\n");
     

--- a/tests/runtime/test_lockfree_mailbox.c
+++ b/tests/runtime/test_lockfree_mailbox.c
@@ -156,6 +156,6 @@ TEST_CATEGORY(lockfree_mailbox_thread_safety, TEST_CATEGORY_RUNTIME) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_lockfree_mailbox_tests() {
+void register_lockfree_mailbox_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/runtime/test_runtime_manual.c
+++ b/tests/runtime/test_runtime_manual.c
@@ -21,7 +21,7 @@ void Counter_step(Counter* self) {
     (self->count = (self->count + 1));
 }
 
-Counter* spawn_Counter() {
+Counter* spawn_Counter(void) {
     Counter* actor = malloc(sizeof(Counter));
     actor->id = 1;
     atomic_store_explicit(&actor->active, 1, memory_order_relaxed);
@@ -41,7 +41,7 @@ void send_message(void* actor_ptr, int type, int payload) {
     atomic_store_explicit(&actor->active, 1, memory_order_relaxed);
 }
 
-int main() {
+int main(void) {
     Counter* c = spawn_Counter();
     
     send_message(c, 1, 0);

--- a/tests/runtime/test_scheduler_optimizations.c
+++ b/tests/runtime/test_scheduler_optimizations.c
@@ -346,7 +346,7 @@ TEST_CATEGORY(direct_send_stats, TEST_CATEGORY_RUNTIME) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_scheduler_optimization_tests() {
+void register_scheduler_optimization_tests(void) {
     // Empty - tests registered by constructor
 }
 

--- a/tests/runtime/test_scheduler_stress.c
+++ b/tests/runtime/test_scheduler_stress.c
@@ -97,7 +97,7 @@ static void cascade_step(CascadeActor* self) {
 // Stress Tests
 // ============================================================================
 
-void test_rapid_init_shutdown() {
+void test_rapid_init_shutdown(void) {
     // Test multiple init/shutdown cycles
     for (int cycle = 0; cycle < 5; cycle++) {
         scheduler_init(2);
@@ -108,7 +108,7 @@ void test_rapid_init_shutdown() {
     }
 }
 
-void test_zero_message_workload() {
+void test_zero_message_workload(void) {
     scheduler_init(2);
     scheduler_start();
     
@@ -119,7 +119,7 @@ void test_zero_message_workload() {
     scheduler_cleanup();
 }
 
-void test_single_message() {
+void test_single_message(void) {
     scheduler_init(1);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -150,7 +150,7 @@ void test_single_message() {
     free(actor);
 }
 
-void test_many_actors_single_core() {
+void test_many_actors_single_core(void) {
     scheduler_init(1);
     
     const int NUM_ACTORS = 100;
@@ -195,7 +195,7 @@ void test_many_actors_single_core() {
     free(actors);
 }
 
-void test_burst_then_idle() {
+void test_burst_then_idle(void) {
     scheduler_init(2);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -247,7 +247,7 @@ void test_burst_then_idle() {
     free(actor);
 }
 
-void test_max_cores() {
+void test_max_cores(void) {
     int max = MAX_CORES;
     if (max > 16) max = 16;  // Limit for test speed
     
@@ -297,7 +297,7 @@ void test_max_cores() {
     free(actors);
 }
 
-void test_alternating_load() {
+void test_alternating_load(void) {
     scheduler_init(4);
     
     StressActor** actors = malloc(4 * sizeof(StressActor*));
@@ -348,7 +348,7 @@ void test_alternating_load() {
     free(actors);
 }
 
-void test_immediate_shutdown() {
+void test_immediate_shutdown(void) {
     scheduler_init(2);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -378,7 +378,7 @@ void test_immediate_shutdown() {
     free(actor);
 }
 
-void test_concurrent_sends_same_actor() {
+void test_concurrent_sends_same_actor(void) {
     scheduler_init(4);
 
     StressActor* actor = malloc(sizeof(StressActor));
@@ -418,7 +418,7 @@ void test_concurrent_sends_same_actor() {
     }
 }
 
-void test_priority_inversion() {
+void test_priority_inversion(void) {
     scheduler_init(2);
     
     StressActor* slow = malloc(sizeof(StressActor));
@@ -473,7 +473,7 @@ void test_priority_inversion() {
     free(fast);
 }
 
-void test_message_ordering_under_load() {
+void test_message_ordering_under_load(void) {
     scheduler_init(1);
 
     OrderActor* actor = malloc(sizeof(OrderActor));
@@ -515,7 +515,7 @@ void test_message_ordering_under_load() {
     schedulers[0].actors = NULL;
 }
 
-void test_cascading_messages() {
+void test_cascading_messages(void) {
     scheduler_init(2);
 
     CascadeActor* actors[3];
@@ -572,7 +572,7 @@ void test_cascading_messages() {
     }
 }
 
-void test_memory_pressure() {
+void test_memory_pressure(void) {
     scheduler_init(2);
     
     const int MANY = 50;

--- a/tests/runtime/test_zerocopy.c
+++ b/tests/runtime/test_zerocopy.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-void test_zerocopy_message_creation() {
+void test_zerocopy_message_creation(void) {
     // Test small message (no zero-copy)
     Message msg1 = message_create_simple(MSG_INCREMENT, 1, 42);
     ASSERT_EQ(msg1.type, MSG_INCREMENT);
@@ -34,7 +34,7 @@ void test_zerocopy_message_creation() {
     message_free(&msg2);
 }
 
-void test_zerocopy_message_transfer() {
+void test_zerocopy_message_transfer(void) {
     int size = 1024;
     void* data = malloc(size);
     memset(data, 0xCD, size);
@@ -59,7 +59,7 @@ void test_zerocopy_message_transfer() {
     message_free(&dest);
 }
 
-void test_zerocopy_mailbox_operations() {
+void test_zerocopy_mailbox_operations(void) {
     Mailbox mbox;
     mailbox_init(&mbox);
     
@@ -93,7 +93,7 @@ void test_zerocopy_mailbox_operations() {
     ASSERT_EQ(mbox.count, 0);
 }
 
-void test_zerocopy_threshold() {
+void test_zerocopy_threshold(void) {
     // Messages below threshold should not allocate
     Message small = message_create_simple(MSG_INCREMENT, 1, 100);
     ASSERT_TRUE(small.zerocopy.data == NULL);
@@ -109,7 +109,7 @@ void test_zerocopy_threshold() {
     message_free(&large);
 }
 
-void test_zerocopy_batch_operations() {
+void test_zerocopy_batch_operations(void) {
     Mailbox mbox;
     mailbox_init(&mbox);
     
@@ -148,7 +148,7 @@ void test_zerocopy_batch_operations() {
     ASSERT_EQ(zerocopy_count, 2);
 }
 
-void test_zerocopy_message_free() {
+void test_zerocopy_message_free(void) {
     // Test freeing null/unowned message (should be safe)
     Message msg1 = message_create_simple(MSG_INCREMENT, 1, 42);
     message_free(&msg1);  // Should be no-op
@@ -162,7 +162,7 @@ void test_zerocopy_message_free() {
     ASSERT_TRUE(msg2.zerocopy.data == NULL);
 }
 
-void register_zerocopy_tests() {
+void register_zerocopy_tests(void) {
     register_test_with_category("Zero-copy message creation", test_zerocopy_message_creation, TEST_CATEGORY_RUNTIME);
     register_test_with_category("Zero-copy message transfer", test_zerocopy_message_transfer, TEST_CATEGORY_RUNTIME);
     register_test_with_category("Zero-copy mailbox operations", test_zerocopy_mailbox_operations, TEST_CATEGORY_RUNTIME);

--- a/tools/apkg/apkg.c
+++ b/tools/apkg/apkg.c
@@ -240,7 +240,7 @@ int apkg_install(const char* package) {
     return 0;
 }
 
-int apkg_publish() {
+int apkg_publish(void) {
     printf("Publishing package...\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -312,7 +312,7 @@ int apkg_publish() {
     return 0;
 }
 
-int apkg_build() {
+int apkg_build(void) {
     printf("Building package...\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -380,7 +380,7 @@ int apkg_build() {
     return 0;
 }
 
-int apkg_test() {
+int apkg_test(void) {
     printf("Running tests...\n");
     
     // Check if tests directory exists
@@ -572,7 +572,7 @@ int apkg_search(const char* query) {
     return 0;
 }
 
-int apkg_update() {
+int apkg_update(void) {
     printf("Updating dependencies...\n\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -659,7 +659,7 @@ int apkg_update() {
     return 0;
 }
 
-int apkg_run() {
+int apkg_run(void) {
     printf("Running package...\n");
     
     // Check if we need to build
@@ -723,7 +723,7 @@ int apkg_run() {
     return result;
 }
 
-void apkg_print_help() {
+void apkg_print_help(void) {
     printf("apkg - Aether Package Manager v%s\n\n", APKG_VERSION);
     printf("USAGE:\n");
     printf("    apkg <command> [options]\n\n");
@@ -741,7 +741,7 @@ void apkg_print_help() {
     printf("For more information, see: https://github.com/aether-lang-dev/aether\n");
 }
 
-void apkg_print_version() {
+void apkg_print_version(void) {
     printf("apkg %s\n", APKG_VERSION);
 }
 

--- a/tools/apkg/apkg.h
+++ b/tools/apkg/apkg.h
@@ -25,20 +25,20 @@ typedef struct {
 
 int apkg_init(const char* name);
 int apkg_install(const char* package);
-int apkg_publish();
-int apkg_build();
-int apkg_test();
+int apkg_publish(void);
+int apkg_build(void);
+int apkg_test(void);
 int apkg_search(const char* query);
-int apkg_update();
-int apkg_run();
+int apkg_update(void);
+int apkg_run(void);
 
 void apkg_free_package(Package* pkg);
 
 PackageInfo apkg_find_package(const char* name);
 int apkg_download_package(const char* name, const char* version);
 
-void apkg_print_help();
-void apkg_print_version();
+void apkg_print_help(void);
+void apkg_print_version(void);
 
 #endif
 

--- a/tools/profiler/profiler_demo.c
+++ b/tools/profiler/profiler_demo.c
@@ -16,7 +16,7 @@
 #endif
 
 // Simulate actor activity for profiling
-void simulate_actor_activity() {
+void simulate_actor_activity(void) {
     printf("Simulating actor activity for profiling...\n");
     
     Arena* arena = arena_create(1024 * 1024); // 1MB arena

--- a/tools/profiler/profiler_server.c
+++ b/tools/profiler/profiler_server.c
@@ -42,7 +42,7 @@ static struct {
 } g_profiler = {0};
 
 // Helper functions
-double profiler_get_time_ms() {
+double profiler_get_time_ms(void) {
     struct timespec ts;
     #ifdef _WIN32
     timespec_get(&ts, TIME_UTC);
@@ -52,11 +52,11 @@ double profiler_get_time_ms() {
     return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
 }
 
-static double get_current_time_ms() {
+static double get_current_time_ms(void) {
     return profiler_get_time_ms();
 }
 
-static void init_winsock() {
+static void init_winsock(void) {
     #ifdef _WIN32
     static int winsock_initialized = 0;
     if (!winsock_initialized) {
@@ -232,7 +232,7 @@ void profiler_init(ProfilerConfig* config) {
     printf("[Profiler] Initialized with max %d events\n", config->max_events);
 }
 
-void profiler_shutdown() {
+void profiler_shutdown(void) {
     if (!g_profiler.initialized) return;
     
     profiler_stop_server();
@@ -244,7 +244,7 @@ void profiler_shutdown() {
     printf("[Profiler] Shutdown complete\n");
 }
 
-void profiler_start_server() {
+void profiler_start_server(void) {
     if (!g_profiler.initialized || g_profiler.server_running) return;
     
     init_winsock();
@@ -287,7 +287,7 @@ void profiler_start_server() {
     printf("\n");
 }
 
-void profiler_stop_server() {
+void profiler_stop_server(void) {
     if (!g_profiler.server_running) return;
     
     g_profiler.server_running = 0;
@@ -321,11 +321,11 @@ void profiler_record_event(ProfilerEvent* event) {
     pthread_mutex_unlock(&g_profiler.event_mutex);
 }
 
-int profiler_is_enabled() {
+int profiler_is_enabled(void) {
     return g_profiler.initialized && g_profiler.config.enabled;
 }
 
-MetricsSnapshot profiler_get_current_metrics() {
+MetricsSnapshot profiler_get_current_metrics(void) {
     MetricsSnapshot metrics = {0};
     
     // Get memory stats

--- a/tools/profiler/profiler_server.h
+++ b/tools/profiler/profiler_server.h
@@ -39,11 +39,11 @@ typedef struct {
 
 // Profiler API
 void profiler_init(ProfilerConfig* config);
-void profiler_shutdown();
-void profiler_start_server();
-void profiler_stop_server();
+void profiler_shutdown(void);
+void profiler_start_server(void);
+void profiler_stop_server(void);
 void profiler_record_event(ProfilerEvent* event);
-int profiler_is_enabled();
+int profiler_is_enabled(void);
 
 // Metric snapshot for JSON export
 typedef struct {
@@ -71,12 +71,12 @@ typedef struct {
     double timestamp_ms;
 } MetricsSnapshot;
 
-MetricsSnapshot profiler_get_current_metrics();
+MetricsSnapshot profiler_get_current_metrics(void);
 const char* profiler_metrics_to_json(MetricsSnapshot* metrics);
 const char* profiler_events_to_json(int count, int offset);
 
 // Helper function
-double profiler_get_time_ms();
+double profiler_get_time_ms(void);
 
 #endif // AETHER_PROFILER_SERVER_H
 


### PR DESCRIPTION
Closes #1996.

## What

In C before C23, `foo()` means "unspecified arguments", not "no arguments", so the compiler cannot check a call against such a declaration — a call passing arguments to a `foo()`-declared function is accepted silently. The project builds as C11 across GCC, Clang and MSYS2, where this is a real argument-checking hole across our own code (no vendored code involved).

Every no-argument declaration/definition the flag reaches now uses `(void)`, and **`-Wstrict-prototypes` is added to `CFLAGS`** so the gap cannot reopen. Mechanical, no behaviour change.

## Scope — verified against every `CFLAGS` + `-Werror` path, not one build's count

The issue estimated ~190 from a wide sweep; a single mainline `make ae` build only flags 40, because different build variants compile different files and neither GCC nor Clang flags `foo() {` *definitions* with bodies (only declarations/prototypes). Rather than trust one number, I fixed everything the flag reaches across all paths — **136 sites, 57 files**:

- **`-Werror` compiler build** (`make compiler EXTRA_CFLAGS=-Werror`, the `make ci` step 1/10) → **0**.
- **ci-coop** (no-pthreads scheduler compiles `aether_scheduler_coop.c`, `aether_cpu_detect.c`, memory-stats, etc. that mainline does not) → **0**, PASSED.
- **check-standalone** (`-Werror`; examples, benches, profiler, demos, `test_arrays.c`) → clean, 22 files.
- Mainline `make ae` → **0** warnings.

Doing this incrementally is why it grew from 40 → 136: each `-Werror` leg surfaced files the previous build didn't compile. Better found here than as a red CI leg.

## Care taken

- Fixes were driven by the compiler's own `file:line` locations (not a blind regex) and applied **binary-safe**: a first attempt in text mode would have rewritten the CRLF line endings in the Windows-authored `aether_lsp.*` / `aether_module.h` (a phantom 1498-line diff). Reverted and redone preserving CRLF — verified every touched file keeps its original line endings.
- Every changed line is a genuine declaration/definition (`Type foo()` → `Type foo(void)`); no call sites or function-pointer types touched. Diff is balanced (136 ins / 136 del across C files).

`make test`: 410 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)