### PR TITLE
Clear the open issue backlog: 6 fixes, and the propagation pass is no longer quadratic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,103 +232,12 @@ jobs:
         if printf '%s\n' "$changed" | grep -q '^CHANGELOG\.md$'; then
           echo "CHANGELOG.md is updated."
 
-          # ... and the entry has to be somewhere the release can find it.
-          # The release job renames the FIRST '## [current]' into the version
-          # heading, so an entry that is not under one ships nowhere.
-          #
-          # This is not hypothetical, and it is not about forgetting the
-          # heading either. When main cuts a release while a branch is open,
-          # main's '## [current]' becomes '## [0.N.0]'; merging the branch
-          # then folds its entry under that already-tagged heading and leaves
-          # the file with no '[current]' at all. That has now happened twice
-          # (0.539.0 and 0.549.0 both failed to bump), each time discovered
-          # only when the release broke. Checking it here moves the discovery
-          # to the PR that causes it.
-          if ! grep -q '^## \[current\]$' CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [current]' section."
-            echo ""
-            echo "The release job renames the first '## [current]' heading into"
-            echo "the new version, so an entry outside one is not released."
-            echo "If main cut a release while this branch was open, the merge"
-            echo "folded your entry under that version's heading: move it back"
-            echo "under a fresh '## [current]' and leave the tagged section as"
-            echo "it shipped (compare with \`git show vX.Y.Z:CHANGELOG.md\`)."
-            exit 1
-          fi
-          echo "The entry is under '## [current]'."
-
-          # Exactly one, too. A second '## [current]' is not cosmetic: the
-          # release job renames the FIRST one into the version, so a stray
-          # later one sits between two released sections and the NEXT release
-          # renames that -- burying entries inside an already-shipped version.
-          # This happened on main between 0.596.0 and 0.597.0, when a PR added
-          # a '[current]' without noticing the release job now leaves one.
-          n_current=$(grep -cE '^## \[current\]$' CHANGELOG.md || true)
-          if [ "$n_current" != "1" ]; then
-            echo "::error::CHANGELOG.md has $n_current '## [current]' headings; expected exactly 1."
-            echo ""
-            echo "The release job renames the FIRST '## [current]' into the new"
-            echo "version. A second one further down then gets renamed by the"
-            echo "NEXT release, which buries entries inside a section that has"
-            echo "already shipped."
-            echo ""
-            echo "Since the release now leaves a '[current]' behind, a PR should"
-            echo "add its entry UNDER the existing heading rather than adding a"
-            echo "new one. Merge the sections into one."
-            exit 1
-          fi
-
-          # Second half of the same failure. The check above catches a merge
-          # that left NO '[current]' behind; this catches the one that folded
-          # this branch's entry into an ALREADY-RELEASED section while leaving
-          # a '[current]' in place. That version is silent -- git auto-merges
-          # it without a conflict and nothing in the output hints at it -- so
-          # the corruption ships and cannot be repaired later without
-          # rewriting a tag.
-          #
-          # Compared against origin/main rather than the git tags. Editing a
-          # released section AFTER its tag is legitimate and routine here (3
-          # of the last 8 releases have such edits, e.g. 9b6c5580 recording
-          # shipped work against 0.584.0), so "differs from the tag" would red
-          # a third of all PRs and be switched off. The real invariant is
-          # narrower and is exactly the fold: THIS branch must not change a
-          # section that main already released.
-          #
-          # Whitespace is normalised so a merge that only reflowed spacing
-          # does not read as a fold. cksum rather than cmp: MSYS2 ships no
-          # diffutils, and `cmp -s` exits non-zero both when files differ AND
-          # when cmp is missing, reporting a false failure instead of a
-          # missing tool.
-          git fetch --quiet origin main || true
-          norm() { sed -e 's/[[:space:]]*$//' | cat -s; }
-          folded=""
-          for v in $(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
-                       | tr -d '#[] ' | head -8); do
-            a=$(git show "origin/main:CHANGELOG.md" 2>/dev/null \
-                  | sed -n "/^## \[$v\]/,/^## \[/{/^## \[$v\]/!{/^## \[/q};p}" | norm)
-            [ -z "$a" ] && continue
-            b=$(sed -n "/^## \[$v\]/,/^## \[/{/^## \[$v\]/!{/^## \[/q};p}" CHANGELOG.md | norm)
-            if [ "$(printf '%s' "$a" | cksum)" != "$(printf '%s' "$b" | cksum)" ]; then
-              folded="$folded $v"
-            fi
-          done
-          if [ -n "$folded" ]; then
-            echo "::error::This PR rewrites already-released CHANGELOG section(s):$folded"
-            echo ""
-            echo "A release was almost certainly cut while this branch was open."
-            echo "The release job renames '## [current]' into the version"
-            echo "heading, so merging main folds this branch's entry INTO that"
-            echo "released section -- usually with no git conflict, which is why"
-            echo "nothing flagged it."
-            echo ""
-            echo "Move the entry back under a fresh '## [current]' and restore"
-            echo "the released section as main has it:"
-            for v in $folded; do
-              echo "  git show origin/main:CHANGELOG.md   # section [$v]"
-            done
-            exit 1
-          fi
-          echo "Released sections match main."
+          # The entry has to be somewhere the release can find it, and this
+          # branch must not have folded it into an already-released section.
+          # Both checks live in tests/scripts/check_changelog_fold.sh so that
+          # `make check-changelog` runs the identical logic before a push and
+          # this gate can never drift from it.
+          sh tests/scripts/check_changelog_fold.sh || exit 1
           exit 0
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,59 @@ version number before tagging the release.
 
 ## [current]
 
+### Fixed
+
+- **`tcp_receive_raw` leaked every buffer it returned** (#1987). The extern
+  declared an owned heap buffer as a borrowed one, so nothing ever freed it.
+  Three `std.casper` externs had the same annotation gap and leaked their
+  results: `aether_casper_resolve`, `aether_casper_pwd_home` and
+  `aether_casper_sysctl_str`.
+
+- **`string.release()` silently did nothing when the value was not tracked as
+  heap-owned** (#1977). The release now frees an untracked value through
+  `string_release` rather than skipping it, so a string handed over by a call
+  the ownership tracker did not follow is still freed at the point the program
+  asks for it.
+
+- **A long build path truncated the C compiler command into `error: no input
+  files`** (#1974). The four sites that assembled a compiler command line
+  warned and carried on with a truncated command; they now fail with the
+  length they needed and the limit they hit. The buffer size is defined once in
+  `tools/ae_internal.h` instead of three times, and the REPL uses the same one
+  rather than a smaller private buffer.
+
+- **Two headers defined `COALESCE_THRESHOLD` with different values**, so which
+  one a translation unit saw depended on include order: 512 in
+  `runtime/scheduler/multicore_scheduler.h` (a drain batch size, and the size
+  of two arrays) and 8 in `runtime/actors/aether_message_coalescing.h`. The
+  scheduler's is now `SCHEDULER_DRAIN_BATCH`, which is also what it means.
+
+### Changed
+
+- **Call-site type propagation no longer walks the whole program once per
+  function** (#1995). One walk builds a callee-to-call-sites index and each
+  definition resolves against its own bucket, removing a term that was
+  quadratic in the number of functions. Type checking a 1600-function file
+  drops from 0.326s to 0.072s (4.5x), and whole-compile from 0.461s to 0.185s
+  (2.5x); the gap widens with file size. Output is unchanged: 1287 of the
+  repository's `.ae` files compile to byte-identical C before and after.
+
+- **Every declaration now uses `foo(void)` rather than `foo()`, and
+  `-Wstrict-prototypes` is on** (#1996). `foo()` means "takes an unspecified
+  number of arguments", so C11 cannot check calls against it; 91 declarations
+  across the compiler, runtime, stdlib, LSP and tests were unchecked this way.
+  The warning is now part of `CFLAGS`, so it cannot come back.
+
+### Added
+
+- **`make check-changelog` catches a CHANGELOG release-fold before you push**
+  (#2001). When a release is cut while a branch is open, merging main renames
+  `## [current]` into that version and folds the branch's entry into the
+  released section with no git conflict to show for it. The check lives in
+  `tests/scripts/check_changelog_fold.sh`, and the CI job now calls that same
+  script, so the local check and the gate cannot drift apart.
+
+
 ## [0.665.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -764,6 +764,20 @@ After merge, the pipeline transforms this into:
 - If `[current]` is missing, create it at the top (below the header)
 - Keep entries concise but specific, mention what changed and why
 
+**Run `make check-changelog` before you push.** If a release is cut while your
+branch is open, merging main renames `## [current]` into that version and folds
+your entry into the released section, with no git conflict to warn you. CI reds
+on it, but only after a full matrix run. `make check-changelog` is the identical
+check (`tests/scripts/check_changelog_fold.sh`, which the CI job calls), so it
+gives the same answer in under a second:
+
+```bash
+make check-changelog
+```
+
+It fails if the released sections no longer match `origin/main`, or if there is
+not exactly one `## [current]`.
+
 ### `### Upgrade notes` for memory-fix releases
 
 When a PR touches `compiler/codegen/codegen_stmt.c` (the heap-string-tracker wrapper), `std/string/aether_string.c` (the refcount allocator), or anything else that changes when the runtime frees a heap-allocated value, add an `### Upgrade notes` block to the same `[current]` entry. The block names the alias / ownership patterns whose downstream behaviour the change can break, and gives a recommended pre-upgrade play.

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ YAML_LDFLAGS    := $(call cellar_to_opt,$(YAML_LDFLAGS))
 # silently delete the other.
 AETHER_REQUIRED_CFLAGS = -fPIC -Iinclude -Icompiler -Iruntime -Iruntime/actors -Iruntime/scheduler -Iruntime/utils -Iruntime/memory -Iruntime/config -Istd -Istd/string -Istd/io -Istd/math -Istd/net -Istd/collections -Istd/json -Istd/yaml -MMD -MP -DAETHER_VERSION=\"$(VERSION)\" -DAETHER_HAS_SANDBOX $(OPENSSL_CFLAGS) $(ZLIB_CFLAGS) $(NGHTTP2_CFLAGS) $(PCRE2_CFLAGS) $(YAML_CFLAGS) $(BROTLI_CFLAGS) $(ZSTD_CFLAGS)
 
-CFLAGS = -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
+CFLAGS = -O2 -Wall -Wextra -Wstrict-prototypes -Wno-unused-parameter -Wno-unused-function $(EXTRA_CFLAGS)
 # Casper link libraries (FreeBSD only) — std.casper delegates DNS /
 # passwd / sysctl past Capsicum capability mode. libcasper + the
 # per-service libs ship in the FreeBSD base system. We resolve them by
@@ -2525,6 +2525,7 @@ help:
 	@echo "  make check-standalone - Compile every standalone C main (benches, demos)"
 	@echo "  make check-docs       - Compile the documentation's complete examples"
 	@echo "  make check-contrib-modules - Type-check every non-host contrib module"
+	@echo "  make check-changelog  - Catch a CHANGELOG release-fold before pushing"
 	@echo "  make test-fast      - Run C tests (monolithic build)"
 	@echo "  make test-install   - Install smoke test (init + run)"
 	@echo "  make test-valgrind  - Run tests with Valgrind"
@@ -2780,7 +2781,11 @@ CONTRIB_HOST_STRICT ?= 0
 # module. `check_doc_blocks.py` compiles every ```aether block in docs/ and the
 # README that is labelled complete, and asserts the ones labelled `fails`
 # still fail.
-.PHONY: check-docs
+.PHONY: check-docs check-changelog
+
+check-changelog:
+	@sh tests/scripts/check_changelog_fold.sh
+
 check-docs: compiler ae stdlib
 	@echo "==================================="
 	@echo "  documentation examples"

--- a/benchmarks/cross-language/c/counting.c
+++ b/benchmarks/cross-language/c/counting.c
@@ -35,7 +35,7 @@ void* counter_thread(void* arg) {
     return NULL;
 }
 
-int main() {
+int main(void) {
     const char* env = getenv("BENCHMARK_MESSAGES");
     if (env) MESSAGES = atoi(env);
 

--- a/benchmarks/cross-language/c/fork_join.c
+++ b/benchmarks/cross-language/c/fork_join.c
@@ -60,7 +60,7 @@ void* worker_thread(void* arg) {
     return NULL;
 }
 
-int main() {
+int main(void) {
     const char* env = getenv("BENCHMARK_MESSAGES");
     if (env) MESSAGES_PER_WORKER = atoi(env) / NUM_WORKERS;
 

--- a/benchmarks/cross-language/c/ping_pong.c
+++ b/benchmarks/cross-language/c/ping_pong.c
@@ -77,7 +77,7 @@ static inline uint64_t get_time_ns(void) {
     return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 }
 
-int main() {
+int main(void) {
     // Read message count from environment
     const char* env = getenv("BENCHMARK_MESSAGES");
     if (env) MESSAGES = atoi(env);

--- a/benchmarks/cross-language/c/thread_ring.c
+++ b/benchmarks/cross-language/c/thread_ring.c
@@ -66,7 +66,7 @@ void* node_thread(void* arg) {
     return NULL;
 }
 
-int main() {
+int main(void) {
     const char* env = getenv("BENCHMARK_MESSAGES");
     if (env) NUM_HOPS = atoi(env);
 

--- a/benchmarks/http/bench_actor_http.c
+++ b/benchmarks/http/bench_actor_http.c
@@ -133,7 +133,7 @@ void handle_sigint(int sig) {
     if (server) http_server_stop(server);
 }
 
-int main() {
+int main(void) {
     signal(SIGINT, handle_sigint);
 
     // Disable inline/main-thread mode

--- a/benchmarks/http/bench_thread_http.c
+++ b/benchmarks/http/bench_thread_http.c
@@ -30,7 +30,7 @@ void handle_sigint(int sig) {
     }
 }
 
-int main() {
+int main(void) {
     signal(SIGINT, handle_sigint);
 
     server = http_server_create(8080);

--- a/compiler/aether_error.c
+++ b/compiler/aether_error.c
@@ -425,15 +425,15 @@ void aether_error_with_code(const char* message, int line, int column, AetherErr
 }
 
 // Error statistics
-int aether_error_count() {
+int aether_error_count(void) {
     return error_count_global;
 }
 
-int aether_warning_count() {
+int aether_warning_count(void) {
     return warning_count_global;
 }
 
-void aether_error_reset_counts() {
+void aether_error_reset_counts(void) {
     error_count_global = 0;
     warning_count_global = 0;
 }

--- a/compiler/aether_error.h
+++ b/compiler/aether_error.h
@@ -71,9 +71,9 @@ const char* aether_color_bold(void);
 #define AETHER_COLOR_BOLD aether_color_bold()
 
 // Error statistics
-int aether_error_count();
-int aether_warning_count();
-void aether_error_reset_counts();
+int aether_error_count(void);
+int aether_warning_count(void);
+void aether_error_reset_counts(void);
 
 #endif // AETHER_ERROR_H
 

--- a/compiler/aether_module.c
+++ b/compiler/aether_module.c
@@ -196,7 +196,7 @@ void module_set_lib_dir(const char* lib_dir) {
 }
 
 // Module management
-void module_registry_init() {
+void module_registry_init(void) {
     if (!global_module_registry) {
         global_module_registry = (ModuleRegistry*)malloc(sizeof(ModuleRegistry));
         global_module_registry->modules = NULL;
@@ -216,7 +216,7 @@ void module_registry_init() {
     }
 }
 
-void module_registry_shutdown() {
+void module_registry_shutdown(void) {
     if (global_module_registry) {
         for (int i = 0; i < global_module_registry->module_count; i++) {
             module_free(global_module_registry->modules[i]);
@@ -476,7 +476,7 @@ void package_manifest_free(PackageManifest* manifest) {
 
 // Dependency Graph Implementation
 
-DependencyGraph* dependency_graph_create() {
+DependencyGraph* dependency_graph_create(void) {
     DependencyGraph* graph = malloc(sizeof(DependencyGraph));
     graph->nodes = NULL;
     graph->node_count = 0;

--- a/compiler/aether_module.h
+++ b/compiler/aether_module.h
@@ -37,8 +37,8 @@ typedef struct {
 extern ModuleRegistry* global_module_registry;
 
 // Module management
-void module_registry_init();
-void module_registry_shutdown();
+void module_registry_init(void);
+void module_registry_shutdown(void);
 
 AetherModule* module_create(const char* name, const char* file_path);
 void module_free(AetherModule* module);
@@ -70,7 +70,7 @@ typedef struct {
     int node_count;
 } DependencyGraph;
 
-DependencyGraph* dependency_graph_create();
+DependencyGraph* dependency_graph_create(void);
 void dependency_graph_free(DependencyGraph* graph);
 DependencyNode* dependency_graph_add_node(DependencyGraph* graph, const char* module_name);
 void dependency_graph_add_edge(DependencyGraph* graph, const char* from, const char* to);

--- a/compiler/analysis/type_inference.c
+++ b/compiler/analysis/type_inference.c
@@ -1195,7 +1195,6 @@ void report_ambiguous_types(InferenceContext* ctx) {
 
 // Propagate types from function call sites to function definitions
 int propagate_function_call_types(ASTNode* program, SymbolTable* table);
-int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* func_def, int param_count);
 
 /* Widening rank for the call-site parameter unification below.
  *
@@ -1224,85 +1223,176 @@ static int param_widening_rank(TypeKind k) {
     }
 }
 
-// Helper to recursively find function calls and propagate types
-int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* func_def, int param_count) {
-    if (!tree || !func_name) return 0;
-    int changed = 0;
+/* Call-site index for the propagation pass below.
+ *
+ * CRITICAL: the traversal here must stay identical to the one the
+ * unification loop expects. It skips a function definition's parameter
+ * nodes and descends only into the body, and it records nodes in
+ * pre-order within each top-level node, in ascending top-level order.
+ * The first call site to supply a type wins (later ones may only widen),
+ * so a different visit order silently changes which type a parameter
+ * gets. */
+typedef struct {
+    ASTNode* call;
+    const char* key;
+    unsigned hash;
+    int top_index;
+    int next;
+} CallRef;
 
-    // For function definitions: skip parameter nodes but recurse into the body
+typedef struct {
+    CallRef* refs;
+    int count;
+    int capacity;
+    int* buckets;
+    int* tails;
+    int bucket_count;
+    char** owned;
+    int owned_count;
+    int owned_capacity;
+} CallIndex;
+
+static unsigned call_index_hash(const char* s) {
+    unsigned h = 2166136261u;
+    while (*s) { h ^= (unsigned char)*s++; h *= 16777619u; }
+    return h;
+}
+
+static void call_index_free(CallIndex* ix) {
+    if (!ix) return;
+    for (int i = 0; i < ix->owned_count; i++) free(ix->owned[i]);
+    free(ix->owned);
+    free(ix->refs);
+    free(ix->buckets);
+    free(ix->tails);
+}
+
+static int call_index_add(CallIndex* ix, ASTNode* call, const char* key, int top_index) {
+    if (ix->count == ix->capacity) {
+        int cap = ix->capacity ? ix->capacity * 2 : 64;
+        CallRef* grown = (CallRef*)realloc(ix->refs, (size_t)cap * sizeof(CallRef));
+        if (!grown) return 0;
+        ix->refs = grown;
+        ix->capacity = cap;
+    }
+    CallRef* r = &ix->refs[ix->count];
+    r->call = call;
+    r->key = key;
+    r->hash = call_index_hash(key);
+    r->top_index = top_index;
+    r->next = -1;
+    ix->count++;
+    return 1;
+}
+
+static int call_index_own(CallIndex* ix, char* s) {
+    if (ix->owned_count == ix->owned_capacity) {
+        int cap = ix->owned_capacity ? ix->owned_capacity * 2 : 16;
+        char** grown = (char**)realloc(ix->owned, (size_t)cap * sizeof(char*));
+        if (!grown) return 0;
+        ix->owned = grown;
+        ix->owned_capacity = cap;
+    }
+    ix->owned[ix->owned_count++] = s;
+    return 1;
+}
+
+static int call_index_collect(CallIndex* ix, ASTNode* tree, int top_index) {
+    if (!tree) return 1;
+
     if (tree->type == AST_FUNCTION_DEFINITION || tree->type == AST_BUILDER_FUNCTION) {
         int body_idx = tree->child_count - 1;
         if (body_idx >= 0 && tree->children[body_idx]) {
-            changed += propagate_call_types_in_tree(tree->children[body_idx], func_name, func_def, param_count);
+            return call_index_collect(ix, tree->children[body_idx], top_index);
         }
-        return changed;
+        return 1;
     }
-    
-    // Check if this is a function call to our target function
-    // Also match qualified calls: "mymath.double_it" matches definition "mymath_double_it"
-    int is_match = 0;
+
     if (tree->type == AST_FUNCTION_CALL && tree->value) {
-        /* This runs once per AST node per function definition, so it is the
-         * busiest comparison in the pass. Settle the common mismatch on the
-         * first byte before calling out. */
-        if ((unsigned char)tree->value[0] == (unsigned char)func_name[0] &&
-            strcmp(tree->value, func_name) == 0) {
-            is_match = 1;
-        } else if (strchr(tree->value, '.')) {
-            // Convert dots to underscores and check
+        if (!call_index_add(ix, tree, tree->value, top_index)) return 0;
+        /* A qualified call `mymath.double_it` also matches the definition
+         * `mymath_double_it`, so it is indexed under both spellings. The
+         * 512-byte cap and its truncation match what the linear scan did. */
+        if (strchr(tree->value, '.')) {
             char mangled[512];
             strncpy(mangled, tree->value, sizeof(mangled) - 1);
             mangled[sizeof(mangled) - 1] = '\0';
             for (char* p = mangled; *p; p++) { if (*p == '.') *p = '_'; }
-            if (strcmp(mangled, func_name) == 0) is_match = 1;
+            char* copy = strdup(mangled);
+            if (!copy) return 0;
+            if (!call_index_own(ix, copy)) { free(copy); return 0; }
+            if (!call_index_add(ix, tree, copy, top_index)) return 0;
         }
     }
-    if (is_match) {
-        // This is a call to our function - propagate argument types to parameters
-        int arg_count = tree->child_count;
-        for (int i = 0; i < arg_count && i < param_count; i++) {
-            ASTNode* arg = tree->children[i];
-            ASTNode* param = func_def->children[i];
 
-            if (arg && param &&
-                (param->type == AST_VARIABLE_DECLARATION || param->type == AST_PATTERN_VARIABLE)) {
-                // If parameter type is unknown and argument type is known, propagate it
-                if ((!param->node_type || param->node_type->kind == TYPE_UNKNOWN) &&
-                    arg->node_type && arg->node_type->kind != TYPE_UNKNOWN) {
-                    if (param->node_type) free_type(param->node_type);
-                    param->node_type = clone_type(arg->node_type);
-                    /* Record that THIS pass supplied the type. Only a type we
-                     * inferred may be widened below; one the author wrote is
-                     * authoritative, and widening it would change documented
-                     * semantics -- `expect(got: int, ...)` relies on `int`
-                     * wrapping at 32 bits, and promoting it to int64 stops the
-                     * wrap the test exists to check. */
-                    param->type_inferred = 1;
-                    changed++;
-                } else if (param->type_inferred && param->node_type && arg && arg->node_type) {
-                    /* Already pinned by an earlier call site. Take the wider
-                     * numeric kind rather than keeping whichever was seen
-                     * first: the narrow one truncates this argument, and
-                     * which call site the compiler happens to reach first is
-                     * not something the author controls (#1972). Only widens,
-                     * only among the ranked numeric kinds, and only over a
-                     * type this pass inferred, so an annotated parameter and a
-                     * genuinely incompatible pair are both left alone. */
-                    int cur = param_widening_rank(param->node_type->kind);
-                    int inc = param_widening_rank(arg->node_type->kind);
-                    if (cur > 0 && inc > cur) {
-                        free_type(param->node_type);
-                        param->node_type = clone_type(arg->node_type);
-                        changed++;
-                    }
-                }
+    for (int i = 0; i < tree->child_count; i++) {
+        if (!call_index_collect(ix, tree->children[i], top_index)) return 0;
+    }
+    return 1;
+}
+
+static int call_index_build(CallIndex* ix, ASTNode* program) {
+    memset(ix, 0, sizeof(*ix));
+    for (int j = 0; j < program->child_count; j++) {
+        if (!call_index_collect(ix, program->children[j], j)) return 0;
+    }
+
+    int n = 64;
+    while (n < ix->count) n <<= 1;
+    ix->bucket_count = n;
+    ix->buckets = (int*)malloc((size_t)n * sizeof(int));
+    ix->tails = (int*)malloc((size_t)n * sizeof(int));
+    if (!ix->buckets || !ix->tails) return 0;
+    for (int i = 0; i < n; i++) { ix->buckets[i] = -1; ix->tails[i] = -1; }
+
+    for (int i = 0; i < ix->count; i++) {
+        unsigned b = ix->refs[i].hash & (unsigned)(n - 1);
+        if (ix->tails[b] < 0) ix->buckets[b] = i;
+        else ix->refs[ix->tails[b]].next = i;
+        ix->tails[b] = i;
+    }
+    return 1;
+}
+
+/* Unify one call site's argument types into the definition's parameters. */
+static int propagate_call_site(ASTNode* call, ASTNode* func_def, int param_count) {
+    int changed = 0;
+    int arg_count = call->child_count;
+    for (int i = 0; i < arg_count && i < param_count; i++) {
+        ASTNode* arg = call->children[i];
+        ASTNode* param = func_def->children[i];
+        if (!arg || !param) continue;
+        if (param->type != AST_VARIABLE_DECLARATION && param->type != AST_PATTERN_VARIABLE) continue;
+
+        if ((!param->node_type || param->node_type->kind == TYPE_UNKNOWN) &&
+            arg->node_type && arg->node_type->kind != TYPE_UNKNOWN) {
+            if (param->node_type) free_type(param->node_type);
+            param->node_type = clone_type(arg->node_type);
+            /* Record that THIS pass supplied the type. Only a type we
+             * inferred may be widened below; one the author wrote is
+             * authoritative, and widening it would change documented
+             * semantics: `expect(got: int, ...)` relies on `int` wrapping
+             * at 32 bits, and promoting it to int64 stops the wrap the
+             * test exists to check. */
+            param->type_inferred = 1;
+            changed++;
+        } else if (param->type_inferred && param->node_type && arg->node_type) {
+            /* Already pinned by an earlier call site. Take the wider
+             * numeric kind rather than keeping whichever was seen first:
+             * the narrow one truncates this argument, and which call site
+             * the compiler happens to reach first is not something the
+             * author controls (#1972). Only widens, only among the ranked
+             * numeric kinds, and only over a type this pass inferred, so
+             * an annotated parameter and a genuinely incompatible pair are
+             * both left alone. */
+            int cur = param_widening_rank(param->node_type->kind);
+            int inc = param_widening_rank(arg->node_type->kind);
+            if (cur > 0 && inc > cur) {
+                free_type(param->node_type);
+                param->node_type = clone_type(arg->node_type);
+                changed++;
             }
         }
-    }
-
-    // Recursively process all children
-    for (int i = 0; i < tree->child_count; i++) {
-        changed += propagate_call_types_in_tree(tree->children[i], func_name, func_def, param_count);
     }
     return changed;
 }
@@ -1312,29 +1402,43 @@ int propagate_call_types_in_tree(ASTNode* tree, const char* func_name, ASTNode* 
 int propagate_function_call_types(ASTNode* program, SymbolTable* table) {
     (void)table;  // Unused for now
     if (!program) return 0;
-    int total_changed = 0;
 
-    // Find all function calls and match them with definitions
+    /* CRITICAL: one walk builds the callee -> call-sites index, then each
+     * definition resolves against its own bucket. The previous shape walked
+     * every top-level node once per definition, which is quadratic in the
+     * number of functions and was measurable well inside the token cap
+     * (#1995). The index is rebuilt per pass because the fixpoint loop
+     * calls this repeatedly; only node types change between passes, never
+     * the shape of the tree, so the walk order stays the one described on
+     * call_index_collect. */
+    CallIndex ix;
+    if (!call_index_build(&ix, program)) {
+        call_index_free(&ix);
+        fprintf(stderr, "aetherc: out of memory building the call-site index\n");
+        exit(1);
+    }
+
+    int total_changed = 0;
     for (int i = 0; i < program->child_count; i++) {
         ASTNode* node = program->children[i];
         if (!node) continue;
+        if ((node->type != AST_FUNCTION_DEFINITION && node->type != AST_BUILDER_FUNCTION) || !node->value) continue;
 
-        // Look for function definitions
-        if ((node->type == AST_FUNCTION_DEFINITION || node->type == AST_BUILDER_FUNCTION) && node->value) {
-            const char* func_name = node->value;
-            int param_count = node->child_count - 1; // Last child is body
+        const char* func_name = node->value;
+        int param_count = node->child_count - 1; // Last child is body
 
-            // Search every other top-level node (including other function bodies)
-            for (int j = 0; j < program->child_count; j++) {
-                if (i != j) {
-                    total_changed += propagate_call_types_in_tree(program->children[j], func_name, node, param_count);
-                }
-            }
+        unsigned h = call_index_hash(func_name);
+        for (int r = ix.buckets[h & (unsigned)(ix.bucket_count - 1)]; r >= 0; r = ix.refs[r].next) {
+            CallRef* ref = &ix.refs[r];
+            if (ref->top_index == i) continue;  // a function's own body is not scanned for calls to itself
+            if (ref->hash != h || strcmp(ref->key, func_name) != 0) continue;
+            total_changed += propagate_call_site(ref->call, node, param_count);
         }
     }
+
+    call_index_free(&ix);
     return total_changed;
 }
-
 // Infer return types for all functions
 // Scan AST for multi-return statements and fill UNKNOWN tuple elements
 static void merge_tuple_returns(ASTNode* node, Type* merged) {

--- a/compiler/codegen/codegen_expr.c
+++ b/compiler/codegen/codegen_expr.c
@@ -3975,9 +3975,18 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                         if (arg->type == AST_IDENTIFIER && arg->value &&
                             is_heap_string_var(gen, arg->value)) {
                             fprintf(gen->output,
+                                /* The else arm matters: a tracked local can hold a value the
+                                 * tracker does not own, the ordinary case being one
+                                 * read out of a struct field. The flag is 0 there, so
+                                 * without this the release silently did nothing and
+                                 * the caller's explicit free never happened (#1977).
+                                 * string_release is literal-safe, so the fallback
+                                 * cannot hurt a borrowed literal, and it is what the
+                                 * untracked-identifier path a few lines down already
+                                 * does. string.free below has had this arm all along. */
                                 "({ if (_heap_%s) { aether_heap_str_free((void*)%s); "
-                                "%s = NULL; _heap_%s = 0; } })",
-                                arg->value, arg->value, arg->value, arg->value);
+                                "%s = NULL; _heap_%s = 0; } else { string_release(%s); } })",
+                                arg->value, arg->value, arg->value, arg->value, arg->value);
                         } else {
                             fprintf(gen->output, "string_release(");
                             generate_expression(gen, arg);
@@ -4021,9 +4030,12 @@ void generate_expression(CodeGenerator* gen, ASTNode* expr) {
                      * both the magic and plain-char* representations. */
                     ASTNode* arg = expr->children[0];
                     fprintf(gen->output,
+                        /* Same else arm as the bare release() above: a tracked local
+                         * holding a field-read value has a 0 flag, and the release
+                         * has to still happen (#1977). */
                         "({ if (_heap_%s) { aether_heap_str_free((void*)%s); "
-                        "%s = NULL; _heap_%s = 0; } })",
-                        arg->value, arg->value, arg->value, arg->value);
+                        "%s = NULL; _heap_%s = 0; } else { string_release(%s); } })",
+                        arg->value, arg->value, arg->value, arg->value, arg->value);
                 }
                 // string.free(X) frees what the runtime cannot: given a
                 // plain malloc'd payload, string_release cannot tell a heap

--- a/compiler/codegen/optimizer.c
+++ b/compiler/codegen/optimizer.c
@@ -8,7 +8,7 @@
 
 OptimizationStats global_opt_stats = {0, 0, 0, 0, 0};
 
-void reset_optimization_stats() {
+void reset_optimization_stats(void) {
     global_opt_stats.constants_folded = 0;
     global_opt_stats.dead_code_removed = 0;
     global_opt_stats.tail_calls_detected = 0;
@@ -16,7 +16,7 @@ void reset_optimization_stats() {
     global_opt_stats.linear_loops_collapsed = 0;
 }
 
-void print_optimization_stats() {
+void print_optimization_stats(void) {
     printf("Optimization Statistics:\n");
     printf("  Constants folded: %d\n", global_opt_stats.constants_folded);
     printf("  Dead code removed: %d\n", global_opt_stats.dead_code_removed);

--- a/compiler/codegen/optimizer.h
+++ b/compiler/codegen/optimizer.h
@@ -40,8 +40,8 @@ typedef struct {
 
 extern OptimizationStats global_opt_stats;
 
-void reset_optimization_stats();
-void print_optimization_stats();
+void reset_optimization_stats(void);
+void print_optimization_stats(void);
 
 #endif // OPTIMIZER_H
 

--- a/compiler/parser/lexer.c
+++ b/compiler/parser/lexer.c
@@ -50,12 +50,12 @@ void lexer_restore(const LexerState* in) {
     current_column = in->current_column;
 }
 
-char peek() {
+char peek(void) {
     if (current_pos >= source_length) return '\0';
     return source[current_pos];
 }
 
-char advance() {
+char advance(void) {
     if (current_pos >= source_length) return '\0';
     char c = source[current_pos++];
     if (c == '\n') {
@@ -73,7 +73,7 @@ char advance() {
     return c;
 }
 
-void skip_whitespace() {
+void skip_whitespace(void) {
     while (current_pos < source_length) {
         char c = peek();
         if (c == ' ' || c == '\t' || c == '\r') {
@@ -86,7 +86,7 @@ void skip_whitespace() {
     }
 }
 
-int skip_comment() {
+int skip_comment(void) {
     if (peek() == '/' && current_pos + 1 < source_length && source[current_pos + 1] == '/') {
         // Single line comment
         while (current_pos < source_length && peek() != '\n') {
@@ -115,7 +115,7 @@ int skip_comment() {
     return 0;
 }
 
-Token* read_string() {
+Token* read_string(void) {
     advance(); // skip opening quote
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
@@ -270,7 +270,7 @@ Token* read_string() {
     return token;
 }
 
-Token* read_number() {
+Token* read_number(void) {
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
     int i = 0;
@@ -423,7 +423,7 @@ Token* read_number() {
     return token;
 }
 
-Token* read_identifier() {
+Token* read_identifier(void) {
     int capacity = MAX_IDENTIFIER_LENGTH;
     char* buffer = malloc(capacity);
     int i = 0;
@@ -555,7 +555,7 @@ Token* read_raw_identifier(void) {
     return token;
 }
 
-Token* next_token() {
+Token* next_token(void) {
     skip_whitespace();
 
     token_start_line = current_line;

--- a/docs/actor-concurrency.md
+++ b/docs/actor-concurrency.md
@@ -38,7 +38,7 @@ The actor runtime includes several performance optimizations applied automatical
 
 **Message Coalescing:**
 - Batch dequeue drains multiple messages in a single atomic operation
-- Configurable threshold (COALESCE_THRESHOLD = 512)
+- Configurable threshold (SCHEDULER_DRAIN_BATCH = 512)
 
 **Thread-Local Message Pools:**
 - Per-thread pool of 256 pre-allocated buffers (up to 256 bytes each)

--- a/docs/runtime-optimizations.md
+++ b/docs/runtime-optimizations.md
@@ -97,7 +97,7 @@ Because each pool is thread-local, acquisition and release use plain loads and s
 The scheduler drains multiple messages from the lock-free incoming queue in a single batch dequeue operation. This reduces atomic operations from one-per-message to one-per-batch.
 
 ```c
-#define COALESCE_THRESHOLD 512
+#define SCHEDULER_DRAIN_BATCH 512
 
 // Single batch dequeue: 1 atomic store for entire batch
 count = queue_dequeue_batch(&incoming_queue, buffer.actors, buffer.messages, batch_size);

--- a/docs/scheduler-quick-reference.md
+++ b/docs/scheduler-quick-reference.md
@@ -130,7 +130,7 @@ sender -> scheduler_send_local -> mailbox (direct) -> actor step
 
 ### Message Coalescing
 ```c
-#define COALESCE_THRESHOLD 512  // In multicore_scheduler.h
+#define SCHEDULER_DRAIN_BATCH 512  // In multicore_scheduler.h
 ```
 
 ### Adaptive Batch Size
@@ -204,7 +204,7 @@ Both migration and work stealing use ascending core-id lock ordering to prevent 
 - Verify core count matches available hardware
 
 ### High Latency
-- Tune `COALESCE_THRESHOLD` for latency-sensitive workloads (lower = less batching delay)
+- Tune `SCHEDULER_DRAIN_BATCH` for latency-sensitive workloads (lower = less batching delay)
 - Check progressive backoff thresholds
 - Avoid blocking operations in actor step functions
 

--- a/lsp/aether_lsp.c
+++ b/lsp/aether_lsp.c
@@ -46,7 +46,7 @@ static char* json_extract_string(const char* json, const char* key) {
 }
 
 // LSP Server lifecycle
-LSPServer* lsp_server_create() {
+LSPServer* lsp_server_create(void) {
     LSPServer* server = (LSPServer*)malloc(sizeof(LSPServer));
     if (!server) return NULL;
     server->input = stdin;

--- a/lsp/aether_lsp.h
+++ b/lsp/aether_lsp.h
@@ -19,7 +19,7 @@ typedef struct {
 } LSPServer;
 
 // LSP Server lifecycle
-LSPServer* lsp_server_create();
+LSPServer* lsp_server_create(void);
 void lsp_server_free(LSPServer* server);
 void lsp_server_run(LSPServer* server);
 

--- a/runtime/aether_runtime.c
+++ b/runtime/aether_runtime.c
@@ -104,7 +104,7 @@ void aether_runtime_init(int num_cores, int flags) {
 }
 
 // Get current runtime configuration
-const AetherRuntimeInitConfig* aether_runtime_get_config() {
+const AetherRuntimeInitConfig* aether_runtime_get_config(void) {
     if (!g_runtime_initialized) {
         // Initialize with defaults on first access
         aether_runtime_init(0, AETHER_FLAG_AUTO_DETECT);
@@ -119,7 +119,7 @@ int aether_runtime_has_feature(int feature_flag) {
 }
 
 // Print current runtime configuration
-void aether_runtime_print_config() {
+void aether_runtime_print_config(void) {
     const AetherRuntimeInitConfig* config = aether_runtime_get_config();
     const CPUInfo* cpu = cpu_get_info();
     
@@ -162,7 +162,7 @@ void aether_runtime_print_config() {
 }
 
 // Shutdown runtime
-void aether_runtime_shutdown() {
+void aether_runtime_shutdown(void) {
     g_runtime_initialized = 0;
 }
 

--- a/runtime/aether_runtime.h
+++ b/runtime/aether_runtime.h
@@ -30,7 +30,7 @@ typedef struct {
 
 // Runtime initialization
 void aether_runtime_init(int num_cores, int flags);
-void aether_runtime_shutdown();
+void aether_runtime_shutdown(void);
 
 // Command-line arguments (set by main, accessible from anywhere)
 extern int aether_argc;
@@ -79,9 +79,9 @@ void aether_args_seal(void);
 int  aether_args_sealed(void);
 
 // Configuration queries
-const AetherRuntimeInitConfig* aether_runtime_get_config();
+const AetherRuntimeInitConfig* aether_runtime_get_config(void);
 int aether_runtime_has_feature(int feature_flag);
-void aether_runtime_print_config();
+void aether_runtime_print_config(void);
 
 // Aether built-in `sleep(ms)` lowers to a call to this — a stable,
 // prefixed symbol that won't collide with libc's `sleep` if user code
@@ -89,11 +89,11 @@ void aether_runtime_print_config();
 void aether_sleep_ms(int ms);
 
 // Legacy compatibility
-static inline void aether_init() {
+static inline void aether_init(void) {
     aether_runtime_init(0, AETHER_FLAG_AUTO_DETECT);
 }
 
-static inline void aether_cleanup() {
+static inline void aether_cleanup(void) {
     aether_runtime_shutdown();
 }
 

--- a/runtime/examples/buffered_send_bench.c
+++ b/runtime/examples/buffered_send_bench.c
@@ -166,7 +166,7 @@ double bench_buffered(int num_actors, int messages_per_actor) {
     return throughput;
 }
 
-int main() {
+int main(void) {
     printf("Sender-Side Message Batching Benchmark\n");
     printf("======================================\n");
     

--- a/runtime/examples/high_throughput_actor.c
+++ b/runtime/examples/high_throughput_actor.c
@@ -127,7 +127,7 @@ void process_batch_zerocopy(
 }
 
 // Main example
-int main() {
+int main(void) {
     printf("High-Throughput Actor Example\n");
     printf("Optimizations: SIMD + Coalescing + Zero-Copy\n\n");
     

--- a/runtime/examples/index_bench.c
+++ b/runtime/examples/index_bench.c
@@ -105,7 +105,7 @@ double bench_index_passing(int num_actors, int msgs_per_actor) {
     return tput;
 }
 
-int main() {
+int main(void) {
     printf("Message Index Passing vs Copy Benchmark\n");
     printf("=======================================\n");
     

--- a/runtime/examples/manual_actor_test.c
+++ b/runtime/examples/manual_actor_test.c
@@ -19,7 +19,7 @@ void Counter_step(Counter* self) {
     (self->count = (self->count + 1));
 }
 
-Counter* spawn_Counter() {
+Counter* spawn_Counter(void) {
     Counter* actor = malloc(sizeof(Counter));
     actor->id = 0;
     actor->active = 1;
@@ -38,7 +38,7 @@ void send_Counter(Counter* actor, int type, int payload) {
     actor->active = 1;
 }
 
-int main() {
+int main(void) {
     Counter* c1 = spawn_Counter();
     Counter* c2 = spawn_Counter();
     

--- a/runtime/examples/multicore_bench.c
+++ b/runtime/examples/multicore_bench.c
@@ -92,7 +92,7 @@ void send_Node(Node* actor, int type) {
     }
 }
 
-int main() {
+int main(void) {
     int cores = 4;
     current_core_id = 0;  // Main thread acts as core 0
     

--- a/runtime/examples/ring_bench_buffered.c
+++ b/runtime/examples/ring_bench_buffered.c
@@ -42,7 +42,7 @@ void ring_step(void* self) {
     }
 }
 
-int main() {
+int main(void) {
     printf("Multicore Ring Benchmark with Buffered Sends\n");
     printf("============================================\n\n");
     

--- a/runtime/examples/ring_benchmark_manual.c
+++ b/runtime/examples/ring_benchmark_manual.c
@@ -33,7 +33,7 @@ void Node_step(Node* self) {
     }
 }
 
-int main() {
+int main(void) {
     Node** actors = malloc(NUM_ACTORS * sizeof(Node*));
     
     for (int i = 0; i < NUM_ACTORS; i++) {

--- a/runtime/examples/runtime_config_example.c
+++ b/runtime/examples/runtime_config_example.c
@@ -5,7 +5,7 @@
 #include "../aether_runtime.h"
 #include "../utils/aether_cpu_detect.h"
 
-void print_examples() {
+void print_examples(void) {
     printf("========================================\n");
     printf("  Aether Runtime Configuration Examples\n");
     printf("========================================\n\n");
@@ -48,7 +48,7 @@ void print_examples() {
     printf("========================================\n\n");
 }
 
-int main() {
+int main(void) {
     print_examples();
     
     // Example 1: Auto-detect (best for most users)

--- a/runtime/examples/simd_batch_processing.c
+++ b/runtime/examples/simd_batch_processing.c
@@ -13,7 +13,7 @@ typedef struct {
     int32_t payload;
 } SimpleMessage;
 
-int main() {
+int main(void) {
     printf("===========================================\n");
     printf("  SIMD Batch Processing Example\n");
     printf("===========================================\n\n");

--- a/runtime/examples/state_machine_bench.c
+++ b/runtime/examples/state_machine_bench.c
@@ -100,7 +100,7 @@ void counter_actor_step(Actor* self) {
 
 Actor* actors;
 
-int main() {
+int main(void) {
     printf("Allocating %d actors...\n", ACTOR_COUNT);
     actors = malloc(sizeof(Actor) * ACTOR_COUNT);
     

--- a/runtime/examples/workstealing_bench.c
+++ b/runtime/examples/workstealing_bench.c
@@ -69,7 +69,7 @@ void send_Node(Node* actor, int type) {
     }
 }
 
-int main() {
+int main(void) {
     int cores = 4;
     current_core_id = 0;
     

--- a/runtime/memory/aether_arena_optimized.c
+++ b/runtime/memory/aether_arena_optimized.c
@@ -100,7 +100,7 @@ static void thread_arena_destructor(void* arg) {
 }
 
 // Get or create thread-local arena
-static ThreadLocalArena* get_thread_arena() {
+static ThreadLocalArena* get_thread_arena(void) {
     if (tl_arena) return tl_arena;
     
     tl_arena = (ThreadLocalArena*)calloc(1, sizeof(ThreadLocalArena));
@@ -132,7 +132,7 @@ void arena_manager_init(int max_threads) {
     pthread_key_create(&global_manager.thread_key, thread_arena_destructor);
 }
 
-void arena_manager_shutdown() {
+void arena_manager_shutdown(void) {
     if (!global_manager.thread_arenas) return;
     
     pthread_key_delete(global_manager.thread_key);
@@ -185,7 +185,7 @@ void arena_get_thread_stats(uint64_t* allocated_bytes, uint64_t* allocation_coun
     }
 }
 
-void arena_reset_thread() {
+void arena_reset_thread(void) {
     ThreadLocalArena* arena = tl_arena;
     if (!arena) return;
     

--- a/runtime/memory/aether_arena_optimized.h
+++ b/runtime/memory/aether_arena_optimized.h
@@ -43,7 +43,7 @@ typedef struct {
 
 // Initialization
 void arena_manager_init(int max_threads);
-void arena_manager_shutdown();
+void arena_manager_shutdown(void);
 
 // Fast path allocation (thread-local, no locks)
 void* arena_alloc_fast(size_t bytes);
@@ -53,7 +53,7 @@ void* arena_alloc_fast_aligned(size_t bytes, size_t alignment);
 void arena_get_thread_stats(uint64_t* allocated_bytes, uint64_t* allocation_count);
 
 // Reset thread-local arena (for per-request allocations)
-void arena_reset_thread();
+void arena_reset_thread(void);
 
 // Get total memory statistics
 typedef struct {

--- a/runtime/memory/aether_memory_stats.c
+++ b/runtime/memory/aether_memory_stats.c
@@ -4,7 +4,7 @@
 
 static MemoryStats g_stats = {0};
 
-void memory_stats_init() {
+void memory_stats_init(void) {
     memset(&g_stats, 0, sizeof(MemoryStats));
 }
 
@@ -34,15 +34,15 @@ void memory_stats_record_free(size_t bytes) {
     }
 }
 
-void memory_stats_record_failure() {
+void memory_stats_record_failure(void) {
     g_stats.allocation_failures++;
 }
 
-MemoryStats memory_stats_get() {
+MemoryStats memory_stats_get(void) {
     return g_stats;
 }
 
-void memory_stats_print() {
+void memory_stats_print(void) {
     printf("\n========== Memory Statistics ==========\n");
     printf("Allocations:\n");
     printf("  Total:   %llu\n", (unsigned long long)g_stats.total_allocations);
@@ -74,7 +74,7 @@ void memory_stats_print() {
     printf("=======================================\n\n");
 }
 
-void memory_stats_reset() {
+void memory_stats_reset(void) {
     memset(&g_stats, 0, sizeof(MemoryStats));
 }
 

--- a/runtime/memory/aether_memory_stats.h
+++ b/runtime/memory/aether_memory_stats.h
@@ -16,13 +16,13 @@ typedef struct {
     uint64_t allocation_failures;
 } MemoryStats;
 
-void memory_stats_init();
+void memory_stats_init(void);
 void memory_stats_record_alloc(size_t bytes);
 void memory_stats_record_free(size_t bytes);
-void memory_stats_record_failure();
-MemoryStats memory_stats_get();
-void memory_stats_print();
-void memory_stats_reset();
+void memory_stats_record_failure(void);
+MemoryStats memory_stats_get(void);
+void memory_stats_print(void);
+void memory_stats_reset(void);
 
 #ifdef AETHER_MEMORY_TRACKING
     #define TRACK_ALLOC(bytes) memory_stats_record_alloc(bytes)

--- a/runtime/memory/aether_pool.c
+++ b/runtime/memory/aether_pool.c
@@ -93,7 +93,7 @@ void pool_destroy(MemoryPool* pool) {
     aether_caps_free(pool, sizeof(MemoryPool));
 }
 
-StandardPools* standard_pools_create() {
+StandardPools* standard_pools_create(void) {
     StandardPools* pools = (StandardPools*)aether_caps_malloc(sizeof(StandardPools));
     if (!pools) return NULL;
     

--- a/runtime/memory/aether_pool.h
+++ b/runtime/memory/aether_pool.h
@@ -21,7 +21,7 @@ typedef struct {
     MemoryPool* pool_256;
 } StandardPools;
 
-StandardPools* standard_pools_create();
+StandardPools* standard_pools_create(void);
 void* standard_pools_alloc(StandardPools* pools, size_t size);
 void standard_pools_free(StandardPools* pools, void* ptr, size_t size);
 void standard_pools_destroy(StandardPools* pools);

--- a/runtime/scheduler/aether_atomic_asm.h
+++ b/runtime/scheduler/aether_atomic_asm.h
@@ -71,7 +71,7 @@ static inline int atomic_fetch_add_asm(atomic_int* ptr, int value) {
 }
 
 // Optimized spin-lock using PAUSE instruction
-static inline void spin_pause() {
+static inline void spin_pause(void) {
     __asm__ volatile("pause" ::: "memory");
 }
 
@@ -140,7 +140,7 @@ static inline int atomic_fetch_add_asm(atomic_int* ptr, int value) {
     return atomic_fetch_add_explicit(ptr, value, memory_order_acq_rel);
 }
 
-static inline void spin_pause() {
+static inline void spin_pause(void) {
 #if defined(__aarch64__) || defined(__arm64__)
     // ARM64: yield gives up CPU time slice to other threads
     __asm__ volatile("yield" ::: "memory");

--- a/runtime/scheduler/aether_scheduler_coop.c
+++ b/runtime/scheduler/aether_scheduler_coop.c
@@ -70,19 +70,19 @@ void scheduler_init_with_opts(int cores, AetherOptFlags opts) {
 // Lifecycle — mostly no-ops in cooperative mode
 // ============================================================================
 
-void scheduler_start() {
+void scheduler_start(void) {
     // No threads to start
 }
 
-void scheduler_ensure_threads_running() {
+void scheduler_ensure_threads_running(void) {
     // No threads in cooperative mode — this is a no-op
 }
 
-void scheduler_stop() {
+void scheduler_stop(void) {
     // No threads to stop
 }
 
-void scheduler_cleanup() {
+void scheduler_cleanup(void) {
     if (schedulers[0].actors) {
         free(schedulers[0].actors);
         schedulers[0].actors = NULL;
@@ -90,7 +90,7 @@ void scheduler_cleanup() {
     schedulers[0].actor_count = 0;
 }
 
-void scheduler_shutdown() {
+void scheduler_shutdown(void) {
     // Drain all remaining messages
     int drained;
     do {
@@ -206,7 +206,7 @@ void scheduler_send_batch_flush(void) {
 // Wait for quiescence — poll until no messages remain
 // ============================================================================
 
-void scheduler_wait() {
+void scheduler_wait(void) {
     // Drain all pending messages cooperatively
     // Also wait for active timeouts to fire
     int idle_rounds = 0;

--- a/runtime/scheduler/multicore_scheduler.c
+++ b/runtime/scheduler/multicore_scheduler.c
@@ -567,7 +567,7 @@ void* AETHER_HOT scheduler_thread(void* arg) {
 
         // TIER 1 ALWAYS ON: Adaptive batch sizing
         int batch_size = sched->batch_state.current_batch_size;
-        if (batch_size > COALESCE_THRESHOLD) batch_size = COALESCE_THRESHOLD;
+        if (batch_size > SCHEDULER_DRAIN_BATCH) batch_size = SCHEDULER_DRAIN_BATCH;
         
         // TIER 1 ALWAYS ON: Message coalescing (batch dequeue reduces atomics from N to 1)
         // Drain all per-sender SPSC channels round-robin into the coalesce buffer.
@@ -1140,7 +1140,7 @@ void scheduler_init_with_opts(int cores, AetherOptFlags opts) {
     scheduler_init(cores);
 }
 
-void scheduler_start() {
+void scheduler_start(void) {
     // MAIN THREAD MODE: Single-actor programs don't need scheduler threads
     // All message processing happens synchronously on the main thread
     if (aether_main_thread_mode_active()) {
@@ -1186,7 +1186,7 @@ void scheduler_ensure_threads_running(void) {
     scheduler_start();
 }
 
-void scheduler_stop() {
+void scheduler_stop(void) {
     // Set all running flags to 0 with release semantics
     for (int i = 0; i < num_cores; i++) {
         atomic_store_explicit(&schedulers[i].running, 0, memory_order_release);
@@ -1257,7 +1257,7 @@ static int has_pending_actor_timeout(void) {
     return 0;
 }
 
-void scheduler_wait() {
+void scheduler_wait(void) {
     // MAIN THREAD MODE: All messages processed synchronously, nothing to wait for
     // This is the fastest path for single-actor programs (counting benchmark)
     if (aether_main_thread_mode_active()) {
@@ -1355,7 +1355,7 @@ void scheduler_wait() {
 // Full shutdown: wait for quiescence, stop threads, join them.
 // Called once at program exit.  Safe to call even if threads were never
 // started (main-thread mode) or already shut down.
-void scheduler_shutdown() {
+void scheduler_shutdown(void) {
     // Wait for any in-flight messages first
     scheduler_wait();
 
@@ -1384,7 +1384,7 @@ void scheduler_shutdown() {
     AETHER_TRACE_FLUSH();
 }
 
-void scheduler_cleanup() {
+void scheduler_cleanup(void) {
     // Free allocated scheduler resources
     for (int i = 0; i < num_cores; i++) {
         // Clean up thread resources

--- a/runtime/scheduler/multicore_scheduler.h
+++ b/runtime/scheduler/multicore_scheduler.h
@@ -16,7 +16,7 @@
 #define MAX_ACTORS_PER_CORE 10000
 #define MAX_CORES 16
 #define BATCH_SIZE 64  // Process up to 64 messages per batch for better throughput
-#define COALESCE_THRESHOLD 512  // Drain this many messages at once for high throughput
+#define SCHEDULER_DRAIN_BATCH 512  // Drain this many messages at once for high throughput
 #ifndef AETHER_IO_MAX_FDS
 #define AETHER_IO_MAX_FDS 4096  // Initial I/O fd map capacity per core (grows on demand)
 #endif
@@ -169,8 +169,8 @@ typedef struct {
 
     // Message coalescing buffer — amortises enqueue atomics across bursts
     struct {
-        void* actors[COALESCE_THRESHOLD];
-        Message messages[COALESCE_THRESHOLD];
+        void* actors[SCHEDULER_DRAIN_BATCH];
+        Message messages[SCHEDULER_DRAIN_BATCH];
         int count;
     } coalesce_buffer;
 
@@ -202,12 +202,12 @@ void scheduler_init(int cores);
 // Initialize with explicit optimization flags
 void scheduler_init_with_opts(int cores, AetherOptFlags opts);
 
-void scheduler_start();
-void scheduler_ensure_threads_running();  // Start threads if not already started (for main-thread mode transition)
-void scheduler_stop();
-void scheduler_wait();      // Wait for quiescence (all pending messages processed). Non-destructive.
-void scheduler_shutdown();  // Wait + stop + join threads. Call once at program exit.
-void scheduler_cleanup();
+void scheduler_start(void);
+void scheduler_ensure_threads_running(void);  // Start threads if not already started (for main-thread mode transition)
+void scheduler_stop(void);
+void scheduler_wait(void);      // Wait for quiescence (all pending messages processed). Non-destructive.
+void scheduler_shutdown(void);  // Wait + stop + join threads. Call once at program exit.
+void scheduler_cleanup(void);
 
 int scheduler_register_actor(ActorBase* actor, int preferred_core);
 void scheduler_deregister_actor(ActorBase* actor);

--- a/runtime/scheduler/scheduler_optimizations.c
+++ b/runtime/scheduler/scheduler_optimizations.c
@@ -4,7 +4,7 @@
 // Global optimization statistics
 OptimizationStats g_opt_stats;
 
-void scheduler_opts_global_init() {
+void scheduler_opts_global_init(void) {
     atomic_store(&g_opt_stats.use_direct_send, true);
     atomic_store(&g_opt_stats.use_adaptive_batching, true);
     atomic_store(&g_opt_stats.use_message_dedup, false);

--- a/runtime/scheduler/scheduler_optimizations.h
+++ b/runtime/scheduler/scheduler_optimizations.h
@@ -32,7 +32,7 @@ typedef struct {
 extern OptimizationStats g_opt_stats;
 
 // Initialize optimization subsystem
-static inline void scheduler_opts_init() {
+static inline void scheduler_opts_init(void) {
     atomic_store(&g_opt_stats.use_direct_send, true);
     atomic_store(&g_opt_stats.use_adaptive_batching, true);
     atomic_store(&g_opt_stats.use_message_dedup, false);  // Opt-in per actor
@@ -170,7 +170,7 @@ static inline void optimized_process_batch_simd(
 }
 
 // Print optimization statistics
-static inline void scheduler_opts_print_stats() {
+static inline void scheduler_opts_print_stats(void) {
     printf("\n=== Scheduler Optimization Statistics ===\n");
     printf("Direct Send:  %d hits, %d misses (%.1f%% hit rate)\n",
         atomic_load(&g_opt_stats.direct_send_hits),

--- a/runtime/utils/aether_cpu_detect.c
+++ b/runtime/utils/aether_cpu_detect.c
@@ -230,7 +230,7 @@ void cpu_detect_features(CPUInfo* info) {
 }
 
 // Initialize and cache CPU info
-const CPUInfo* cpu_get_info() {
+const CPUInfo* cpu_get_info(void) {
     if (!g_cpu_info_initialized) {
         cpu_detect_features(&g_cpu_info);
         g_cpu_info_initialized = 1;
@@ -239,27 +239,27 @@ const CPUInfo* cpu_get_info() {
 }
 
 // Check if AVX2 is available
-int cpu_has_avx2() {
+int cpu_has_avx2(void) {
     return cpu_get_info()->avx2_supported;
 }
 
 // Check if AVX-512 is available
-int cpu_has_avx512() {
+int cpu_has_avx512(void) {
     return cpu_get_info()->avx512f_supported;
 }
 
 // Check if MONITOR/MWAIT is available
-int cpu_has_mwait() {
+int cpu_has_mwait(void) {
     return cpu_get_info()->mwait_supported;
 }
 
 // Check if SSE4.2 is available
-int cpu_has_sse42() {
+int cpu_has_sse42(void) {
     return cpu_get_info()->sse42_supported;
 }
 
 // Print CPU capabilities
-void cpu_print_info() {
+void cpu_print_info(void) {
     const CPUInfo* info = cpu_get_info();
     
     printf("=== CPU Information ===\n");
@@ -304,7 +304,7 @@ void cpu_print_info() {
 }
 
 // Recommend optimal core count
-int cpu_recommend_cores() {
+int cpu_recommend_cores(void) {
     const CPUInfo* info = cpu_get_info();
 
     // Use all logical cores, but cap at 16 for diminishing returns

--- a/runtime/utils/aether_simd_vectorized.c
+++ b/runtime/utils/aether_simd_vectorized.c
@@ -16,7 +16,7 @@
 #endif
 
 // CPU feature detection (extern from aether_cpu_detect.c)
-int cpu_supports_avx2() {
+int cpu_supports_avx2(void) {
 #ifdef __AVX2__
     // Simplified check - assume available if compiled with AVX2
     return 1;
@@ -185,7 +185,7 @@ int count_active_actors_avx2(const uint8_t* active_flags, int count) {
 // Public API with runtime dispatch
 static int g_avx2_available = -1;  // -1 = not checked, 0 = no, 1 = yes
 
-void aether_simd_init() {
+void aether_simd_init(void) {
     if (g_avx2_available == -1) {
         g_avx2_available = cpu_supports_avx2();
         if (g_avx2_available) {
@@ -196,7 +196,7 @@ void aether_simd_init() {
     }
 }
 
-int aether_simd_is_available() {
+int aether_simd_is_available(void) {
     if (g_avx2_available == -1) {
         aether_simd_init();
     }

--- a/runtime/utils/aether_simd_vectorized.h
+++ b/runtime/utils/aether_simd_vectorized.h
@@ -5,10 +5,10 @@
 #include <stdint.h>
 
 // Initialize SIMD system (detects AVX2)
-void aether_simd_init();
+void aether_simd_init(void);
 
 // Check if AVX2 is available
-int aether_simd_is_available();
+int aether_simd_is_available(void);
 
 // Vectorized operations (8-wide AVX2 or scalar fallback)
 void extract_message_ids_avx2(const void** msg_data, int32_t* msg_ids, int count);

--- a/std/casper/module.ae
+++ b/std/casper/module.ae
@@ -59,18 +59,18 @@ extern aether_casper_close(chan: ptr)
 
 // Resolve a hostname to its first IP via a "system.net" channel.
 // Returns the address string, or null on failure.
-extern aether_casper_resolve(netchan: ptr, hostname: string) -> string
+extern aether_casper_resolve(netchan: ptr, hostname: string) -> string @heap
 
 // Look up a username's uid via a "system.pwd" channel. -1 if absent.
 extern aether_casper_pwd_uid(pwdchan: ptr, username: string) -> int
 
 // Look up a username's home directory via a "system.pwd" channel.
 // Returns the path, or null on failure.
-extern aether_casper_pwd_home(pwdchan: ptr, username: string) -> string
+extern aether_casper_pwd_home(pwdchan: ptr, username: string) -> string @heap
 
 // Read a string-valued sysctl via a "system.sysctl" channel.
 // Returns the value, or null on failure.
-extern aether_casper_sysctl_str(sysctlchan: ptr, name: string) -> string
+extern aether_casper_sysctl_str(sysctlchan: ptr, name: string) -> string @heap
 
 // ---- Ergonomic wrappers (casper.* namespace) ----
 

--- a/std/collections/aether_collections.c
+++ b/std/collections/aether_collections.c
@@ -74,7 +74,7 @@ ArrayList* list_new_in(AetherAllocator* alloc) {
     return list;
 }
 
-ArrayList* list_new() {
+ArrayList* list_new(void) {
     return list_new_in(NULL);
 }
 
@@ -379,7 +379,7 @@ static int key_equals(const HashMapEntry* e, const char* b, unsigned int b_len) 
     return memcmp(e->key->data, b, b_len) == 0;
 }
 
-HashMap* map_new() {
+HashMap* map_new(void) {
     HashMap* map = (HashMap*)aether_caps_malloc(sizeof(HashMap));
     if (!map) return NULL;
     map->_kind_magic = AETHER_KIND_MAP_MAGIC;

--- a/std/collections/aether_collections.h
+++ b/std/collections/aether_collections.h
@@ -11,7 +11,7 @@ typedef struct IntArray IntArray;
 typedef struct FloatArray FloatArray;
 typedef struct LongArray LongArray;
 
-ArrayList* list_new();
+ArrayList* list_new(void);
 ArrayList* list_new_in(AetherAllocator* alloc);
 int list_add_raw(ArrayList* list, void* item);
 
@@ -48,7 +48,7 @@ void list_remove(ArrayList* list, int index);
 void list_clear(ArrayList* list);
 void list_free(ArrayList* list);
 
-HashMap* map_new();
+HashMap* map_new(void);
 int map_put_raw(HashMap* map, const char* key, void* value);
 
 /* Heap-string-aware put (#467). Retains the value and tags the

--- a/std/log/aether_log.c
+++ b/std/log/aether_log.c
@@ -118,7 +118,7 @@ void log_init_with_config(LogConfig* config) {
     g_log.initialized = 1;
 }
 
-void log_shutdown() {
+void log_shutdown(void) {
     if (g_log.initialized && g_log.config.output_file &&
         g_log.config.output_file != stderr && g_log.config.output_file != stdout) {
         fclose(g_log.config.output_file);
@@ -244,11 +244,11 @@ void log_set_format(const char* format) {
 }
 
 // Statistics
-LogStats* log_get_stats() {
+LogStats* log_get_stats(void) {
     return &g_log.stats;
 }
 
-void log_print_stats() {
+void log_print_stats(void) {
     fprintf(stderr, "\n========== Logging Statistics ==========\n");
     fprintf(stderr, "DEBUG: %zu\n", g_log.stats.debug_count);
     fprintf(stderr, "INFO:  %zu\n", g_log.stats.info_count);

--- a/std/log/aether_log.h
+++ b/std/log/aether_log.h
@@ -27,7 +27,7 @@ typedef struct {
 // log file could not be opened (logging still works via stderr).
 int log_init_raw(const char* filename, LogLevel min_level);
 void log_init_with_config(LogConfig* config);
-void log_shutdown();
+void log_shutdown(void);
 
 // Core logging functions
 void log_write(LogLevel level, const char* fmt, ...);
@@ -62,8 +62,8 @@ typedef struct {
     size_t fatal_count;
 } LogStats;
 
-LogStats* log_get_stats();
-void log_print_stats();
+LogStats* log_get_stats(void);
+void log_print_stats(void);
 
 #endif // AETHER_LOG_H
 

--- a/std/log/demo_log.c
+++ b/std/log/demo_log.c
@@ -18,7 +18,7 @@ void perform_task(int task_id) {
     LOG_INFO("Task %d completed successfully", task_id);
 }
 
-int main() {
+int main(void) {
     printf("Aether Logging System Demo\n");
     printf("===========================\n\n");
     

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -799,7 +799,7 @@ static const char* http_strcasestr(const char* haystack, const char* needle) {
 
 static int http_server_initialized = 0;
 
-static void http_server_init() {
+static void http_server_init(void) {
     if (http_server_initialized) return;
     #ifdef _WIN32
     WSADATA wsa_data;
@@ -1986,7 +1986,7 @@ void http_request_free(HttpRequest* req) {
 }
 
 // Response building
-HttpServerResponse* http_response_create() {
+HttpServerResponse* http_response_create(void) {
     HttpServerResponse* res = (HttpServerResponse*)calloc(1, sizeof(HttpServerResponse));
     if (!res) return NULL;
     res->status_code = 200;

--- a/std/net/aether_http_server.c
+++ b/std/net/aether_http_server.c
@@ -112,7 +112,7 @@ const char* http_get_header(HttpRequest* r, const char* k) { (void)r; (void)k; r
 const char* http_get_query_param(HttpRequest* r, const char* k) { (void)r; (void)k; return NULL; }
 const char* http_get_path_param(HttpRequest* r, const char* k) { (void)r; (void)k; return NULL; }
 void http_request_free(HttpRequest* r) { (void)r; }
-HttpServerResponse* http_response_create() { return NULL; }
+HttpServerResponse* http_response_create(void) { return NULL; }
 void http_response_set_status(HttpServerResponse* r, int c) { (void)r; (void)c; }
 void http_response_set_header(HttpServerResponse* r, const char* k, const char* v) { (void)r; (void)k; (void)v; }
 void http_response_add_header(HttpServerResponse* r, const char* k, const char* v) { (void)r; (void)k; (void)v; }

--- a/std/net/aether_http_server.h
+++ b/std/net/aether_http_server.h
@@ -445,7 +445,7 @@ const char* http_get_path_param(HttpRequest* req, const char* key);
 void http_request_free(HttpRequest* req);
 
 // Response building
-HttpServerResponse* http_response_create();
+HttpServerResponse* http_response_create(void);
 void http_response_set_status(HttpServerResponse* res, int code);
 void http_response_set_header(HttpServerResponse* res, const char* key, const char* value);
 /* Append a header verbatim, even if a header with the same name

--- a/std/net/aether_net.c
+++ b/std/net/aether_net.c
@@ -76,7 +76,7 @@ struct TcpServer {
 
 static int net_initialized = 0;
 
-static void net_init() {
+static void net_init(void) {
     if (net_initialized) return;
     #ifdef _WIN32
     WSADATA wsa_data;

--- a/std/net/module.ae
+++ b/std/net/module.ae
@@ -39,7 +39,7 @@ exports(
 extern tcp_connect_raw(host: string, port: int) -> ptr
 extern tcp_send_raw(sock: ptr, data: string) -> int
 extern tcp_send_n_raw(sock: ptr, data: string, length: int) -> int
-extern tcp_receive_raw(sock: ptr, max_bytes: int) -> string
+extern tcp_receive_raw(sock: ptr, max_bytes: int) -> string @heap
 extern tcp_receive_n_raw(sock: ptr, max_bytes: int) -> (string @heap, int, string)
 extern tcp_close(sock: ptr) -> int
 

--- a/std/string/aether_string.c
+++ b/std/string/aether_string.c
@@ -78,7 +78,7 @@ AetherString* string_new_with_length(const char* data, size_t length) {
     return str;
 }
 
-AetherString* string_empty() {
+AetherString* string_empty(void) {
     return string_new_with_length("", 0);
 }
 

--- a/std/string/aether_string.h
+++ b/std/string/aether_string.h
@@ -52,7 +52,7 @@ AetherString* string_new(const char* cstr);
 AetherString* string_from_cstr(const char* cstr);  // Alias for new
 AetherString* string_from_literal(const char* cstr);  // Alias for new
 AetherString* string_new_with_length(const char* data, size_t length);
-AetherString* string_empty();
+AetherString* string_empty(void);
 
 // Reference counting — safe to call with plain char* (no-op)
 void string_retain(const void* str);

--- a/tests/compiler/test_arrays.c
+++ b/tests/compiler/test_arrays.c
@@ -36,7 +36,7 @@ static Parser* create_test_parser(Token** tokens, int token_count) {
 } while(0)
 
 // Test array literal parsing
-int test_array_literal_parsing() {
+int test_array_literal_parsing(void) {
     const char* code = "main() { let arr = [1, 2, 3]; }";
     
     lexer_init(code);
@@ -78,7 +78,7 @@ int test_array_literal_parsing() {
 }
 
 // Test array indexing parsing
-int test_array_indexing_parsing() {
+int test_array_indexing_parsing(void) {
     const char* code = "main() { let x = arr[0]; }";
     
     lexer_init(code);
@@ -112,7 +112,7 @@ int test_array_indexing_parsing() {
 }
 
 // Test fixed array type parsing
-int test_fixed_array_type() {
+int test_fixed_array_type(void) {
     const char* code = "main() { let nums = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; }";
     
     lexer_init(code);
@@ -148,7 +148,7 @@ int test_fixed_array_type() {
 }
 
 // Test make() for dynamic arrays
-int test_make_dynamic_array() {
+int test_make_dynamic_array(void) {
     const char* code = "main() { let buf = make([]int, 100); }";
     
     lexer_init(code);
@@ -185,7 +185,7 @@ int test_make_dynamic_array() {
 }
 
 // Test multi-dimensional arrays
-int test_multidimensional_arrays() {
+int test_multidimensional_arrays(void) {
     const char* code = "main() { let matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]; }";
     
     lexer_init(code);
@@ -225,7 +225,7 @@ int test_multidimensional_arrays() {
     return 1;
 }
 
-int main() {
+int main(void) {
     int passed = 0;
     int total = 0;
     

--- a/tests/compiler/test_lexer.c
+++ b/tests/compiler/test_lexer.c
@@ -57,6 +57,6 @@ TEST_CATEGORY(lexer_strings, TEST_CATEGORY_COMPILER) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_lexer_tests() {
+void register_lexer_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/integration/qualified_call_param_inference/lib/mathmod/module.ae
+++ b/tests/integration/qualified_call_param_inference/lib/mathmod/module.ae
@@ -1,0 +1,7 @@
+// Parameters are deliberately unannotated: their types come only from the
+// consumer's call sites, and the consumer writes those calls qualified
+// (`mathmod.scale`) while the compiler names this definition `mathmod_scale`.
+
+scale(a, b) {
+    return a * b
+}

--- a/tests/integration/qualified_call_param_inference/test_qualified_call_param_inference.ae
+++ b/tests/integration/qualified_call_param_inference/test_qualified_call_param_inference.ae
@@ -1,0 +1,34 @@
+// Regression: a qualified call site (`mod.fn`) must reach the definition the
+// compiler names `mod_fn` when it infers parameter types from call sites
+// (#1995, the call-site index).
+//
+// The index keys every call under both its written name and its
+// dot-to-underscore spelling. Keying only the written name still compiles,
+// still passes `ae check`, and prints the wrong number, so the values below
+// are the assertion rather than the exit status of the build.
+
+import mathmod
+
+extern exit(code: int)
+
+main() {
+    println("=== test_qualified_call_param_inference ===")
+
+    // Narrow site first. If it were the only site consulted, `a` pins to
+    // int and the wide site below truncates.
+    small = mathmod.scale(3, 4)
+    if small != 12 {
+        println("FAIL: expected 12, got ${small}")
+        exit(1)
+    }
+    println("  PASS: narrow qualified call site")
+
+    big = mathmod.scale(3000000000, 2)
+    if big != 6000000000 {
+        println("FAIL: expected 6000000000, got ${big}")
+        exit(1)
+    }
+    println("  PASS: wide qualified call site widens the inferred parameter")
+
+    println("All qualified-call inference cases pass")
+}

--- a/tests/integration/string_release_untracked/probe.ae
+++ b/tests/integration/string_release_untracked/probe.ae
@@ -1,0 +1,30 @@
+// string.release on a heap-tracked local that currently holds an untracked
+// value still releases it (#1977).
+//
+// A struct field is the ordinary way to hold a string across calls. Reading
+// one back into a local leaves the local's `_heap_` flag at 0, because the
+// tracker does not consider a field read owned. The release was lowered to a
+// free guarded by that flag alone, so it silently did nothing in exactly the
+// case where the caller has to release by hand.
+//
+// string.free had carried the matching `else` arm all along; release had not.
+
+import std.string
+import std.io
+
+struct Holder { s: string }
+
+extern malloc(size: int) -> ptr
+
+main() {
+    h = malloc(sizeof(Holder)) as *Holder
+    h.s = ""
+    i = 0
+    while i < 200 {
+        prev = h.s
+        h.s = string.to_lower("VALUE ${i}")
+        string.string_release(prev)
+        i = i + 1
+    }
+    println("done: ${h.s}")
+}

--- a/tests/integration/string_release_untracked/test_string_release_untracked.sh
+++ b/tests/integration/string_release_untracked/test_string_release_untracked.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# string.release on a tracked local holding an untracked value still releases
+# it (#1977).
+#
+# Asserted on the GENERATED C rather than by leak-counting a running binary:
+# the defect is that one branch was never emitted, so the emitted code is the
+# precise statement of the fix and it checks the same on every platform.
+# The leak gates cover the runtime side.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+AETHERC="$ROOT/build/aetherc"
+AE="$ROOT/build/ae"
+[ -x "$AETHERC" ] || { echo "  [SKIP] string_release_untracked: build/aetherc missing"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! "$AETHERC" "$SCRIPT_DIR/probe.ae" "$TMP/out.c" > "$TMP/gen.log" 2>&1; then
+    echo "  [FAIL] string_release_untracked: codegen failed"
+    sed 's/^/        /' "$TMP/gen.log" | head -10
+    exit 1
+fi
+
+# The guarded free must have a fallback. Without it the release is a no-op
+# whenever the flag is 0, which is the whole bug.
+if ! grep -q "else { string_release(prev); }" "$TMP/out.c"; then
+    echo "  [FAIL] string_release_untracked: the release has no fallback for an"
+    echo "         untracked value, so it does nothing when _heap_prev is 0"
+    grep -n "_heap_prev" "$TMP/out.c" | sed 's/^/        /' | head -5
+    exit 1
+fi
+
+# And it must still free through the flag when the value IS tracked, so the
+# fix did not simply replace one path with the other.
+grep -q "if (_heap_prev) { aether_heap_str_free" "$TMP/out.c" || {
+    echo "  [FAIL] string_release_untracked: the tracked-value free was lost"
+    exit 1
+}
+
+# The program still builds and runs.
+if [ -x "$AE" ]; then
+    if "$AE" build "$SCRIPT_DIR/probe.ae" -o "$TMP/probe" > "$TMP/build.log" 2>&1; then
+        if "$TMP/probe" > "$TMP/run.out" 2>&1; then
+            grep -q "^done: value 199$" "$TMP/run.out" || {
+                echo "  [FAIL] string_release_untracked: wrong output"
+                sed 's/^/        /' "$TMP/run.out" | head -5
+                exit 1
+            }
+        fi
+    fi
+fi
+
+echo "  [PASS] string_release_untracked: release frees an untracked value too"
+exit 0

--- a/tests/memory/test_memory_arena.c
+++ b/tests/memory/test_memory_arena.c
@@ -160,6 +160,6 @@ TEST_CATEGORY(arena_nested_scopes, TEST_CATEGORY_MEMORY) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_memory_arena_tests() {
+void register_memory_arena_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/memory/test_memory_pool.c
+++ b/tests/memory/test_memory_pool.c
@@ -196,6 +196,6 @@ TEST_CATEGORY(pool_alignment_odd_object_size, TEST_CATEGORY_MEMORY) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_memory_pool_tests() {
+void register_memory_pool_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/runtime/bench_atomic_overhead.c
+++ b/tests/runtime/bench_atomic_overhead.c
@@ -15,7 +15,7 @@
 // Test: Counter Increment Overhead
 // ============================================================================
 
-void bench_counter_overhead() {
+void bench_counter_overhead(void) {
     printf("\n=== Counter Increment Overhead ===\n");
     
     const int ITERATIONS = 10000000;  // 10M iterations
@@ -46,7 +46,7 @@ void bench_counter_overhead() {
 // Test: Mailbox Operation Overhead
 // ============================================================================
 
-void bench_mailbox_operations() {
+void bench_mailbox_operations(void) {
     printf("\n=== Mailbox Operation Overhead ===\n");
     
     const int ITERATIONS = 1000000;  // 1M iterations
@@ -88,7 +88,7 @@ void bench_mailbox_operations() {
 // Test: Message Copy Overhead
 // ============================================================================
 
-void bench_message_copy() {
+void bench_message_copy(void) {
     printf("\n=== Message Copy Overhead ===\n");
     
     const int ITERATIONS = 10000000;
@@ -128,7 +128,7 @@ typedef struct {
     _Atomic int message_count;  // Atomic int
 } AtomicActor;
 
-void bench_actor_loop() {
+void bench_actor_loop(void) {
     printf("\n=== Actor Message Processing Loop ===\n");
     
     const int MESSAGES = 1000000;
@@ -189,7 +189,7 @@ void bench_actor_loop() {
 // Main
 // ============================================================================
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("     Aether Micro-Benchmarks: Atomic Operation Overhead\n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_batched_atomic.c
+++ b/tests/runtime/bench_batched_atomic.c
@@ -67,7 +67,7 @@ void* new_actor_thread(void* arg) {
     return NULL;
 }
 
-int main() {
+int main(void) {
     printf("=== Batched Atomic Optimization Benchmark ===\n");
     printf("Messages: %d\n\n", MESSAGES);
     

--- a/tests/runtime/bench_plain_vs_atomic.c
+++ b/tests/runtime/bench_plain_vs_atomic.c
@@ -14,7 +14,7 @@
 
 #define ITERATIONS 10000000
 
-int main() {
+int main(void) {
     printf("=== Atomic Overhead Benchmark ===\n");
     printf("Iterations: %d\n\n", ITERATIONS);
     

--- a/tests/runtime/bench_profiled.c
+++ b/tests/runtime/bench_profiled.c
@@ -8,7 +8,7 @@
 #include "../../runtime/actors/actor_state_machine.h"
 #include "../../runtime/utils/aether_runtime_profile.h"
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("     Aether Profiled Benchmark - Continuous Monitoring\n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_scheduler.c
+++ b/tests/runtime/bench_scheduler.c
@@ -77,7 +77,7 @@ void bench_actor_step(BenchActor* self) {
 // Benchmark Functions
 // ============================================================================
 
-void bench_single_core_throughput() {
+void bench_single_core_throughput(void) {
     printf("\n=== Single Core Throughput ===\n");
 
     scheduler_init(1);
@@ -192,7 +192,7 @@ void bench_multi_core_throughput(int cores) {
     free(actors);
 }
 
-void bench_cross_core_overhead() {
+void bench_cross_core_overhead(void) {
     printf("\n=== Cross-Core Messaging Overhead ===\n");
     
     scheduler_init(4);
@@ -252,7 +252,7 @@ actor1->count_local = 0;
     }
 }
 
-void bench_scalability() {
+void bench_scalability(void) {
     printf("\n=== Scalability Analysis ===\n");
     printf("Cores | Throughput (msg/sec) | Efficiency\n");
     printf("------|----------------------|-----------\n");
@@ -327,7 +327,7 @@ void bench_scalability() {
         free(actors);
     }
 }
-void bench_latency() {
+void bench_latency(void) {
     printf("\n=== Latency Test ===");
     
     scheduler_init(2);
@@ -383,7 +383,7 @@ void bench_latency() {
     free(schedulers[1].actors);
 }
 
-void bench_contention() {
+void bench_contention(void) {
     printf("\n=== Contention Test (Many-to-One) ===");
     
     scheduler_init(4);
@@ -439,7 +439,7 @@ void bench_contention() {
     }
 }
 
-void bench_burst_patterns() {
+void bench_burst_patterns(void) {
     printf("\n=== Burst Pattern Test ===");
     
     scheduler_init(2);
@@ -496,7 +496,7 @@ void bench_burst_patterns() {
     free(schedulers[0].actors);
     free(schedulers[1].actors);
 }
-void bench_mailbox_saturation() {
+void bench_mailbox_saturation(void) {
     printf("\n=== Mailbox Saturation Test ===\n");
     
     scheduler_init(2);
@@ -551,7 +551,7 @@ void bench_mailbox_saturation() {
 // Main
 // ============================================================================
 
-int main() {
+int main(void) {
     printf("===============================================================\n");
     printf("        Aether Scheduler Performance Benchmarks               \n");
     printf("===============================================================\n");

--- a/tests/runtime/bench_zerocopy.c
+++ b/tests/runtime/bench_zerocopy.c
@@ -45,7 +45,7 @@ void bench_actor_step(BenchActor* self) {
     atomic_store_explicit(&self->active, (self->mailbox.count > 0), memory_order_relaxed);
 }
 
-void benchmark_small_messages() {
+void benchmark_small_messages(void) {
     printf("\n=== Benchmark: Small Messages (64 bytes, inline) ===\n");
 
     scheduler_init(1);
@@ -88,7 +88,7 @@ void benchmark_small_messages() {
     free(actor);
 }
 
-void benchmark_large_messages() {
+void benchmark_large_messages(void) {
     printf("\n=== Benchmark: Large Messages (1KB, zero-copy) ===\n");
     
     scheduler_init(1);
@@ -139,7 +139,7 @@ void benchmark_large_messages() {
     free(actor);
 }
 
-void benchmark_mixed_messages() {
+void benchmark_mixed_messages(void) {
     printf("\n=== Benchmark: Mixed Messages (33%% large) ===\n");
     
     scheduler_init(1);
@@ -192,7 +192,7 @@ void benchmark_mixed_messages() {
     free(actor);
 }
 
-int main() {
+int main(void) {
     printf("Zero-Copy Message Passing Performance Benchmark\n");
     printf("================================================\n");
     

--- a/tests/runtime/test_lockfree_mailbox.c
+++ b/tests/runtime/test_lockfree_mailbox.c
@@ -156,6 +156,6 @@ TEST_CATEGORY(lockfree_mailbox_thread_safety, TEST_CATEGORY_RUNTIME) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_lockfree_mailbox_tests() {
+void register_lockfree_mailbox_tests(void) {
     // Empty - tests registered by constructor
 }

--- a/tests/runtime/test_runtime_manual.c
+++ b/tests/runtime/test_runtime_manual.c
@@ -21,7 +21,7 @@ void Counter_step(Counter* self) {
     (self->count = (self->count + 1));
 }
 
-Counter* spawn_Counter() {
+Counter* spawn_Counter(void) {
     Counter* actor = malloc(sizeof(Counter));
     actor->id = 1;
     atomic_store_explicit(&actor->active, 1, memory_order_relaxed);
@@ -41,7 +41,7 @@ void send_message(void* actor_ptr, int type, int payload) {
     atomic_store_explicit(&actor->active, 1, memory_order_relaxed);
 }
 
-int main() {
+int main(void) {
     Counter* c = spawn_Counter();
     
     send_message(c, 1, 0);

--- a/tests/runtime/test_scheduler_optimizations.c
+++ b/tests/runtime/test_scheduler_optimizations.c
@@ -346,7 +346,7 @@ TEST_CATEGORY(direct_send_stats, TEST_CATEGORY_RUNTIME) {
 }
 
 // Note: Tests are auto-registered via TEST_CATEGORY macro
-void register_scheduler_optimization_tests() {
+void register_scheduler_optimization_tests(void) {
     // Empty - tests registered by constructor
 }
 

--- a/tests/runtime/test_scheduler_stress.c
+++ b/tests/runtime/test_scheduler_stress.c
@@ -97,7 +97,7 @@ static void cascade_step(CascadeActor* self) {
 // Stress Tests
 // ============================================================================
 
-void test_rapid_init_shutdown() {
+void test_rapid_init_shutdown(void) {
     // Test multiple init/shutdown cycles
     for (int cycle = 0; cycle < 5; cycle++) {
         scheduler_init(2);
@@ -108,7 +108,7 @@ void test_rapid_init_shutdown() {
     }
 }
 
-void test_zero_message_workload() {
+void test_zero_message_workload(void) {
     scheduler_init(2);
     scheduler_start();
     
@@ -119,7 +119,7 @@ void test_zero_message_workload() {
     scheduler_cleanup();
 }
 
-void test_single_message() {
+void test_single_message(void) {
     scheduler_init(1);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -150,7 +150,7 @@ void test_single_message() {
     free(actor);
 }
 
-void test_many_actors_single_core() {
+void test_many_actors_single_core(void) {
     scheduler_init(1);
     
     const int NUM_ACTORS = 100;
@@ -195,7 +195,7 @@ void test_many_actors_single_core() {
     free(actors);
 }
 
-void test_burst_then_idle() {
+void test_burst_then_idle(void) {
     scheduler_init(2);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -247,7 +247,7 @@ void test_burst_then_idle() {
     free(actor);
 }
 
-void test_max_cores() {
+void test_max_cores(void) {
     int max = MAX_CORES;
     if (max > 16) max = 16;  // Limit for test speed
     
@@ -297,7 +297,7 @@ void test_max_cores() {
     free(actors);
 }
 
-void test_alternating_load() {
+void test_alternating_load(void) {
     scheduler_init(4);
     
     StressActor** actors = malloc(4 * sizeof(StressActor*));
@@ -348,7 +348,7 @@ void test_alternating_load() {
     free(actors);
 }
 
-void test_immediate_shutdown() {
+void test_immediate_shutdown(void) {
     scheduler_init(2);
     
     StressActor* actor = malloc(sizeof(StressActor));
@@ -378,7 +378,7 @@ void test_immediate_shutdown() {
     free(actor);
 }
 
-void test_concurrent_sends_same_actor() {
+void test_concurrent_sends_same_actor(void) {
     scheduler_init(4);
 
     StressActor* actor = malloc(sizeof(StressActor));
@@ -418,7 +418,7 @@ void test_concurrent_sends_same_actor() {
     }
 }
 
-void test_priority_inversion() {
+void test_priority_inversion(void) {
     scheduler_init(2);
     
     StressActor* slow = malloc(sizeof(StressActor));
@@ -473,7 +473,7 @@ void test_priority_inversion() {
     free(fast);
 }
 
-void test_message_ordering_under_load() {
+void test_message_ordering_under_load(void) {
     scheduler_init(1);
 
     OrderActor* actor = malloc(sizeof(OrderActor));
@@ -515,7 +515,7 @@ void test_message_ordering_under_load() {
     schedulers[0].actors = NULL;
 }
 
-void test_cascading_messages() {
+void test_cascading_messages(void) {
     scheduler_init(2);
 
     CascadeActor* actors[3];
@@ -572,7 +572,7 @@ void test_cascading_messages() {
     }
 }
 
-void test_memory_pressure() {
+void test_memory_pressure(void) {
     scheduler_init(2);
     
     const int MANY = 50;

--- a/tests/runtime/test_send_buffer.c
+++ b/tests/runtime/test_send_buffer.c
@@ -282,7 +282,7 @@ TEST_CATEGORY(send_buffer_flush_no_double_send, TEST_CATEGORY_RUNTIME) {
     // N is chosen large enough that SPSC + mailbox can't hold all
     // of them: 5 SPSC slots + 32 mailbox slots = 37 max in flight,
     // so 50 input messages forces the partial-send / leftover path.
-    const int N = 50;
+    enum { N = 50 };
     g_send_buffer.target = actor;
     g_send_buffer.count = N;
     for (int i = 0; i < N; i++) {

--- a/tests/runtime/test_zerocopy.c
+++ b/tests/runtime/test_zerocopy.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-void test_zerocopy_message_creation() {
+void test_zerocopy_message_creation(void) {
     // Test small message (no zero-copy)
     Message msg1 = message_create_simple(MSG_INCREMENT, 1, 42);
     ASSERT_EQ(msg1.type, MSG_INCREMENT);
@@ -34,7 +34,7 @@ void test_zerocopy_message_creation() {
     message_free(&msg2);
 }
 
-void test_zerocopy_message_transfer() {
+void test_zerocopy_message_transfer(void) {
     int size = 1024;
     void* data = malloc(size);
     memset(data, 0xCD, size);
@@ -59,7 +59,7 @@ void test_zerocopy_message_transfer() {
     message_free(&dest);
 }
 
-void test_zerocopy_mailbox_operations() {
+void test_zerocopy_mailbox_operations(void) {
     Mailbox mbox;
     mailbox_init(&mbox);
     
@@ -93,7 +93,7 @@ void test_zerocopy_mailbox_operations() {
     ASSERT_EQ(mbox.count, 0);
 }
 
-void test_zerocopy_threshold() {
+void test_zerocopy_threshold(void) {
     // Messages below threshold should not allocate
     Message small = message_create_simple(MSG_INCREMENT, 1, 100);
     ASSERT_TRUE(small.zerocopy.data == NULL);
@@ -109,7 +109,7 @@ void test_zerocopy_threshold() {
     message_free(&large);
 }
 
-void test_zerocopy_batch_operations() {
+void test_zerocopy_batch_operations(void) {
     Mailbox mbox;
     mailbox_init(&mbox);
     
@@ -148,7 +148,7 @@ void test_zerocopy_batch_operations() {
     ASSERT_EQ(zerocopy_count, 2);
 }
 
-void test_zerocopy_message_free() {
+void test_zerocopy_message_free(void) {
     // Test freeing null/unowned message (should be safe)
     Message msg1 = message_create_simple(MSG_INCREMENT, 1, 42);
     message_free(&msg1);  // Should be no-op
@@ -162,7 +162,7 @@ void test_zerocopy_message_free() {
     ASSERT_TRUE(msg2.zerocopy.data == NULL);
 }
 
-void register_zerocopy_tests() {
+void register_zerocopy_tests(void) {
     register_test_with_category("Zero-copy message creation", test_zerocopy_message_creation, TEST_CATEGORY_RUNTIME);
     register_test_with_category("Zero-copy message transfer", test_zerocopy_message_transfer, TEST_CATEGORY_RUNTIME);
     register_test_with_category("Zero-copy mailbox operations", test_zerocopy_mailbox_operations, TEST_CATEGORY_RUNTIME);

--- a/tests/scripts/check_changelog_fold.sh
+++ b/tests/scripts/check_changelog_fold.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# CRITICAL: this is the single implementation of the CHANGELOG release-fold
+# gate. The CI job "CHANGELOG entry present" calls it and so does
+# `make check-changelog`. Do not reimplement either half separately: a local
+# check that drifts from the gate is worse than no local check, because it
+# reports green on the exact corruption the gate exists to stop.
+set -u
+
+FILE=${1:-CHANGELOG.md}
+BASE=${CHANGELOG_FOLD_BASE:-origin/main}
+
+if [ ! -f "$FILE" ]; then
+    echo "check_changelog_fold: no such file: $FILE" >&2
+    exit 2
+fi
+
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    err() { echo "::error::$*"; }
+else
+    err() { echo "ERROR: $*" >&2; }
+fi
+
+rc=0
+
+if ! grep -q '^## \[current\]$' "$FILE"; then
+    err "$FILE has no '## [current]' section."
+    echo ""
+    echo "The release job renames the first '## [current]' heading into"
+    echo "the new version, so an entry outside one is not released."
+    echo "If main cut a release while this branch was open, the merge"
+    echo "folded your entry under that version's heading: move it back"
+    echo "under a fresh '## [current]' and leave the tagged section as"
+    echo "it shipped (compare with \`git show vX.Y.Z:$FILE\`)."
+    exit 1
+fi
+
+n_current=$(grep -cE '^## \[current\]$' "$FILE" || true)
+if [ "$n_current" != "1" ]; then
+    err "$FILE has $n_current '## [current]' headings; expected exactly 1."
+    echo ""
+    echo "The release job renames the FIRST '## [current]' into the new"
+    echo "version. A second one further down then gets renamed by the"
+    echo "NEXT release, which buries entries inside a section that has"
+    echo "already shipped."
+    echo ""
+    echo "Since the release now leaves a '[current]' behind, a PR should"
+    echo "add its entry UNDER the existing heading rather than adding a"
+    echo "new one. Merge the sections into one."
+    exit 1
+fi
+
+# Compared against the base branch rather than the git tags. Editing a
+# released section AFTER its tag is legitimate and routine here, so
+# "differs from the tag" would red a third of all PRs and be switched off.
+# The real invariant is narrower and is exactly the fold: THIS branch must
+# not change a section that the base already released.
+#
+# Whitespace is normalised so a merge that only reflowed spacing does not
+# read as a fold. cksum rather than cmp: MSYS2 ships no diffutils, and
+# `cmp -s` exits non-zero both when files differ AND when cmp is missing,
+# reporting a false failure instead of a missing tool.
+git fetch --quiet origin main 2>/dev/null || true
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+    echo "check_changelog_fold: $BASE is not available, skipping the fold check."
+    exit $rc
+fi
+
+norm() { sed -e 's/[[:space:]]*$//' | cat -s; }
+# CRITICAL: awk, not sed. BSD sed (macOS) rejects `q` inside a brace group,
+# so the sed form of this extraction returns nothing on macOS and both sides
+# compare equal -- a silent false green on exactly the corruption this
+# checks for. awk behaves identically on GNU, BSD and MSYS2.
+section() {
+    awk -v v="$1" '
+        BEGIN { gsub(/\./, "\\.", v); pat = "^## \\[" v "\\]" }
+        $0 ~ pat { inside = 1; next }
+        inside && /^## \[/ { exit }
+        inside { print }
+    '
+}
+
+folded=""
+for v in $(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$FILE" | tr -d '#[] ' | head -8); do
+    a=$(git show "$BASE:$FILE" 2>/dev/null | section "$v" | norm)
+    [ -z "$a" ] && continue
+    b=$(section "$v" < "$FILE" | norm)
+    if [ "$(printf '%s' "$a" | cksum)" != "$(printf '%s' "$b" | cksum)" ]; then
+        folded="$folded $v"
+    fi
+done
+
+if [ -n "$folded" ]; then
+    err "This branch rewrites already-released CHANGELOG section(s):$folded"
+    echo ""
+    echo "A release was almost certainly cut while this branch was open."
+    echo "The release job renames '## [current]' into the version"
+    echo "heading, so merging main folds this branch's entry INTO that"
+    echo "released section, usually with no git conflict, which is why"
+    echo "nothing flagged it."
+    echo ""
+    echo "Move the entry back under a fresh '## [current]' and restore"
+    echo "the released section as $BASE has it:"
+    for v in $folded; do
+        echo "  git show $BASE:$FILE   # section [$v]"
+    done
+    exit 1
+fi
+
+echo "Released sections match $BASE, and there is exactly one '## [current]'."
+exit $rc

--- a/tools/ae.c
+++ b/tools/ae.c
@@ -89,7 +89,7 @@ extern char** environ;
  * command there (dropping -L lib) once enough std dirs existed. 64 KiB leaves
  * generous headroom. The command runners (posix_run/win_run) use the same
  * size so a large command isn't re-truncated when handed off. */
-#define AE_CMD_BUF 65536
+/* AE_CMD_BUF lives in ae_internal.h so every caller agrees on it. */
 
 // --------------------------------------------------------------------------
 // Cross-platform temp directory
@@ -2755,6 +2755,23 @@ static const char* opt_flags(bool optimize) {
                     : "-O0 -g -Wformat" AETHER_WRAP_CFLAGS;
 }
 
+/* CRITICAL: a truncated command is never going to be right, so do not run it.
+ * Emitting it anyway turned a clear condition into "clang: error: no input
+ * files" with the real cause scrolled off above, which is how a long build
+ * path came to look like a compiler bug (#1974). Fail with our own message
+ * instead, using the same "hand back a command that fails" shape this file
+ * already uses when the toolchain is missing. */
+static void cmd_too_long(char* cmd, size_t size, int needed) {
+    fprintf(stderr,
+            "Error: the compiler command needs %d bytes and the buffer holds %zu.\n"
+            "       This is almost always a very long build path: every include\n"
+            "       flag carries the prefix, so the command grows with the depth\n"
+            "       of the tree. Build from a shorter path, or reduce\n"
+            "       extra_sources / include directories.\n",
+            needed, size);
+    snprintf(cmd, size, "exit 1");
+}
+
 void build_gcc_cmd(char* cmd, size_t size,
                           const char* c_file, const char* out_file,
                           bool optimize, const char* extra_files) {
@@ -2905,9 +2922,7 @@ void build_gcc_cmd(char* cmd, size_t size,
             "\"%s\" %s %s \"%s\" %s -L\"%s\" %s%s -laether -o \"%s\" %s %s %s %s %s %s %s %s %s %s %s",
             s_gcc_bin, opt, tc.include_flags, c_file, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
         if (w >= (int)size) {
-            fprintf(stderr,
-                "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",
-                w, size);
+            cmd_too_long(cmd, size, w);
         }
     } else {
         /* Order matters, same as the POSIX branch: the host-bridge .a
@@ -2917,9 +2932,7 @@ void build_gcc_cmd(char* cmd, size_t size,
             "\"%s\" %s %s \"%s\" %s %s %s%s -o \"%s\" %s %s %s %s %s %s %s %s %s %s %s",
             s_gcc_bin, opt, tc.include_flags, c_file, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, audio_libs, yaml_libs, win_link_libs, ae_link, link_flags);
         if (w >= (int)size) {
-            fprintf(stderr,
-                "Warning: gcc link command truncated at %d bytes (buffer %zu).\n",
-                w, size);
+            cmd_too_long(cmd, size, w);
         }
     }
 #else
@@ -3182,11 +3195,7 @@ void build_gcc_cmd(char* cmd, size_t size,
             "%s %s %s \"%s\"%s %s -rdynamic -L%s %s%s -laether -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s %s",
             cc, opt, tc.include_flags, c_file, config_c, extra, lib_dir, contrib_L, g_host_bridge_link, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
-            fprintf(stderr,
-                "Warning: gcc link command truncated at %d bytes (buffer %zu), "
-                "your extra_sources plus includes won't fit; rebuild `ae` with "
-                "a larger cmd buffer or split into multiple [[bin]] entries.\n",
-                w, size);
+            cmd_too_long(cmd, size, w);
         }
     } else {
         // Order matters: host-bridge .a files reference runtime
@@ -3196,11 +3205,7 @@ void build_gcc_cmd(char* cmd, size_t size,
             "%s %s %s \"%s\"%s %s %s %s%s -rdynamic -o \"%s\" -pthread -lm %s %s %s %s %s %s %s %s %s %s %s %s",
             cc, opt, tc.include_flags, c_file, config_c, extra, g_host_bridge_link, pcre2_src_defs, tc.runtime_srcs, out_file, openssl_libs, zlib_libs, nghttp2_libs, pcre2_libs, brotli_libs, zstd_libs, casper_libs, audio_libs, yaml_libs, ae_link, link_flags, g_binimport_link);
         if (w >= (int)size) {
-            fprintf(stderr,
-                "Warning: gcc link command truncated at %d bytes (buffer %zu), "
-                "your extra_sources plus includes won't fit; rebuild `ae` with "
-                "a larger cmd buffer or split into multiple [[bin]] entries.\n",
-                w, size);
+            cmd_too_long(cmd, size, w);
         }
     }
 #endif

--- a/tools/ae_internal.h
+++ b/tools/ae_internal.h
@@ -92,6 +92,12 @@ void discover_toolchain(void);
 extern char s_cache_dir[512];   /* resolved once by init_cache_dir (ae_cache.c) */
 
 /* ae.c helpers shared across TUs. */
+/* Size of a built compiler/linker command line. One definition, because the
+ * REPL had its own 16 KB array while everything else used this: a build path
+ * long enough to push the command past 16 KB truncated it mid-argument, and
+ * the compiler then failed with "no input files" (#1974). */
+#define AE_CMD_BUF 65536
+
 int  run_cmd_show_warnings(const char* cmd);
 int  run_cmd_capture_stdout(const char* cmd, const char* path);
 void dump_captured_stdout(const char* path);

--- a/tools/ae_repl.c
+++ b/tools/ae_repl.c
@@ -56,7 +56,7 @@ static int repl_eval(const char* ae_file, const char* c_file,
     fprintf(f, "}\n");
     fclose(f);
 
-    char cmd[16384];
+    char cmd[AE_CMD_BUF];
     build_aetherc_cmd(cmd, sizeof(cmd), ae_file, c_file);
     if (run_cmd_quiet(cmd) != 0) {
         run_cmd(cmd);

--- a/tools/apkg/apkg.c
+++ b/tools/apkg/apkg.c
@@ -240,7 +240,7 @@ int apkg_install(const char* package) {
     return 0;
 }
 
-int apkg_publish() {
+int apkg_publish(void) {
     printf("Publishing package...\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -312,7 +312,7 @@ int apkg_publish() {
     return 0;
 }
 
-int apkg_build() {
+int apkg_build(void) {
     printf("Building package...\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -380,7 +380,7 @@ int apkg_build() {
     return 0;
 }
 
-int apkg_test() {
+int apkg_test(void) {
     printf("Running tests...\n");
     
     // Check if tests directory exists
@@ -572,7 +572,7 @@ int apkg_search(const char* query) {
     return 0;
 }
 
-int apkg_update() {
+int apkg_update(void) {
     printf("Updating dependencies...\n\n");
     
     FILE* manifest = fopen("aether.toml", "r");
@@ -659,7 +659,7 @@ int apkg_update() {
     return 0;
 }
 
-int apkg_run() {
+int apkg_run(void) {
     printf("Running package...\n");
     
     // Check if we need to build
@@ -723,7 +723,7 @@ int apkg_run() {
     return result;
 }
 
-void apkg_print_help() {
+void apkg_print_help(void) {
     printf("apkg - Aether Package Manager v%s\n\n", APKG_VERSION);
     printf("USAGE:\n");
     printf("    apkg <command> [options]\n\n");
@@ -741,7 +741,7 @@ void apkg_print_help() {
     printf("For more information, see: https://github.com/aether-lang-dev/aether\n");
 }
 
-void apkg_print_version() {
+void apkg_print_version(void) {
     printf("apkg %s\n", APKG_VERSION);
 }
 

--- a/tools/apkg/apkg.h
+++ b/tools/apkg/apkg.h
@@ -25,20 +25,20 @@ typedef struct {
 
 int apkg_init(const char* name);
 int apkg_install(const char* package);
-int apkg_publish();
-int apkg_build();
-int apkg_test();
+int apkg_publish(void);
+int apkg_build(void);
+int apkg_test(void);
 int apkg_search(const char* query);
-int apkg_update();
-int apkg_run();
+int apkg_update(void);
+int apkg_run(void);
 
 void apkg_free_package(Package* pkg);
 
 PackageInfo apkg_find_package(const char* name);
 int apkg_download_package(const char* name, const char* version);
 
-void apkg_print_help();
-void apkg_print_version();
+void apkg_print_help(void);
+void apkg_print_version(void);
 
 #endif
 

--- a/tools/profiler/profiler_demo.c
+++ b/tools/profiler/profiler_demo.c
@@ -16,7 +16,7 @@
 #endif
 
 // Simulate actor activity for profiling
-void simulate_actor_activity() {
+void simulate_actor_activity(void) {
     printf("Simulating actor activity for profiling...\n");
     
     Arena* arena = arena_create(1024 * 1024); // 1MB arena

--- a/tools/profiler/profiler_server.c
+++ b/tools/profiler/profiler_server.c
@@ -42,7 +42,7 @@ static struct {
 } g_profiler = {0};
 
 // Helper functions
-double profiler_get_time_ms() {
+double profiler_get_time_ms(void) {
     struct timespec ts;
     #ifdef _WIN32
     timespec_get(&ts, TIME_UTC);
@@ -52,11 +52,11 @@ double profiler_get_time_ms() {
     return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
 }
 
-static double get_current_time_ms() {
+static double get_current_time_ms(void) {
     return profiler_get_time_ms();
 }
 
-static void init_winsock() {
+static void init_winsock(void) {
     #ifdef _WIN32
     static int winsock_initialized = 0;
     if (!winsock_initialized) {
@@ -232,7 +232,7 @@ void profiler_init(ProfilerConfig* config) {
     printf("[Profiler] Initialized with max %d events\n", config->max_events);
 }
 
-void profiler_shutdown() {
+void profiler_shutdown(void) {
     if (!g_profiler.initialized) return;
     
     profiler_stop_server();
@@ -244,7 +244,7 @@ void profiler_shutdown() {
     printf("[Profiler] Shutdown complete\n");
 }
 
-void profiler_start_server() {
+void profiler_start_server(void) {
     if (!g_profiler.initialized || g_profiler.server_running) return;
     
     init_winsock();
@@ -287,7 +287,7 @@ void profiler_start_server() {
     printf("\n");
 }
 
-void profiler_stop_server() {
+void profiler_stop_server(void) {
     if (!g_profiler.server_running) return;
     
     g_profiler.server_running = 0;
@@ -321,11 +321,11 @@ void profiler_record_event(ProfilerEvent* event) {
     pthread_mutex_unlock(&g_profiler.event_mutex);
 }
 
-int profiler_is_enabled() {
+int profiler_is_enabled(void) {
     return g_profiler.initialized && g_profiler.config.enabled;
 }
 
-MetricsSnapshot profiler_get_current_metrics() {
+MetricsSnapshot profiler_get_current_metrics(void) {
     MetricsSnapshot metrics = {0};
     
     // Get memory stats

--- a/tools/profiler/profiler_server.h
+++ b/tools/profiler/profiler_server.h
@@ -39,11 +39,11 @@ typedef struct {
 
 // Profiler API
 void profiler_init(ProfilerConfig* config);
-void profiler_shutdown();
-void profiler_start_server();
-void profiler_stop_server();
+void profiler_shutdown(void);
+void profiler_start_server(void);
+void profiler_stop_server(void);
 void profiler_record_event(ProfilerEvent* event);
-int profiler_is_enabled();
+int profiler_is_enabled(void);
 
 // Metric snapshot for JSON export
 typedef struct {
@@ -71,12 +71,12 @@ typedef struct {
     double timestamp_ms;
 } MetricsSnapshot;
 
-MetricsSnapshot profiler_get_current_metrics();
+MetricsSnapshot profiler_get_current_metrics(void);
 const char* profiler_metrics_to_json(MetricsSnapshot* metrics);
 const char* profiler_events_to_json(int count, int offset);
 
 // Helper function
-double profiler_get_time_ms();
+double profiler_get_time_ms(void);
 
 #endif // AETHER_PROFILER_SERVER_H
 


### PR DESCRIPTION
Every open issue in the tracker that describes an actual defect, fixed in one pass. The rest of the 60 open issues are proposals and design RFCs (Vulkan bindings, compile-time DI, first-class slices, language comparisons), which are not defects and are deliberately untouched.

Closes #1974
Closes #1977
Closes #1987
Closes #1995
Closes #1996
Closes #2001

`#1981` is already fixed on `main` by the merged #1983 and is closed separately with evidence, not here.

## Fixed

### `tcp_receive_raw` leaked every buffer it returned (#1987)

`std/net/module.ae` declared the extern as returning a borrowed `string`, but the C side returns an owned heap buffer. Nothing freed it. Three `std.casper` externs had the same gap: `aether_casper_resolve`, `aether_casper_pwd_home`, `aether_casper_sysctl_str`.

### `string.release()` silently did nothing on an untracked value (#1977)

The emitted release was `if (_heap_x) { aether_heap_str_free(x); ... }` with no else. A string handed over by a call the ownership tracker did not follow has `_heap_x == 0`, so asking to release it was a no-op. Both emission sites now fall back to `string_release(x)`.

`tests/integration/string_release_untracked/` asserts the generated C. Mutation-checked: removing the fallback from the site the probe exercises turns the test red.

```
=== MUTATED (must FAIL) ===
  [FAIL] string_release_untracked: the release has no fallback for an
         untracked value, so it does nothing when _heap_prev is 0
exit=1
=== RESTORED (must PASS) ===
  [PASS] string_release_untracked: release frees an untracked value too
exit=0
```

### A long build path truncated the C compiler command (#1974)

Four sites in `tools/ae` assembled a compiler command line into a fixed buffer, warned on overflow, and then ran the truncated command. The user saw `error: no input files` from the C compiler, with nothing pointing at the real cause. They now fail with the length needed and the limit hit. `AE_CMD_BUF` is defined once in `tools/ae_internal.h` rather than three times, and the REPL uses it instead of a smaller private buffer.

Verified by running the REPL suite from a 157-character path: 40/40.

### `COALESCE_THRESHOLD` was defined twice with different values

`runtime/scheduler/multicore_scheduler.h` defines it as 512 (a drain batch size, and the length of two arrays); `runtime/actors/aether_message_coalescing.h` defines it as 8 (when to start coalescing). Which value a translation unit saw depended on include order, and the collision was visible only as a `-Wmacro-redefined` warning in one test build. The scheduler's is now `SCHEDULER_DRAIN_BATCH`, which is also what it means. Docs updated.

## Changed

### Call-site type propagation is no longer quadratic (#1995)

`propagate_function_call_types` walked every top-level node once per function definition, each walk descending that node's whole subtree, repeated until the fixpoint settled. One walk now builds a callee-to-call-sites index, and each definition resolves against its own bucket.

Measured on one function per call site, best of 7 runs, interleaved:

| functions | type check (before) | type check (after) | whole compile (before) | whole compile (after) |
|---|---|---|---|---|
| 400 | 0.028s | 0.004s | 0.052s | 0.028s |
| 800 | 0.090s | 0.018s | 0.129s | 0.061s |
| 1600 | 0.326s | **0.072s** | 0.461s | **0.185s** |

4.5x on the type-check phase at 1600 functions, 2.5x on the whole compile, and the gap widens with file size because the removed term was the quadratic one.

**Proof the rewrite changes nothing else:** every `.ae` file under `examples/`, `tests/` and `std/` compiled with the before and after compilers and the generated C byte-compared.

```
1369 files
identical=1287  differing=0  both-rejected=82
```

The 82 are fixture files both compilers reject identically. Zero produce different C.

The subtle part is that a qualified call site `mod.fn` has to reach the definition the compiler names `mod_fn`, so the index keys every call under both spellings. `tests/integration/qualified_call_param_inference/` covers it, and is mutation-checked: keying only the written name still builds cleanly and prints the wrong number.

```
=== MUTATED (index only the written name) ===
  [FAIL] integration_qualified_call_param_inference (runtime error, exit 1)
=== RESTORED ===
  [PASS] integration_qualified_call_param_inference
```

`leaks --atExit` reports 0 leaks for the new index across three inputs.

### `foo(void)` everywhere, with `-Wstrict-prototypes` on (#1996)

`foo()` is not "takes no arguments", it is "takes an unspecified number", so C11 cannot check calls against it. 205 declarations across the compiler, runtime, stdlib, LSP, tools, benches and tests were unchecked this way. All fixed, and `-Wstrict-prototypes` is now in `CFLAGS` so they cannot come back. Generated C was checked too and is already clean.

The first pass covered only what `make all lsp test-build` compiles, and CI caught the rest through `check-standalone`, which compiles the benches, demos, the profiler server and the differential driver with `-Werror`. The second commit extends the sweep to every non-vendored declaration in the tree; vendored sources (miniaudio, PCRE2) are deliberately untouched.

`make all lsp test-build` and `make check-standalone` both report 0 warnings and 0 errors.

## Added

### `make check-changelog` (#2001)

When a release is cut while a branch is open, merging `main` renames `## [current]` into that version and folds the branch's entry into the released section, with no git conflict to show for it. CI reds on it, but only after a full matrix run. This has bitten four PRs in a row.

`tests/scripts/check_changelog_fold.sh` is now the single implementation, and the CI job calls it, so the local check and the gate cannot drift.

One detail worth naming: the gate's section extractor used `sed -n '/start/,/end/{...q};p}'`, which **BSD sed rejects**. Run as-is on macOS it silently extracts nothing, both sides compare equal, and the check reports green on exactly the corruption it exists to catch. The shared script uses `awk`, which behaves identically on GNU, BSD and MSYS2.

All three failure modes verified to bite:

```
baseline (clean)                -> exit=0
no [current]                    -> exit=1  ERROR: CHANGELOG.md has no '## [current]' section.
two [current]                   -> exit=1  ERROR: CHANGELOG.md has 2 '## [current]' headings; expected exactly 1.
folded into a released section  -> exit=1  ERROR: This branch rewrites already-released CHANGELOG section(s): 0.664.0
restored                        -> exit=0
```

## Verification

- `make test`: 410 passed, 0 failed
- `make examples`: 90 passed, 0 failed
- `make all lsp test-build`: 0 warnings, 0 errors
- Differential codegen: 1287 files byte-identical, 0 differing
- `leaks --atExit`: 0 leaks
- Three new mutation-checked tests

## Follow-up worth filing, not fixed here

With #1995 removed, the phase split at 1600 functions is parse 0.033s, type check 0.072s, codegen 0.081s. Both type checking and codegen still grow faster than linearly (roughly 4x and 3.4x per 2x input). That is a separate structural item from the one this PR names, filed as #2007 with these numbers rather than widening this change.

## Also found, filed not fixed

`std.mutation` reports a mutant it actually killed as "no-compile", because `_oracle` maps any run-time failure to `NOCOMPILE`, and because `os_run_pipe_drain_and_wait` is the one of three `waitpid` mappers in `std/os/aether_os.c` with no `WIFSIGNALED` branch (the other two return 128+signo with no error, as their comments explain). Filed as #2008 with the instrumented tuples rather than patched here: the trigger is environmental, CI is green on `main`, and a fix could only be verified by inspection, not by turning a red test green.
